### PR TITLE
Refactor profile and display name handling

### DIFF
--- a/server/evr/session_crypto.go
+++ b/server/evr/session_crypto.go
@@ -1,0 +1,67 @@
+package evr
+
+/*
+type PacketEncoderConfig struct {
+	HashSize           int
+	HashIterationCount int
+	HashSecret         []byte
+	CryptSecret        []byte
+	StreamSecret       []byte
+	HMACAlgorithm      int
+	HMACKeySize        int
+	StreamSeedSize     int
+	EncryptionKeySize  int
+}
+
+func (p PacketEncoderConfig) EncKeySize() int {
+	return p.EncryptionKeySize * 8
+}
+
+type PacketEncoderOptions struct {
+	StreamSeedSize     int
+	HMACAlgorithm      int
+	HMACKeySize        int
+	HashIterationCount int
+	EncryptionKeySize  int
+}
+
+func (p *PacketEncoderConfig) ToFlags() uint64 {
+	var flags uint64
+
+	// Set bit 0 if encryption enabled
+	if p.StreamSeedSize != 0 {
+		flags |= 1
+	}
+	// Set bit 1 if MAC enabled
+	if p.HMACAlgorithm != 0 {
+		flags |= 2
+	}
+	// Bits 2-13: MACDigestSize
+	flags |= (uint64(p.HMACKeySize) & 0xFFF) << 2
+	// Bits 14-25: MACPBKDF2IterationCount
+	flags |= (uint64(p.HashIterationCount) & 0xFFF) << 14
+	// Bits 26-37: MACKeySize
+	flags |= (uint64(p.HMACKeySize) & 0xFFF) << 26
+	// Bits 38-49: EncryptionKeySize
+	flags |= (uint64(p.EncryptionKeySize) & 0xFFF) << 38
+	// Bits 50-61: RandomKeySize
+	flags |= (uint64(len(p.CryptSecret)) & 0xFFF) << 50
+
+	return flags
+}
+
+// CreateCryptoConfig derives keys and populates the CryptoConfig struct.
+func CreateCryptoConfig(sessionKey, salt []byte, iterations int, encryptionKeySize, macKeySize, randomKeySize, macDigestSize int, initialSequenceId uint64) CryptoConfig {
+	// 1. Derive enough key material for all three keys.
+	derivedMaterial := pbkdf2.Key(sessionKey, salt, iterations, encryptionKeySize+macKeySize, sha512.New)
+
+	// 3. Populate the final config struct.
+	return CryptoConfig{
+		SequenceID: initialSequenceId,
+		EncKey:     derivedMaterial[0:encryptionKeySize],
+		MacKey:     derivedMaterial[encryptionKeySize : encryptionKeySize+macKeySize],
+		RandomKey:  derivedMaterial[encryptionKeySize+macKeySize:],
+	}
+}
+
+*/

--- a/server/evr_account_displayname_history.go
+++ b/server/evr_account_displayname_history.go
@@ -46,7 +46,7 @@ func (h *DisplayNameHistory) StorageMeta() StorableMetadata {
 		Key:             DisplayNameHistoryKey,
 		PermissionRead:  0,
 		PermissionWrite: 0,
-		Version:         "*", // No version tracking for DisplayNameHistory
+		Version:         "", // No version tracking for DisplayNameHistory
 	}
 }
 
@@ -221,7 +221,7 @@ func (h *DisplayNameHistory) ReplaceInGameNames(names []string) {
 
 func DisplayNameHistoryLoad(ctx context.Context, nk runtime.NakamaModule, userID string) (*DisplayNameHistory, error) {
 	history := NewDisplayNameHistory()
-	
+
 	if err := StorableRead(ctx, nk, userID, history, false); err != nil {
 		if status.Code(err) == codes.NotFound {
 			return history, nil

--- a/server/evr_account_displayname_history.go
+++ b/server/evr_account_displayname_history.go
@@ -141,7 +141,11 @@ func (h *DisplayNameHistory) compile() {
 		sort.Slice(historocal, func(i, j int) bool {
 			return historocal[i].time.After(historocal[j].time)
 		})
-		historical[gID] = historocal
+	for gID, historical := range historical {
+		sort.Slice(historical, func(i, j int) bool {
+			return historical[i].time.After(historical[j].time)
+		})
+		historical[gID] = historical
 	}
 
 	// Limit the number to 15 most recent per group

--- a/server/evr_account_displayname_history.go
+++ b/server/evr_account_displayname_history.go
@@ -141,11 +141,7 @@ func (h *DisplayNameHistory) compile() {
 		sort.Slice(historocal, func(i, j int) bool {
 			return historocal[i].time.After(historocal[j].time)
 		})
-	for gID, historical := range historical {
-		sort.Slice(historical, func(i, j int) bool {
-			return historical[i].time.After(historical[j].time)
-		})
-		historical[gID] = historical
+		historical[gID] = historocal
 	}
 
 	// Limit the number to 15 most recent per group

--- a/server/evr_account_settings.go
+++ b/server/evr_account_settings.go
@@ -1,38 +1,35 @@
 package server
 
-var _ = IndexedVersionedStorable(&ProfileOptions{})
+import "encoding/json"
 
 type ProfileOptions struct {
-	DisableAFKTimeout      bool   `json:"disable_afk_timeout"`       // Disable AFK detection
-	AllowBrokenCosmetics   bool   `json:"allow_broken_cosmetics"`    // Allow broken cosmetics
-	EnableAllCosmetics     bool   `json:"enable_all_cosmetics"`      // Enable all cosmetics
-	IsGlobalDeveloper      bool   `json:"is_global_developer"`       // Is a global developer
-	IsGlobalOperator       bool   `json:"is_global_operator"`        // Is a global operator
-	GoldDisplayNameActive  bool   `json:"gold_display_name"`         // The gold name display name
-	RelayMessagesToDiscord bool   `json:"relay_messages_to_discord"` // Relay messages to Discord
-	DisabledAccountMessage string `json:"disabled_account_message"`  // The disabled account message that the user will see.
-	version                int    `json:"version"`                   // Version of the profile options
-	userID                 string `json:"user_id"`                   // The user ID this profile options belongs to
+	DisableAFKTimeout     bool   `json:"disable_afk_timeout"`    // Disable AFK detection
+	AllowBrokenCosmetics  bool   `json:"allow_broken_cosmetics"` // Allow broken cosmetics
+	EnableAllCosmetics    bool   `json:"enable_all_cosmetics"`   // Enable all cosmetics
+	GoldDisplayNameActive bool   `json:"gold_display_name"`      // The gold name display name
+	version               string // Version of the options
 }
 
-// Ensure UserSettings implements IndexedVersionedStorable
-var _ IndexedVersionedStorable = (*ProfileOptions)(nil)
-
-func (u *ProfileOptions) StorageCollection() string {
-	return "Profile"
+func (h *ProfileOptions) StorageMeta() StorableMetadata {
+	return StorableMetadata{
+		Collection:      LatencyHistoryStorageCollection,
+		Key:             LatencyHistoryStorageKey,
+		PermissionRead:  0,
+		PermissionWrite: 0,
+		Version:         h.version,
+	}
 }
 
-func (u *ProfileOptions) StorageKey() string {
-	// This should be set to the user's ID or a unique identifier.
-	// Placeholder: return empty string, should be set by caller.
-	return "options"
+func (h *ProfileOptions) SetStorageMeta(meta StorableMetadata) {
+	h.version = meta.Version
 }
 
-func (u *ProfileOptions) StorageVersion() int {
-	return 1
-}
-
-func (u *ProfileOptions) StorageIndex() string {
-	// This could be used for secondary indexing, e.g. by username or email.
-	return ""
+func (h *LatencyHistory) String() string {
+	h.RLock()
+	defer h.RUnlock()
+	data, err := json.Marshal(h)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }

--- a/server/evr_account_settings.go
+++ b/server/evr_account_settings.go
@@ -1,0 +1,38 @@
+package server
+
+var _ = IndexedVersionedStorable(&ProfileOptions{})
+
+type ProfileOptions struct {
+	DisableAFKTimeout      bool   `json:"disable_afk_timeout"`       // Disable AFK detection
+	AllowBrokenCosmetics   bool   `json:"allow_broken_cosmetics"`    // Allow broken cosmetics
+	EnableAllCosmetics     bool   `json:"enable_all_cosmetics"`      // Enable all cosmetics
+	IsGlobalDeveloper      bool   `json:"is_global_developer"`       // Is a global developer
+	IsGlobalOperator       bool   `json:"is_global_operator"`        // Is a global operator
+	GoldDisplayNameActive  bool   `json:"gold_display_name"`         // The gold name display name
+	RelayMessagesToDiscord bool   `json:"relay_messages_to_discord"` // Relay messages to Discord
+	DisabledAccountMessage string `json:"disabled_account_message"`  // The disabled account message that the user will see.
+	version                int    `json:"version"`                   // Version of the profile options
+	userID                 string `json:"user_id"`                   // The user ID this profile options belongs to
+}
+
+// Ensure UserSettings implements IndexedVersionedStorable
+var _ IndexedVersionedStorable = (*ProfileOptions)(nil)
+
+func (u *ProfileOptions) StorageCollection() string {
+	return "Profile"
+}
+
+func (u *ProfileOptions) StorageKey() string {
+	// This should be set to the user's ID or a unique identifier.
+	// Placeholder: return empty string, should be set by caller.
+	return "options"
+}
+
+func (u *ProfileOptions) StorageVersion() int {
+	return 1
+}
+
+func (u *ProfileOptions) StorageIndex() string {
+	// This could be used for secondary indexing, e.g. by username or email.
+	return ""
+}

--- a/server/evr_account_settings.go
+++ b/server/evr_account_settings.go
@@ -1,6 +1,9 @@
 package server
 
-import "encoding/json"
+var (
+	ProfileOptionsStorageCollection = "ProfileOptions"
+	ProfileOptionsStorageKey        = "store"
+)
 
 type ProfileOptions struct {
 	DisableAFKTimeout     bool   `json:"disable_afk_timeout"`    // Disable AFK detection
@@ -12,7 +15,6 @@ type ProfileOptions struct {
 
 func (h *ProfileOptions) StorageMeta() StorableMetadata {
 	return StorableMetadata{
-		Collection:      LatencyHistoryStorageCollection,
 		Collection:      ProfileOptionsStorageCollection,
 		Key:             ProfileOptionsStorageKey,
 		PermissionRead:  0,
@@ -23,14 +25,4 @@ func (h *ProfileOptions) StorageMeta() StorableMetadata {
 
 func (h *ProfileOptions) SetStorageMeta(meta StorableMetadata) {
 	h.version = meta.Version
-}
-
-func (h *LatencyHistory) String() string {
-	h.RLock()
-	defer h.RUnlock()
-	data, err := json.Marshal(h)
-	if err != nil {
-		return ""
-	}
-	return string(data)
 }

--- a/server/evr_account_settings.go
+++ b/server/evr_account_settings.go
@@ -13,7 +13,8 @@ type ProfileOptions struct {
 func (h *ProfileOptions) StorageMeta() StorableMetadata {
 	return StorableMetadata{
 		Collection:      LatencyHistoryStorageCollection,
-		Key:             LatencyHistoryStorageKey,
+		Collection:      ProfileOptionsStorageCollection,
+		Key:             ProfileOptionsStorageKey,
 		PermissionRead:  0,
 		PermissionWrite: 0,
 		Version:         h.version,

--- a/server/evr_authenticate_history.go
+++ b/server/evr_authenticate_history.go
@@ -481,7 +481,7 @@ func (h *LoginHistory) UpdateAlternates(ctx context.Context, logger runtime.Logg
 			logger.WithFields(map[string]interface{}{
 				"current_user_id":   h.userID,
 				"alternate_user_id": alternateUserID,
-				"error":            err,
+				"error":             err,
 			}).Warn("Failed to load alternate user's login history for bidirectional update")
 			continue
 		}
@@ -503,7 +503,7 @@ func (h *LoginHistory) UpdateAlternates(ctx context.Context, logger runtime.Logg
 				logger.WithFields(map[string]interface{}{
 					"current_user_id":   h.userID,
 					"alternate_user_id": alternateUserID,
-					"error":            err,
+					"error":             err,
 				}).Warn("Failed to save alternate user's login history for bidirectional update")
 				continue
 			}

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -1248,12 +1248,17 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			}
 
 			if displayName == "" || displayName == "-" || displayName == user.Username {
-				delete(md.InGameNameOverrides, groupID)
+				delete(md.InGameNames, groupID)
 			} else {
-				if md.InGameNameOverrides == nil {
-					md.InGameNameOverrides = make(map[string]string)
+				if md.InGameNames == nil {
+					md.InGameNames = make(map[string]GroupInGameName, 1)
 				}
-				md.InGameNameOverrides[groupID] = sanitizeDisplayName(displayName)
+				// Store the in-game name override for this groupID
+				md.InGameNames[groupID] = GroupInGameName{
+					GroupID:     groupID,
+					DisplayName: displayName,
+					IsOverride:  true,
+				}
 			}
 
 			if err := EVRProfileUpdate(ctx, nk, userID, md); err != nil {

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -1248,12 +1248,12 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			}
 
 			if displayName == "" || displayName == "-" || displayName == user.Username {
-				delete(md.GuildDisplayNameOverrides, groupID)
+				delete(md.InGameNameOverrides, groupID)
 			} else {
-				if md.GuildDisplayNameOverrides == nil {
-					md.GuildDisplayNameOverrides = make(map[string]string)
+				if md.InGameNameOverrides == nil {
+					md.InGameNameOverrides = make(map[string]string)
 				}
-				md.GuildDisplayNameOverrides[groupID] = displayName
+				md.InGameNameOverrides[groupID] = sanitizeDisplayName(displayName)
 			}
 
 			if err := EVRProfileUpdate(ctx, nk, userID, md); err != nil {

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -3415,7 +3415,7 @@ func IPVerificationEmbed(entry *LoginHistoryEntry, ipInfo IPInfo) ([]*discordgo.
 
 func (d *DiscordAppBot) interactionToSignature(prefix string, options []*discordgo.ApplicationCommandInteractionDataOption) string {
 	args := make([]string, 0, len(options))
-	sep := ": "
+	sep := "="
 
 	for _, opt := range options {
 		strval := ""
@@ -3425,7 +3425,7 @@ func (d *DiscordAppBot) interactionToSignature(prefix string, options []*discord
 		case discordgo.ApplicationCommandOptionSubCommandGroup:
 			strval = d.interactionToSignature(opt.Name, opt.Options)
 		case discordgo.ApplicationCommandOptionString:
-			strval = "`" + opt.StringValue() + "`"
+			strval = fmt.Sprintf(`"%s"`, EscapeDiscordMarkdown(opt.StringValue()))
 		case discordgo.ApplicationCommandOptionNumber:
 			strval = fmt.Sprintf("%f", opt.FloatValue())
 		case discordgo.ApplicationCommandOptionInteger:
@@ -3444,7 +3444,7 @@ func (d *DiscordAppBot) interactionToSignature(prefix string, options []*discord
 			strval = fmt.Sprintf("unknown type %d", opt.Type)
 		}
 		if strval != "" {
-			args = append(args, fmt.Sprintf("`%s`%s%s", opt.Name, sep, strval))
+			args = append(args, fmt.Sprintf("*%s*%s%s", opt.Name, sep, strval))
 		}
 	}
 
@@ -3464,7 +3464,7 @@ func (d *DiscordAppBot) LogInteractionToChannel(i *discordgo.InteractionCreate, 
 	data := i.ApplicationCommandData()
 	signature := d.interactionToSignature(data.Name, data.Options)
 
-	content := fmt.Sprintf("<@%s> used %s", i.Member.User.ID, signature)
+	content := fmt.Sprintf("%s (<@%s>) used %s", EscapeDiscordMarkdown(InGameName(i.Member)), i.Member.User.ID, signature)
 	d.dg.ChannelMessageSendComplex(channelID, &discordgo.MessageSend{
 		Content:         content,
 		AllowedMentions: &discordgo.MessageAllowedMentions{},

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -118,6 +118,15 @@ func (d *DiscordAppBot) handleInteractionApplicationCommand(ctx context.Context,
 		if !isGlobalOperator && !gg.IsAllocator(userID) {
 			return simpleInteractionResponse(s, i, "You must be a guild allocator to use this command.")
 		}
+	case "kick-player":
+		gg := d.guildGroupRegistry.Get(groupID)
+		if gg == nil {
+			return simpleInteractionResponse(s, i, "This guild is not registered.")
+		}
+
+		if err := d.LogInteractionToChannel(i, gg.AuditChannelID); err != nil {
+			logger.Warn("Failed to log interaction to channel")
+		}
 
 	case "join-player", "igp", "ign", "shutdown-match":
 

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -592,9 +592,9 @@ func (d *DiscordAppBot) kickPlayer(logger runtime.Logger, i *discordgo.Interacti
 			if len(voids) > 0 {
 				title = "Voided Suspension(s)"
 			} else if len(recordsByGroupID) > 0 {
-				title = fmt.Sprintf("Suspension: *%s*", Query.QuoteStringValue(profile.GetGroupDisplayNameOrDefault(groupID)))
+				title = fmt.Sprintf("Suspension: *%s*", Query.QuoteStringValue(profile.GetGroupIGN(groupID)))
 			}
-			targetDN := profile.GetGroupDisplayNameOrDefault(groupID)
+			targetDN := profile.GetGroupIGN(groupID)
 			targetDN = EscapeDiscordMarkdown(targetDN)
 			callerDN := caller.DisplayName()
 			if callerDN == "" {

--- a/server/evr_discord_appbot_igp.go
+++ b/server/evr_discord_appbot_igp.go
@@ -625,7 +625,7 @@ func (p *InGamePanel) HandleInteraction(i *discordgo.InteractionCreate, command 
 		}
 
 		// Get the selected user ID
-		modal := p.createSetIGNModal(evrProfile.GetGroupDisplayNameOrDefault(groupID))
+		modal := p.createSetIGNModal(evrProfile.GetGroupIGN(groupID))
 		return p.dg.InteractionRespond(i.Interaction, modal)
 
 	case "select_player":

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -729,7 +729,7 @@ func (d *DiscordIntegrator) handleMemberUpdate(logger *zap.Logger, s *discordgo.
 				}
 				if player := label.GetPlayerByUserID(evrAccount.ID()); player != nil {
 					if player.DisplayName != InGameName(e.Member) {
-						AuditLogSendGuild(s, group, fmt.Sprintf("Setting display name for `%s` to match in-game name: `%s`", e.Member.User.Username, InGameName(e.Member)))
+						AuditLogSendGuild(s, group, fmt.Sprintf("Forcing guild nick to match in-game name for `%s` (`%s` -> `%s`)", e.Member.User.Username, InGameName(e.Member), player.DisplayName))
 						// Force the display name to match the in-game name
 						if err := s.GuildMemberNickname(group.GuildID, e.Member.User.ID, player.DisplayName); err != nil {
 							logger.Warn("Failed to set display name", zap.Error(err))

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -437,6 +437,9 @@ func (d *DiscordIntegrator) updateLinkStatus(ctx context.Context, discordID stri
 }
 
 func InGameName(m *discordgo.Member) string {
+	if m == nil || m.User == nil {
+		return ""
+	}
 	for _, name := range [...]string{m.Nick, m.User.GlobalName, m.User.Username} {
 		if n := sanitizeDisplayName(name); n != "" {
 			return n

--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -439,7 +439,7 @@ func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcem
 func createEnforcementActionComponents(record GuildEnforcementRecord, profile *EVRProfile, gg *GuildGroup, guild *discordgo.Guild, enforcer, target *discordgo.Member, isVoid bool) *discordgo.MessageSend {
 	// Is just a kick
 
-	displayName := profile.GetGroupDisplayNameOrDefault(gg.Group.Id)
+	displayName := profile.GetGroupIGN(gg.Group.Id)
 	displayName = EscapeDiscordMarkdown(displayName)
 
 	fields := []*discordgo.MessageEmbedField{

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/json"
 	"math/rand"
 	"net"
 	"slices"
@@ -45,16 +44,6 @@ func (h *LatencyHistory) SetStorageMeta(meta StorableMetadata) {
 	h.Lock()
 	defer h.Unlock()
 	h.version = meta.Version
-}
-
-func (h *LatencyHistory) String() string {
-	h.RLock()
-	defer h.RUnlock()
-	data, err := json.Marshal(h)
-	if err != nil {
-		return ""
-	}
-	return string(data)
 }
 
 // Add adds a new RTT to the history for the given external IP

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"math/rand"
 	"net"
 	"slices"
@@ -44,6 +45,16 @@ func (h *LatencyHistory) SetStorageMeta(meta StorableMetadata) {
 	h.Lock()
 	defer h.Unlock()
 	h.version = meta.Version
+}
+
+func (h *LatencyHistory) String() string {
+	h.RLock()
+	defer h.RUnlock()
+	data, err := json.Marshal(h)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // Add adds a new RTT to the history for the given external IP

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -205,7 +205,7 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 
 	joinRejected := func(metricKey, reason, auditMessage string) error {
 		metricsTags["error"] = metricKey
-		auditMessage = fmt.Sprintf("Rejected lobby join by %s <@%s>[%s] to `%s`: %s", EscapeDiscordMarkdown(lobbyParams.DisplayName), lobbyParams.DiscordID, session.Username(), lobbyParams.Mode, auditMessage)
+		auditMessage = fmt.Sprintf("Rejected lobby join by %s <@%s>[%s] to `%s`: %s", EscapeDiscordMarkdown(lobbyparams.profile.GetGroupIGN), lobbyParams.DiscordID, session.Username(), lobbyParams.Mode, auditMessage)
 		if _, err := p.appBot.LogAuditMessage(ctx, groupID, auditMessage, true); err != nil {
 			p.logger.Warn("Failed to send audit message", zap.String("channel_id", groupID), zap.Error(err))
 		}
@@ -412,7 +412,7 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 		}
 	}
 
-	displayName := params.DisplayName(groupID)
+	displayName := params.profile.GetGroupIGN(groupID)
 	p.nk.Event(ctx, &api.Event{
 		Name: EventLobbySessionAuthorized,
 		Properties: map[string]string{

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -284,18 +284,18 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 
 			if suspensionRecord.UserID == userID {
 				// User has an active suspension
-				auditLog = fmt.Sprintf("suspension record: `%s` (expires <t:%d:R>)", suspensionRecord.UserNoticeText, suspensionRecord.Expiry.Unix())
+				auditLog = fmt.Sprintf("suspended (expires <t:%d:R>): `%s`", suspensionRecord.Expiry.Unix(), suspensionRecord.UserNoticeText)
 				metricTag = "suspended_user"
 			} else {
 				// This is an alternate account of a suspended user.
-				auditLog = fmt.Sprintf("suspended alt (<@!%s>)", suspensionRecord.UserID)
+				auditLog = fmt.Sprintf("suspended alternate (<@!%s>) (expires <t:%d:R>): `%s`", suspensionRecord.UserID, suspensionRecord.Expiry.Unix(), suspensionRecord.UserNoticeText)
 				metricTag = "suspended_alt_user"
 			}
 
 			if suspensionRecord.SuspensionExcludesPrivateLobbies() {
-				auditLog := fmt.Sprintf("Rejected limited access user <@%s> (%s) from public lobby (%s)", lobbyParams.DiscordID, lobbyParams.DisplayName, lobbyParams.Mode)
-				reason = "Public Lobby Access Denied: " + reason
-				return joinRejected("limited_access_user", suspensionRecord.UserNoticeText, auditLog)
+				auditLog = fmt.Sprintf("Rejected limited access user (expires <t:%d:R>): `%s`", suspensionRecord.Expiry.Unix(), suspensionRecord.UserNoticeText)
+				reason = "Public Access Denied: " + reason
+				metricTag = "limited_access_user"
 			}
 
 			expires := fmt.Sprintf(" [exp: %s]", FormatDuration(time.Until(suspensionRecord.Expiry)))

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -413,9 +413,6 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 	}
 
 	displayName := params.profile.GetGroupIGN(groupID)
-	if err != nil {
-		return fmt.Errorf("failed to get display name: %w", err)
-	}
 
 	p.nk.Event(ctx, &api.Event{
 		Name: EventLobbySessionAuthorized,

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -205,7 +205,7 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 
 	joinRejected := func(metricKey, reason, auditMessage string) error {
 		metricsTags["error"] = metricKey
-		auditMessage = fmt.Sprintf("Rejected lobby join by %s <@%s>[%s] to `%s`: %s", EscapeDiscordMarkdown(lobbyparams.profile.GetGroupIGN), lobbyParams.DiscordID, session.Username(), lobbyParams.Mode, auditMessage)
+		auditMessage = fmt.Sprintf("Rejected lobby join by %s <@%s>[%s] to `%s`: %s", EscapeDiscordMarkdown(lobbyParams.DisplayName), lobbyParams.DiscordID, session.Username(), lobbyParams.Mode, auditMessage)
 		if _, err := p.appBot.LogAuditMessage(ctx, groupID, auditMessage, true); err != nil {
 			p.logger.Warn("Failed to send audit message", zap.String("channel_id", groupID), zap.Error(err))
 		}
@@ -413,6 +413,10 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 	}
 
 	displayName := params.profile.GetGroupIGN(groupID)
+	if err != nil {
+		return fmt.Errorf("failed to get display name: %w", err)
+	}
+
 	p.nk.Event(ctx, &api.Event{
 		Name: EventLobbySessionAuthorized,
 		Properties: map[string]string{

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -434,7 +434,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 		MatchmakingTimeout:           time.Duration(globalSettings.MatchmakingTimeoutSecs) * time.Second,
 		FailsafeTimeout:              time.Duration(failsafeTimeoutSecs) * time.Second,
 		FallbackTimeout:              time.Duration(globalSettings.FallbackTimeoutSecs) * time.Second,
-		DisplayName:                  sessionparams.profile.GetGroupIGN(groupIDStr),
+		DisplayName:                  sessionParams.profile.GetGroupIGN(groupIDStr),
 	}, nil
 }
 

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -434,7 +434,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 		MatchmakingTimeout:           time.Duration(globalSettings.MatchmakingTimeoutSecs) * time.Second,
 		FailsafeTimeout:              time.Duration(failsafeTimeoutSecs) * time.Second,
 		FallbackTimeout:              time.Duration(globalSettings.FallbackTimeoutSecs) * time.Second,
-		DisplayName:                  sessionParams.DisplayName(groupIDStr),
+		DisplayName:                  sessionparams.profile.GetGroupIGN(groupIDStr),
 	}, nil
 }
 

--- a/server/evr_match_presence.go
+++ b/server/evr_match_presence.go
@@ -122,7 +122,7 @@ func EntrantPresenceFromSession(session Session, partyID uuid.UUID, roleAlignmen
 		SessionID:         session.ID(),
 		LoginSessionID:    params.loginSession.ID(),
 		Username:          session.Username(),
-		DisplayName:       params.DisplayName(groupID),
+		DisplayName:       params.profile.GetGroupIGN(groupID),
 		EvrID:             params.xpID,
 		PartyID:           partyID,
 		RoleAlignment:     roleAlignment,

--- a/server/evr_pipeline_login_displayname_test.go
+++ b/server/evr_pipeline_login_displayname_test.go
@@ -28,7 +28,7 @@ func TestDisplayNameCurrentValueFix(t *testing.T) {
 	// Create a profile
 	profile := &EVRProfile{
 		account:     &api.Account{User: &api.User{Username: username}},
-		InGameNames: make(map[string]string),
+		InGameNames: make(map[string]GroupInGameName),
 	}
 
 	// Simulate the scenario where a display name override is applied
@@ -101,7 +101,7 @@ func TestDisplayNameHistoryConsistency(t *testing.T) {
 
 	profile := &EVRProfile{
 		account:     &api.Account{User: &api.User{Username: username}},
-		InGameNames: make(map[string]string),
+		InGameNames: make(map[string]GroupInGameName),
 	}
 
 	// Update sequence: 1 -> 2 -> 3

--- a/server/evr_pipeline_login_displayname_test.go
+++ b/server/evr_pipeline_login_displayname_test.go
@@ -47,7 +47,7 @@ func TestDisplayNameCurrentValueFix(t *testing.T) {
 	profile.SetGroupDisplayName(groupID, defaultDisplayName)
 
 	// Step 4: get the current value from the profile
-	activeGroupDisplayNameFixed := profile.GetGroupDisplayNameOrDefault(groupID)
+	activeGroupDisplayNameFixed := profile.GetGroupIGN(groupID)
 
 	// Verify the fix: should use the new display name, not the old one
 	if activeGroupDisplayNameFixed != newDisplayName {
@@ -112,7 +112,7 @@ func TestDisplayNameHistoryConsistency(t *testing.T) {
 		profile.SetGroupDisplayName(groupID, name)
 
 		// Get current name from profile (the fixed approach)
-		currentName := profile.GetGroupDisplayNameOrDefault(groupID)
+		currentName := profile.GetGroupIGN(groupID)
 
 		// Update history with current name
 		history.Update(groupID, currentName, username, true)
@@ -133,7 +133,7 @@ func TestDisplayNameHistoryConsistency(t *testing.T) {
 
 	// Final verification: latest should be the third name
 	latestFromHistory, _ := history.LatestGroup(groupID)
-	currentFromProfile := profile.GetGroupDisplayNameOrDefault(groupID)
+	currentFromProfile := profile.GetGroupIGN(groupID)
 
 	if latestFromHistory != displayName3 {
 		t.Errorf("Final: Expected latest from history to be %s, got %s", displayName3, latestFromHistory)

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -173,7 +173,7 @@ func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, n
 	}
 
 	cosmetics := make(map[string]map[string]bool)
-	for m, c := range cosmeticDefaults(evrProfile.EnableAllCosmetics) {
+	for m, c := range cosmeticDefaults(evrProfile.Options.EnableAllCosmetics) {
 		cosmetics[m] = make(map[string]bool, len(c))
 		maps.Copy(cosmetics[m], c)
 	}
@@ -188,7 +188,7 @@ func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, n
 
 	var developerFeatures *evr.DeveloperFeatures
 
-	if evrProfile.GoldDisplayNameActive {
+	if evrProfile.Options.GoldDisplayNameActive {
 		developerFeatures = &evr.DeveloperFeatures{}
 	}
 
@@ -207,7 +207,7 @@ func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, n
 		return nil, fmt.Errorf("failed to get user tablet statistics: %w", err)
 	}
 
-	if evrProfile.DisableAFKTimeout {
+	if evrProfile.Options.DisableAFKTimeout {
 		developerFeatures = &evr.DeveloperFeatures{
 			DisableAfkTimeout: true,
 		}

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -162,7 +162,7 @@ func walletToCosmetics(wallet map[string]int64, unlocks map[string]map[string]bo
 }
 
 func UserServerProfileFromParameters(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, params SessionParameters, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol) (*evr.ServerProfile, error) {
-	return NewUserServerProfile(ctx, logger, db, nk, params.profile, params.xpID, groupID, modes, dailyWeeklyMode, params.DisplayName(groupID))
+	return NewUserServerProfile(ctx, logger, db, nk, params.profile, params.xpID, groupID, modes, dailyWeeklyMode, params.profile.GetGroupIGN(groupID))
 }
 
 func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, evrProfile *EVRProfile, xpID evr.EvrId, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol, displayName string) (*evr.ServerProfile, error) {

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -257,10 +257,11 @@ func RegisterIndexes(initializer runtime.Initializer) error {
 
 	// Register storage indexes for any Storables
 	storables := []StorableIndexer{
-		// TODO: Convert these to use new adapter pattern
+		&DisplayNameHistory{},
+		&DeveloperApplications{},
 		&MatchmakingSettings{},
 		&VRMLPlayerSummary{},
-		// TODO: Add all converted types back with new adapter pattern
+		&LoginHistory{},
 	}
 	for _, s := range storables {
 		for _, idx := range s.StorageIndexes() {

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -33,12 +33,12 @@ type SessionParameters struct {
 	isGlobalDeveloper bool              // The user is a developer
 	isGlobalOperator  bool              // The user is a moderator
 
-	relayOutgoing bool                // The user wants (some) outgoing messages relayed to them via discord
-	debug         bool                // The user wants debug information
-	serverTags    []string            // []string of the server tags
-	serverGuilds  []string            // []string of the server guilds
-	serverRegions []string            // []string of the server regions
-	urlParameters map[string][]string // The URL parameters
+	relayOutgoing       bool                // The user wants (some) outgoing messages relayed to them via discord
+	enableAllRemoteLogs bool                // The user wants debug information
+	serverTags          []string            // []string of the server tags
+	serverGuilds        []string            // []string of the server guilds
+	serverRegions       []string            // []string of the server regions
+	urlParameters       map[string][]string // The URL parameters
 
 	profile                      *EVRProfile                      // The account
 	matchmakingSettings          *MatchmakingSettings             // The matchmaking settings

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -42,7 +42,6 @@ type SessionParameters struct {
 
 	profile                      *EVRProfile                      // The account
 	matchmakingSettings          *MatchmakingSettings             // The matchmaking settings
-	displayNameHistory           *DisplayNameHistory              // The display name history
 	guildGroups                  map[string]*GuildGroup           // map[string]*GuildGroup
 	earlyQuitConfig              *atomic.Pointer[EarlyQuitConfig] // The early quit config
 	isGoldNameTag                *atomic.Bool                     // If this user should have a gold name tag
@@ -67,7 +66,7 @@ func (s SessionParameters) DisplayName(groupID string) string {
 	if s.userDisplayNameOverride != "" {
 		return s.userDisplayNameOverride
 	}
-	return s.profile.GetGroupDisplayNameOrDefault(groupID)
+	return s.profile.GetGroupIGN(groupID)
 }
 
 func (s *SessionParameters) IsIGPOpen() bool {

--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -191,7 +191,7 @@ func NewSessionWS(logger *zap.Logger, config Config, format SessionFormat, sessi
 		serverGuilds:         parseUserQueryCommaDelimited(&request, "guilds", 32, guildPattern),
 		serverRegions:        parseUserQueryCommaDelimited(&request, "regions", 32, regionPattern),
 		relayOutgoing:        parseUserQueryFunc(&request, "verbose", 5, nil) == "true",
-		debug:                parseUserQueryFunc(&request, "debug", 5, nil) == "true",
+		enableAllRemoteLogs:  parseUserQueryFunc(&request, "debug", 5, nil) == "true",
 		urlParameters:        urlParams,
 		lastMatchmakingError: atomic.NewError(nil),
 		guildGroups:          make(map[string]*GuildGroup),


### PR DESCRIPTION
This PR refactors group display name (IGN) handling in user profiles, consolidates related logic, and introduces a `ProfileOptions` struct for profile flags. Discord bot logging and nickname syncing are improved for clarity and consistency.

**Group Display Name Refactor:**

- Replaces `GuildDisplayNameOverrides` and related maps in `EVRProfile` with an `InGameNames` map of `GroupInGameName` structs (`GroupID`, `DisplayName`, `IsOverride`) for explicit, flexible group IGN management. Legacy methods are removed/replaced.  
- All usage and logging of group IGNs now use `GetGroupIGN` for consistent name retrieval.

**Profile Options:**

- Adds `ProfileOptions` struct for profile-related flags (e.g., `DisableAFKTimeout`, `AllowBrokenCosmetics`, `EnableAllCosmetics`, `GoldDisplayNameActive`), moving these from `EVRProfile`. Includes storage metadata methods.

**Discord Bot & Nickname Sync:**

- Discord bot logging now includes in-game names and better-formatted interaction signatures.
- Nickname sync logic is clearer, with improved audit logging.

**Display Name History & Misc:**

- Display name history tracking is refined to keep only recent names; storage metadata version handling fixed.
- Removes unused JSON marshaling from `LatencyHistory`.

**Other:**

- Adds (commented out) crypto config struct and methods for future use.