### PR TITLE
Enhance/mmr calculations

### DIFF
--- a/server/evr/login_serverprofileupdate_request.go
+++ b/server/evr/login_serverprofileupdate_request.go
@@ -63,17 +63,6 @@ func (m UpdatePayload) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
-func (m UpdatePayload) IsWinner() bool {
-	switch m.mode {
-	case ModeArenaPublic:
-		return m.Update.Statistics.Arena.ArenaWins.Value > 0
-	case ModeCombatPublic:
-		return m.Update.Statistics.Combat.CombatWins.Value > 0
-	default:
-		return false
-	}
-}
-
 type ServerProfileUpdate struct {
 	Statistics *ServerProfileUpdateStatistics `json:"stats,omitempty"`
 	Unlocks    *ServerProfileUpdateUnlocks    `json:"unlocks,omitempty"`

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -303,7 +303,6 @@ func (s *MatchLabel) rebuildCache() {
 	s.Size = len(presences)
 	s.Players = make([]PlayerInfo, 0, s.Size)
 	s.PlayerCount = 0
-	ratingScores := s.CalculateRatingWeights()
 	for _, p := range presences {
 		// Do not include spectators or moderators in player count
 		if p.RoleAlignment != evr.TeamSpectator && p.RoleAlignment != evr.TeamModerator {
@@ -337,7 +336,6 @@ func (s *MatchLabel) rebuildCache() {
 					PartyID:       p.PartyID.String(),
 					RatingMu:      p.Rating.Mu,
 					RatingSigma:   p.Rating.Sigma,
-					RatingScore:   ratingScores[p.EvrID],
 					JoinTime:      s.joinTimeMilliseconds[p.SessionID.String()],
 					SessionID:     p.SessionID.String(),
 					IsReservation: s.reservationMap[p.SessionID.String()] != nil,
@@ -357,7 +355,6 @@ func (s *MatchLabel) rebuildCache() {
 					JoinTime:      s.joinTimeMilliseconds[p.SessionID.String()],
 					RatingMu:      p.Rating.Mu,
 					RatingSigma:   p.Rating.Sigma,
-					RatingScore:   ratingScores[p.EvrID],
 					SessionID:     p.SessionID.String(),
 					IsReservation: s.reservationMap[p.SessionID.String()] != nil,
 					GeoHash:       p.GeoHash,
@@ -556,7 +553,6 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 				JoinTime:    l.Players[i].JoinTime,
 				RatingMu:    l.Players[i].RatingMu,
 				RatingSigma: l.Players[i].RatingSigma,
-				RatingScore: l.Players[i].RatingScore,
 			})
 		}
 

--- a/server/evr_match_player.go
+++ b/server/evr_match_player.go
@@ -16,7 +16,6 @@ type PlayerInfo struct {
 	JoinTime      int64      `json:"join_time_ms,omitempty"` // The time on the round clock that the player joined
 	RatingMu      float64    `json:"rating_mu,omitempty"`
 	RatingSigma   float64    `json:"rating_sigma,omitempty"`
-	RatingScore   int        `json:"rating_score,omitempty"`
 	Username      string     `json:"username,omitempty"`
 	DiscordID     string     `json:"discord_id,omitempty"`
 	UserID        string     `json:"user_id,omitempty"`

--- a/server/evr_matchmaker_ratings.go
+++ b/server/evr_matchmaker_ratings.go
@@ -114,7 +114,7 @@ func CalculateNewPlayerRatings(playerInfos []PlayerInfo, playerStats map[evr.Evr
 	for _, p := range playerInfos {
 		var score int64 = 0
 		if stats, ok := playerStats[p.EvrID]; ok {
-			score += stats.Goals * 2
+			score += stats.Points
 			score += stats.Assists * 2
 			score += stats.Saves * 3
 			score += stats.Passes * 1

--- a/server/evr_matchmaker_ratings.go
+++ b/server/evr_matchmaker_ratings.go
@@ -5,6 +5,7 @@ import (
 
 	"slices"
 
+	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/intinig/go-openskill/rating"
 	"github.com/intinig/go-openskill/types"
 	"go.uber.org/thriftrw/ptr"
@@ -87,7 +88,9 @@ func NewDefaultRating() types.Rating {
 }
 
 // CalculateNewPlayerRatings calculates the new player ratings based on the match outcome.
-func CalculateNewPlayerRatings(players []PlayerInfo, blueWins bool) map[string]types.Rating {
+func CalculateNewPlayerRatings(playerInfos []PlayerInfo, playerStats map[evr.EvrId]evr.MatchTypeStats, blueWins bool) map[string]types.Rating {
+
+	const WinningTeamBonus = 4
 
 	winningTeam := BlueTeam
 	if !blueWins {
@@ -95,25 +98,36 @@ func CalculateNewPlayerRatings(players []PlayerInfo, blueWins bool) map[string]t
 	}
 
 	// copy the players slice so as to not modify the original
-	players = players[:]
+	playerInfos = slices.Clone(playerInfos)
 
 	// Remove players that are not on blue/orange
-	for i := 0; i < len(players); i++ {
-		if !players[i].IsCompetitor() {
-			players = slices.Delete(players, i, i+1)
+	for i := 0; i < len(playerInfos); i++ {
+		if !playerInfos[i].IsCompetitor() {
+			playerInfos = slices.Delete(playerInfos, i, i+1)
 			i--
 			continue
 		}
 	}
 
 	// Create a map of player scores
-	playerScores := make(map[string]int, len(players))
-	for _, p := range players {
-		playerScores[p.SessionID] = p.RatingScore
+	playerScores := make(map[string]int, len(playerInfos))
+	for _, p := range playerInfos {
+		var score int64 = 0
+		if stats, ok := playerStats[p.EvrID]; ok {
+			score += stats.Goals * 2
+			score += stats.Assists * 2
+			score += stats.Saves * 3
+			score += stats.Passes * 1
+			score -= stats.ShotsOnGoal * 1 // penalty for missed shots
+		}
+		if p.Team == winningTeam {
+			score += WinningTeamBonus
+		}
+		playerScores[p.SessionID] = int(score)
 	}
 
 	// Sort the players by score
-	slices.SortStableFunc(players, func(a, b PlayerInfo) int {
+	slices.SortStableFunc(playerInfos, func(a, b PlayerInfo) int {
 		// Sort winning team first
 		if a.Team == winningTeam && b.Team != winningTeam {
 			return -1
@@ -126,14 +140,14 @@ func CalculateNewPlayerRatings(players []PlayerInfo, blueWins bool) map[string]t
 	})
 
 	// Split the roster by teamRatings (all players are separated on their own team)
-	teamRatings := make([]types.Team, len(players))
-	for i, p := range players {
+	teamRatings := make([]types.Team, len(playerInfos))
+	for i, p := range playerInfos {
 		teamRatings[i] = types.Team{p.Rating()}
 	}
 
 	// Create a map of player scores; used to weight the new ratings
-	scores := make([]int, len(players))
-	for i, p := range players {
+	scores := make([]int, len(playerInfos))
+	for i, p := range playerInfos {
 		scores[i] = playerScores[p.SessionID]
 	}
 
@@ -143,9 +157,9 @@ func CalculateNewPlayerRatings(players []PlayerInfo, blueWins bool) map[string]t
 		Tau:   ptr.Float64(0.3), // prevent sigma from dropping too low
 	})
 
-	ratingMap := make(map[string]types.Rating, len(players))
+	ratingMap := make(map[string]types.Rating, len(playerInfos))
 	for i, team := range teamRatings {
-		sID := players[i].SessionID
+		sID := playerInfos[i].SessionID
 		ratingMap[sID] = team[0]
 	}
 

--- a/server/evr_matchmaker_ratings_test.go
+++ b/server/evr_matchmaker_ratings_test.go
@@ -10,9 +10,10 @@ import (
 
 func TestCalculatePlayerRating(t *testing.T) {
 	type args struct {
-		evrID    evr.EvrId
-		players  []PlayerInfo
-		blueWins bool
+		evrID       evr.EvrId
+		players     []PlayerInfo
+		playerStats map[evr.EvrId]evr.MatchTypeStats
+		blueWins    bool
 	}
 	tests := []struct {
 		name string
@@ -35,7 +36,6 @@ func TestCalculatePlayerRating(t *testing.T) {
 						RatingMu:    30,
 						RatingSigma: 7.5,
 						JoinTime:    0.0,
-						RatingScore: 6,
 					},
 					{
 						SessionID:   "2",
@@ -43,7 +43,6 @@ func TestCalculatePlayerRating(t *testing.T) {
 						Team:        0,
 						RatingMu:    19,
 						RatingSigma: 4.333,
-						RatingScore: 4,
 						JoinTime:    0.0,
 					},
 					{
@@ -52,7 +51,6 @@ func TestCalculatePlayerRating(t *testing.T) {
 						Team:        1,
 						RatingMu:    20,
 						RatingSigma: 6.666,
-						RatingScore: 2,
 						JoinTime:    0.0,
 					},
 					{
@@ -61,17 +59,22 @@ func TestCalculatePlayerRating(t *testing.T) {
 						Team:        1,
 						RatingMu:    22,
 						RatingSigma: 7.0,
-						RatingScore: 6,
 						JoinTime:    0.0,
 					},
+				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 987654321}: {Points: 4, Assists: 2},
+					{PlatformCode: 4, AccountId: 123456789}: {Points: 2, Assists: 2},
+					{PlatformCode: 4, AccountId: 112233445}: {Points: 2, Assists: 0},
+					{PlatformCode: 4, AccountId: 556677889}: {Points: 4, Assists: 2},
 				},
 				blueWins: true,
 			},
 			want: map[string]types.Rating{
-				"1": {Mu: 29.51354881824657, Sigma: 7.397377605157138, Z: 3},
-				"2": {Mu: 19.075596838556958, Sigma: 4.32566475663472, Z: 3},
-				"3": {Mu: 20.14266178646694, Sigma: 6.622734811533342, Z: 3},
-				"4": {Mu: 22.069139105906665, Sigma: 6.942133769169642, Z: 3},
+				"1": {Mu: 32.25100494750614, Sigma: 7.403291008004081, Z: 3},
+				"2": {Mu: 19.620014923159122, Sigma: 4.325701896576898, Z: 3},
+				"3": {Mu: 17.134731637125135, Sigma: 6.501092020874961, Z: 3},
+				"4": {Mu: 21.584260659198744, Sigma: 6.787349653038609, Z: 3},
 			},
 		},
 		{
@@ -115,13 +118,19 @@ func TestCalculatePlayerRating(t *testing.T) {
 						JoinTime:    0.0,
 					},
 				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 112233445}: {Points: 2, Assists: 0},
+					{PlatformCode: 4, AccountId: 556677889}: {Points: 4, Assists: 2},
+					{PlatformCode: 4, AccountId: 987654321}: {Points: 4, Assists: 2},
+					{PlatformCode: 4, AccountId: 123456789}: {Points: 2, Assists: 2},
+				},
 				blueWins: false,
 			},
 			want: map[string]types.Rating{
-				"112233445": {Mu: 20.14266178646694, Sigma: 6.622734811533342, Z: 3},
-				"123456789": {Mu: 19.075596838556958, Sigma: 4.32566475663472, Z: 3},
-				"556677889": {Mu: 22.069139105906665, Sigma: 6.942133769169642, Z: 3},
-				"987654321": {Mu: 29.51354881824657, Sigma: 7.397377605157138, Z: 3},
+				"112233445": {Mu: 17.134731637125135, Sigma: 6.501092020874961, Z: 3},
+				"123456789": {Mu: 19.620014923159122, Sigma: 4.325701896576898, Z: 3},
+				"556677889": {Mu: 21.584260659198744, Sigma: 6.787349653038609, Z: 3},
+				"987654321": {Mu: 32.25100494750614, Sigma: 7.403291008004081, Z: 3},
 			},
 		},
 		{
@@ -165,13 +174,19 @@ func TestCalculatePlayerRating(t *testing.T) {
 						JoinTime:    0.0,
 					},
 				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 123456789}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 987654321}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 112233445}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 556677889}: {Points: 0, Assists: 0},
+				},
 				blueWins: false,
 			},
 			want: map[string]types.Rating{
-				"112233445": {Mu: 20.079170415596188, Sigma: 6.631380089140646, Z: 3},
-				"123456789": {Mu: 12.461070326499232, Sigma: 8.274574225729237, Z: 3},
-				"556677889": {Mu: 22.00810922884636, Sigma: 6.954278202505372, Z: 3},
-				"987654321": {Mu: 29.516973992402264, Sigma: 7.4224151743985205, Z: 3},
+				"112233445": {Mu: 20.734078648705445, Sigma: 6.638048733401844, Z: 3},
+				"123456789": {Mu: 12.430429521320995, Sigma: 8.184594812783692, Z: 3},
+				"556677889": {Mu: 22.73008417680748, Sigma: 6.960619786170357, Z: 3},
+				"987654321": {Mu: 27.884449958743556, Sigma: 7.365617736624244, Z: 3},
 			},
 		},
 		{
@@ -215,13 +230,19 @@ func TestCalculatePlayerRating(t *testing.T) {
 						JoinTime:    0.0,
 					},
 				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 987654321}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 123456789}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 112233445}: {Points: 0, Assists: 0},
+					{PlatformCode: 4, AccountId: 556677889}: {Points: 0, Assists: 0},
+				},
 				blueWins: true,
 			},
 			want: map[string]types.Rating{
-				"112233445": {Mu: 20.079170415596188, Sigma: 6.631380089140646, Z: 3},
-				"123456789": {Mu: 12.461070326499232, Sigma: 8.274574225729237, Z: 3},
-				"556677889": {Mu: 22.00810922884636, Sigma: 6.954278202505372, Z: 3},
-				"987654321": {Mu: 29.516973992402264, Sigma: 7.4224151743985205, Z: 3},
+				"112233445": {Mu: 19.501306348685958, Sigma: 6.58730676305727, Z: 3},
+				"123456789": {Mu: 13.483755866429656, Sigma: 8.279910016496327, Z: 3},
+				"556677889": {Mu: 21.201229156253063, Sigma: 6.89881982340915, Z: 3},
+				"987654321": {Mu: 30.345453845567764, Sigma: 7.4283160798165335, Z: 3},
 			},
 		},
 		{
@@ -241,10 +262,13 @@ func TestCalculatePlayerRating(t *testing.T) {
 						JoinTime:    0.0,
 					},
 				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 123456789}: {Points: 0, Assists: 0},
+				},
 				blueWins: true,
 			},
 			want: map[string]types.Rating{
-				"123456789": {Mu: 30, Sigma: 7.5, Z: 3},
+				"123456789": {Mu: 30, Sigma: 7.505997601918082, Z: 3},
 			},
 		},
 		{
@@ -264,16 +288,19 @@ func TestCalculatePlayerRating(t *testing.T) {
 						JoinTime:    0.0,
 					},
 				},
+				playerStats: map[evr.EvrId]evr.MatchTypeStats{
+					{PlatformCode: 4, AccountId: 987654321}: {Points: 0, Assists: 0},
+				},
 				blueWins: true,
 			},
 			want: map[string]types.Rating{
-				"987654321": {Mu: 30, Sigma: 7.5, Z: 3},
+				"987654321": {Mu: 30, Sigma: 7.505997601918082, Z: 3},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := CalculateNewPlayerRatings(tt.args.players, tt.args.blueWins); cmp.Diff(got, tt.want) != "" {
+			if got := CalculateNewPlayerRatings(tt.args.players, tt.args.playerStats, tt.args.blueWins); cmp.Diff(got, tt.want) != "" {
 				t.Errorf("calculatePlayerRating() = %s", cmp.Diff(got, tt.want))
 			}
 		})

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -1222,22 +1222,6 @@ func (p *EvrPipeline) processUserServerProfileUpdate(ctx context.Context, logger
 
 	serviceSettings := ServiceSettings()
 
-	validModes := []evr.Symbol{evr.ModeArenaPublic, evr.ModeCombatPublic}
-
-	if serviceSettings.UseSkillBasedMatchmaking() && slices.Contains(validModes, label.Mode) {
-
-		// Determine winning team
-		blueWins := playerInfo.Team == BlueTeam && payload.IsWinner()
-		ratings := CalculateNewPlayerRatings(label.Players, blueWins)
-		if rating, ok := ratings[playerInfo.SessionID]; ok {
-			if err := MatchmakingRatingStore(ctx, p.nk, playerInfo.UserID, playerInfo.DiscordID, playerInfo.DisplayName, groupIDStr, label.Mode, rating); err != nil {
-				logger.Warn("Failed to record percentile to leaderboard", zap.Error(err))
-			}
-		} else {
-			logger.Warn("Failed to get player rating", zap.String("sessionID", playerInfo.SessionID))
-		}
-	}
-
 	// Update the player's statistics, if the service settings allow it
 	if serviceSettings.DisableStatisticsUpdates {
 		return nil

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -537,7 +537,7 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 		})
 
 		// Increment the completed matches for the player
-		if err := s.incrementCompletedMatches(ctx, logger, nk, sessionRegistry, s.UserID, s.SessionID); err != nil {
+		if err := s.incrementCompletedMatches(ctx, logger, nk, sessionRegistry, playerInfo.UserID, playerInfo.SessionID); err != nil {
 			logger.WithField("error", err).Warn("Failed to increment completed matches")
 		}
 
@@ -545,7 +545,7 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 		if serviceSettings.UseSkillBasedMatchmaking() {
 
 			// Determine winning team
-			blueWins := playerInfo.Team == BlueTeam && typeStats.ArenaWins > 0 || playerInfo.Team == OrangeTeam && typeStats.ArenaLosses > 0
+			blueWins := (playerInfo.Team == BlueTeam && typeStats.ArenaWins > 0) || (playerInfo.Team == OrangeTeam && typeStats.ArenaLosses > 0)
 
 			// Calculate new ratings
 			ratings := CalculateNewPlayerRatings(label.Players, statsByPlayer, blueWins)
@@ -566,11 +566,12 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 			}
 			allStatEntries = append(allStatEntries, statEntries...)
 		}
-
-		if len(allStatEntries) > 0 {
-			return statisticsQueue.Add(allStatEntries)
-		}
 	}
+
+	if len(allStatEntries) > 0 {
+		return statisticsQueue.Add(allStatEntries)
+	}
+
 	return nil
 }
 

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -115,6 +115,9 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 	// Collect the updates to the match's game metadata (e.g. game clock)
 	updates := MapOf[uuid.UUID, *MatchGameStateUpdate]{}
 
+	// Collect the post-match messages for processing
+	postMatchMessages := make(map[uuid.UUID][]evr.RemoteLog)
+
 	for _, e := range entries {
 		logger := logger.WithField("message_type", fmt.Sprintf("%T", e))
 
@@ -390,40 +393,15 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 		case *evr.RemoteLogPostMatchMatchStats:
 			update, _ = updates.LoadOrStore(msg.SessionUUID(), &MatchGameStateUpdate{})
 			update.MatchOver = true
-			// Increment the completed matches for the player
-			if err := s.incrementCompletedMatches(ctx, logger, nk, sessionRegistry, s.UserID, s.SessionID); err != nil {
-				logger.WithField("error", err).Warn("Failed to increment completed matches")
-				continue
-			}
+			postMatchMessages[msg.SessionUUID()] = append(postMatchMessages[msg.SessionUUID()], msg)
 
 		case *evr.RemoteLogPostMatchTypeStats:
 			update, _ = updates.LoadOrStore(msg.SessionUUID(), &MatchGameStateUpdate{})
 			update.MatchOver = true
-			// Process the post match stats into the player's statistics
-			if err := s.processPostMatchTypeStats(ctx, logger, db, nk, sessionRegistry, statisticsQueue, msg); err != nil {
-				logger.WithFields(map[string]any{
-					"error": err,
-					"msg":   msg,
-				}).Warn("Failed to process post match type stats")
+			postMatchMessages[msg.SessionUUID()] = append(postMatchMessages[msg.SessionUUID()], msg)
 
-				continue
-			}
 		case *evr.RemoteLogPostMatchMatchTypeXPLevel:
-			// This provides the XP gain from the match
-			/*
-							{
-				    "message": "process post-match match type xp level",
-				    "message_type": "POST_MATCH_MATCH_TYPE_XP_LEVEL",
-				    "CurrentLevel": 2,
-				    "CurrentXP": 1000,
-				    "PreviousLevel": 1,
-				    "PreviousXP": 0,
-				    "RemainingXP": 500,
-				    "[session][uuid]": "{8DFB17C0-4CF3-481A-B898-F090343A5DA1}",
-				    "match_type": "Echo_Arena",
-				    "userid": "OVR-ORG-8185598851511174"
-				  },
-			*/
+			postMatchMessages[msg.SessionUUID()] = append(postMatchMessages[msg.SessionUUID()], msg)
 		case *evr.RemoteLogLoadStats:
 
 			if msg.ClientLoadTime > 45 {
@@ -461,6 +439,17 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 		}
 	}
 
+	for sessionUUID, msgs := range postMatchMessages {
+		matchID, err := NewMatchID(sessionUUID, s.Node)
+		if err != nil {
+			logger.Warn("Failed to create match ID for post match processing")
+			continue
+		}
+		if err := s.processPostMatchMessages(ctx, logger, db, nk, sessionRegistry, statisticsQueue, matchID, msgs); err != nil {
+			logger.WithField("error", err).Warn("Failed to process post match messages")
+		}
+	}
+
 	updates.Range(func(key uuid.UUID, value *MatchGameStateUpdate) bool {
 		matchRegistry.SendData(key, s.Node, uuid.FromStringOrNil(s.UserID), uuid.FromStringOrNil(s.SessionID), s.Username, s.Node, OpCodeMatchGameStateUpdate, value.Bytes(), false, time.Now().Unix())
 		return true
@@ -488,66 +477,101 @@ func (s *EventRemoteLogSet) incrementCompletedMatches(ctx context.Context, logge
 	return nil
 }
 
-func (s *EventRemoteLogSet) processPostMatchTypeStats(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, sessionRegistry SessionRegistry, statisticsQueue *StatisticsQueue, msg *evr.RemoteLogPostMatchTypeStats) error {
-	var err error
-	matchID, err := NewMatchID(msg.SessionUUID(), s.Node)
-	if err != nil {
-		return fmt.Errorf("failed to create match ID: %w", err)
+func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, sessionRegistry SessionRegistry, statisticsQueue *StatisticsQueue, matchID MatchID, msgs []evr.RemoteLog) error {
+	var statsByPlayer = make(map[evr.EvrId]evr.MatchTypeStats, 8)
+
+	//var xpLevel *evr.RemoteLogPostMatchMatchTypeXPLevel
+
+	for _, msg := range msgs {
+		switch m := msg.(type) {
+		case *evr.RemoteLogPostMatchMatchTypeXPLevel:
+			continue
+		case *evr.RemoteLogPostMatchMatchStats:
+			continue
+		case *evr.RemoteLogPostMatchTypeStats:
+
+			xpid, err := evr.ParseEvrId(m.XPID)
+			if err != nil {
+				return fmt.Errorf("failed to parse evr ID: %w", err)
+			}
+			statsByPlayer[*xpid] = m.Stats
+
+		}
 	}
-	// Get the match label
+
 	label, err := MatchLabelByID(ctx, nk, matchID)
 	if err != nil || label == nil {
 		return fmt.Errorf("failed to get match label: %w", err)
 	}
-	xpid, err := evr.ParseEvrId(msg.XPID)
-	if err != nil {
-		return fmt.Errorf("failed to parse evr ID: %w", err)
+	if label.Mode != evr.ModeArenaPublic {
+		return nil // Only process type stats for arena mode
 	}
-	// Get the player's information
-	playerInfo := label.GetPlayerByEvrID(*xpid)
-	if playerInfo == nil {
-		// If the player isn't in the match, do not update the stats
-		return fmt.Errorf("player not in match: %s", msg.XPID)
-	}
-
-	// If the player isn't in the match, or isn't a player, do not update the stats
-	if playerInfo.Team != BlueTeam && playerInfo.Team != OrangeTeam {
-		return fmt.Errorf("non-player profile update request: %s", msg.XPID)
-	}
-	logger = logger.WithFields(map[string]any{
-		"player_uid":  playerInfo.UserID,
-		"player_sid":  playerInfo.SessionID,
-		"player_xpid": playerInfo.EvrID.String(),
-	})
 
 	groupIDStr := label.GetGroupID().String()
-	validModes := []evr.Symbol{evr.ModeArenaPublic, evr.ModeCombatPublic}
 
-	serviceSettings := ServiceSettings()
-	if serviceSettings.UseSkillBasedMatchmaking() && slices.Contains(validModes, label.Mode) {
+	logger = logger.WithFields(map[string]any{
+		"mid": matchID.String(),
+	})
 
-		// Determine winning team
-		blueWins := playerInfo.Team == BlueTeam && msg.IsWinner()
-		ratings := CalculateNewPlayerRatings(label.Players, blueWins)
-		if rating, ok := ratings[playerInfo.SessionID]; ok {
-			if err := MatchmakingRatingStore(ctx, nk, playerInfo.UserID, playerInfo.DiscordID, playerInfo.DisplayName, groupIDStr, label.Mode, rating); err != nil {
-				logger.WithField("error", err).Warn("Failed to record rating to leaderboard")
+	allStatEntries := make([]*StatisticsQueueEntry, 0)
+
+	for xpid, typeStats := range statsByPlayer {
+		// Get the match label
+
+		// Get the player's information
+		playerInfo := label.GetPlayerByEvrID(xpid)
+		if playerInfo == nil {
+			// If the player isn't in the match, do not update the stats
+			return fmt.Errorf("player not in match: %s", xpid.String())
+		}
+
+		// If the player isn't in the match, or isn't a player, do not update the stats
+		if playerInfo.Team != BlueTeam && playerInfo.Team != OrangeTeam {
+			return fmt.Errorf("non-competitor player cannot have stats updated: %s", xpid.String())
+		}
+
+		logger = logger.WithFields(map[string]any{
+			"player_uid":  playerInfo.UserID,
+			"player_sid":  playerInfo.SessionID,
+			"player_xpid": playerInfo.EvrID.String(),
+		})
+
+		// Increment the completed matches for the player
+		if err := s.incrementCompletedMatches(ctx, logger, nk, sessionRegistry, s.UserID, s.SessionID); err != nil {
+			logger.WithField("error", err).Warn("Failed to increment completed matches")
+		}
+
+		serviceSettings := ServiceSettings()
+		if serviceSettings.UseSkillBasedMatchmaking() {
+
+			// Determine winning team
+			blueWins := playerInfo.Team == BlueTeam && typeStats.ArenaWins > 0 || playerInfo.Team == OrangeTeam && typeStats.ArenaLosses > 0
+
+			// Calculate new ratings
+			ratings := CalculateNewPlayerRatings(label.Players, statsByPlayer, blueWins)
+			if rating, ok := ratings[playerInfo.SessionID]; ok {
+				if err := MatchmakingRatingStore(ctx, nk, playerInfo.UserID, playerInfo.DiscordID, playerInfo.DisplayName, groupIDStr, label.Mode, rating); err != nil {
+					logger.WithField("error", err).Warn("Failed to record rating to leaderboard")
+				}
+			} else {
+				logger.WithField("target_sid", playerInfo.SessionID).Warn("No rating found for player in matchmaking ratings")
 			}
-		} else {
-			logger.WithField("target_sid", playerInfo.SessionID).Warn("No rating found for player in matchmaking ratings")
+		}
+
+		// Update the player's statistics, if the service settings allow it
+		if !serviceSettings.DisableStatisticsUpdates {
+			statEntries, err := typeStatsToScoreMap(playerInfo.UserID, playerInfo.DisplayName, groupIDStr, label.Mode, typeStats)
+			if err != nil {
+				return fmt.Errorf("failed to convert type stats to score map: %w", err)
+			}
+			allStatEntries = append(allStatEntries, statEntries...)
+		}
+
+		if len(allStatEntries) > 0 {
+			return statisticsQueue.Add(allStatEntries)
 		}
 	}
-
-	// Update the player's statistics, if the service settings allow it
-	if serviceSettings.DisableStatisticsUpdates {
-		return nil
-	}
-
-	statEntries, err := typeStatsToScoreMap(playerInfo.UserID, playerInfo.DisplayName, groupIDStr, label.Mode, msg.Stats)
-	if err != nil {
-		return fmt.Errorf("failed to convert type stats to score map: %w", err)
-	}
-	return statisticsQueue.Add(statEntries)
+	return nil
 }
 
 func iterateMatchTypeStatsFields(stats evr.MatchTypeStats, fn func(statName string, op LeaderboardOperator, value float64)) {


### PR DESCRIPTION
 This pull request refactors the player rating calculation and post-match processing logic. The main improvements include removing the `RatingScore` field from `PlayerInfo`, updating the rating calculation to use detailed match statistics, and restructuring how post-match messages are processed. These changes improve the accuracy of skill-based matchmaking and streamline post-match data handling.

**Player rating calculation and data model updates:**

* Removed the `RatingScore` field from the `PlayerInfo` struct and all related usages, shifting rating calculations to use detailed match statistics instead of a single score value. (`server/evr_match_player.go`, `server/evr_match_label.go`, `server/evr_matchmaker_ratings.go`, `server/evr_matchmaker_ratings_test.go`) [[1]](diffhunk://#diff-3155ceb2da74816416cd102a7dfd90b3f821e7eedb8bb8a2848822879f7c740cL19) [[2]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L306) [[3]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L340) [[4]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L360) [[5]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L559) [[6]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4L38-L46) [[7]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4L55) [[8]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4L64-R77)
* Refactored the `CalculateNewPlayerRatings` function to compute player scores from match statistics (goals, assists, saves, passes, missed shots, and team bonus) and updated all usages and tests accordingly. (`server/evr_matchmaker_ratings.go`, `server/evr_matchmaker_ratings_test.go`) [[1]](diffhunk://#diff-2b7bd9fd46f799b42ac7811d6f9f3e888a121c69d4ee2ca6d88c90a01e015221L90-R130) [[2]](diffhunk://#diff-2b7bd9fd46f799b42ac7811d6f9f3e888a121c69d4ee2ca6d88c90a01e015221L129-R150) [[3]](diffhunk://#diff-2b7bd9fd46f799b42ac7811d6f9f3e888a121c69d4ee2ca6d88c90a01e015221L146-R162) [[4]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R15) [[5]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R121-R133) [[6]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R177-R189) [[7]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R233-R245) [[8]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R265-R271) [[9]](diffhunk://#diff-1ad871a7feafa78c7bd8e7baa9ffecfc7f393a4fc6ff97187a934bed931e04d4R291-R303)
* Removed the obsolete `IsWinner` method from `UpdatePayload`, as winner determination for rating purposes is now handled differently. (`server/evr/login_serverprofileupdate_request.go`)

**Post-match message processing improvements:**

* Changed post-match processing to batch and process all relevant post-match messages together, improving reliability and maintainability. (`server/evr_runtime_event_remotelogset.go`) [[1]](diffhunk://#diff-df01c042328880c11731f9ee9e33e9741c40879d32e5844b3ffb58105c6ec390R118-R120) [[2]](diffhunk://#diff-df01c042328880c11731f9ee9e33e9741c40879d32e5844b3ffb58105c6ec390L393-R404) [[3]](diffhunk://#diff-df01c042328880c11731f9ee9e33e9741c40879d32e5844b3ffb58105c6ec390R442-R452)

**Pipeline and matchmaking logic updates:**

* Removed old skill-based matchmaking rating update logic from the login pipeline, which is now handled with the new approach. (`server/evr_pipeline_login.go`)

**Miscellaneous:**

* Added missing import for `evr` package in the rating calculation file. (`server/evr_matchmaker_ratings.go`)