### PR TITLE
Fix incorrect command descriptions

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -433,11 +433,11 @@ var (
 		},
 		{
 			Name:        "igp",
-			Description: "Use the mod panel.",
+			Description: "Enable the gold nametag for your current session as a moderator.",
 		},
 		{
 			Name:        "party-status",
-			Description: "Use the mod panel.",
+			Description: "Show the members of your party.",
 		},
 		{
 			Name:        "ign",


### PR DESCRIPTION
Fix some old command descriptions that were labeled as "Use the mod panel".

Assuming `/igp` is still for the nametag.

Also fixed `/party-status`.