### PR TITLE
Fix leaderboard score handling for increment and decrement operations

### DIFF
--- a/server/evr_statistics_queue.go
+++ b/server/evr_statistics_queue.go
@@ -81,6 +81,71 @@ func NewStatisticsQueue(logger runtime.Logger, db *sql.DB, nk runtime.NakamaModu
 					if !slices.Contains(ValidLeaderboardModes, e.BoardMeta.Mode) {
 						continue
 					}
+
+					// If the operator is increment or decrement, read the current value, decode it, add the delta, and write it back.
+					// This is because the leaderboard uses a float64 encoding that is not compatible with simple integer arithmetic.
+					if e.BoardMeta.Operator == OperatorIncrement || e.BoardMeta.Operator == OperatorDecrement {
+						var currentVal float64
+						// Handle the case where the leaderboard might not exist yet.
+						_, ownerRecords, _, _, err := nk.LeaderboardRecordsList(ctx, e.BoardMeta.ID(), []string{e.UserID}, 1, "", 0)
+						if err != nil {
+							if err == ErrLeaderboardNotFound {
+								// Leaderboard doesn't exist, so current value is 0.
+								currentVal = 0
+							} else {
+								logger.WithFields(map[string]any{
+									"error":          err.Error(),
+									"leaderboard_id": e.BoardMeta.ID(),
+								}).Error("Failed to list leaderboard records")
+								continue
+							}
+						} else {
+							if len(ownerRecords) > 0 {
+								currentVal, err = ScoreToFloat64(ownerRecords[0].Score, ownerRecords[0].Subscore)
+								if err != nil {
+									logger.WithFields(map[string]any{
+										"error":          err.Error(),
+										"leaderboard_id": e.BoardMeta.ID(),
+									}).Error("Failed to decode current score")
+									continue
+								}
+							} else {
+								// Record doesn't exist, so current value is 0.
+								currentVal = 0
+							}
+						}
+
+						deltaVal, err := ScoreToFloat64(e.Score, e.Subscore)
+						if err != nil {
+							logger.WithFields(map[string]any{
+								"error":          err.Error(),
+								"leaderboard_id": e.BoardMeta.ID(),
+							}).Error("Failed to decode delta score")
+							continue
+						}
+
+						var newVal float64
+						if e.BoardMeta.Operator == OperatorIncrement {
+							newVal = currentVal + deltaVal
+						} else {
+							newVal = currentVal - deltaVal
+						}
+
+						newScore, newSubscore, err := Float64ToScore(newVal)
+						if err != nil {
+							logger.WithFields(map[string]any{
+								"error":          err.Error(),
+								"leaderboard_id": e.BoardMeta.ID(),
+							}).Error("Failed to encode new score")
+							continue
+						}
+
+						// Update the entry to be a SET operation with the new value
+						e.Score = newScore
+						e.Subscore = newSubscore
+						e.BoardMeta.Operator = OperatorSet
+					}
+
 					var md map[string]any
 					if e.Metadata != nil {
 						md = make(map[string]any)


### PR DESCRIPTION
This pull request introduces an important improvement to how leaderboard score updates are handled for increment and decrement operations in the statistics queue. Instead of applying arithmetic directly to encoded values, the code now reads the current score, decodes it, applies the delta, re-encodes the result, and updates the leaderboard with the new value. This ensures score updates are accurate and compatible with the leaderboard's float64 encoding.

Leaderboard increment/decrement handling:

* Added logic to read the current leaderboard value, decode it, apply the increment/decrement, and re-encode before updating, ensuring compatibility with float64 encoding.
* Handles cases where the leaderboard or record does not exist by defaulting the current value to zero.
* Converts the update operation to a SET after calculating the new value, ensuring consistency in how scores are applied.
* Improved error handling and logging for score decoding and leaderboard record retrieval failures.