### PR TITLE
Fix/Extend global operator permissions

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2098,7 +2098,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			}
 
 			isGuildAuditor = isGuildAuditor || isGlobalOperator
-			isGuildEnforcer = isGuildEnforcer || isGuildAuditor
+			isGuildEnforcer = isGuildEnforcer || isGuildAuditor || isGlobalOperator
 
 			loginsSince := time.Now().Add(-30 * 24 * time.Hour)
 			if !isGlobalOperator {
@@ -2106,7 +2106,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			}
 
 			opts := UserProfileRequestOptions{
-				IncludeSuspensionsEmbed:      true,
+				IncludeSuspensionsEmbed:      isGuildEnforcer,
 				IncludePastSuspensions:       isGuildEnforcer,
 				IncludeCurrentMatchesEmbed:   isGuildEnforcer,
 				IncludeVRMLHistoryEmbed:      isGlobalOperator,

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -420,7 +420,13 @@ func (d *DiscordAppBot) handleAllocateMatch(ctx context.Context, logger runtime.
 		}
 	}
 
-	if !gg.IsAllocator(userID) {
+	isGlobalOperator := false
+	isGlobalOperator, err = CheckSystemGroupMembership(ctx, d.db, userID, GroupGlobalOperators)
+	if err != nil {
+		return nil, 0, status.Errorf(codes.Internal, "error checking global operator status: %v", err)
+	}
+
+	if !gg.IsAllocator(userID) && !isGlobalOperator {
 		return nil, 0, status.Error(codes.PermissionDenied, "user does not have the allocator role in this guild.")
 	}
 


### PR DESCRIPTION
global operators must be able to do anything on a guild that a priviledged member of a guild *should* be able to do, so they can provide real-time help/workarounds for problems that may take code changes to fix.