### PR TITLE
Fix IGP bugs

### DIFF
--- a/server/evr_discord_appbot_igp.go
+++ b/server/evr_discord_appbot_igp.go
@@ -592,11 +592,11 @@ func (p *InGamePanel) createSuspendPlayerModal(targetDiscordID, displayName stri
 	}
 }
 
-func (p *InGamePanel) createSetIGNModal(currentDisplayName string) *discordgo.InteractionResponse {
+func (p *InGamePanel) createSetIGNModal(userID, groupID, currentDisplayName string) *discordgo.InteractionResponse {
 	return &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseModal,
 		Data: &discordgo.InteractionResponseData{
-			CustomID: "igp:set_ign_modal",
+			CustomID: fmt.Sprintf("igp:set_ign_modal:%s:%s", userID, groupID),
 			Title:    "Set IGN",
 			Components: []discordgo.MessageComponent{
 				discordgo.ActionsRow{
@@ -646,7 +646,7 @@ func (p *InGamePanel) HandleInteraction(i *discordgo.InteractionCreate, command 
 		}
 
 		// Get the selected user ID
-		modal := p.createSetIGNModal(evrProfile.GetGroupIGN(groupID))
+		modal := p.createSetIGNModal(userID, groupID, evrProfile.GetGroupIGN(groupID))
 		return p.dg.InteractionRespond(i.Interaction, modal)
 
 	case "select_player":

--- a/server/evr_discord_appbot_igp_test.go
+++ b/server/evr_discord_appbot_igp_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetIGNModalCustomIDFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		customID       string
+		expectedAction string
+		expectedParts  int
+		shouldParse    bool
+	}{
+		{
+			name:           "valid IGP set_ign_modal with userID and groupID",
+			customID:       "igp:set_ign_modal:userid123:groupid456",
+			expectedAction: "set_ign_modal",
+			expectedParts:  2,
+			shouldParse:    true,
+		},
+		{
+			name:           "invalid IGP set_ign_modal without userID and groupID",
+			customID:       "igp:set_ign_modal",
+			expectedAction: "set_ign_modal",
+			expectedParts:  0,
+			shouldParse:    false,
+		},
+		{
+			name:           "valid lookup set_ign_modal with userID and groupID",
+			customID:       "lookup:set_ign_modal:userid123:groupid456",
+			expectedAction: "set_ign_modal",
+			expectedParts:  2,
+			shouldParse:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, value, _ := strings.Cut(tt.customID, ":")
+
+			// For IGP modals, the action will be "igp"
+			// For lookup modals, the action will be "lookup"
+			require.NotEmpty(t, action)
+
+			// Parse the value to get action and parameters
+			modalAction, params, _ := strings.Cut(value, ":")
+
+			assert.Equal(t, tt.expectedAction, modalAction)
+
+			if tt.shouldParse {
+				parts := strings.SplitN(params, ":", 2)
+				require.Len(t, parts, tt.expectedParts)
+				assert.NotEmpty(t, parts[0]) // targetUserID
+				assert.NotEmpty(t, parts[1]) // groupID
+			} else {
+				parts := strings.SplitN(params, ":", 2)
+				require.NotEqual(t, tt.expectedParts, len(parts),
+					"Expected parsing to fail but got %d parts", len(parts))
+			}
+		})
+	}
+}
+
+func TestIGPCreateSetIGNModalCustomID(t *testing.T) {
+	// This test verifies that the IGP's createSetIGNModal produces
+	// a CustomID in the correct format that can be parsed by handleModalSubmit
+	tests := []struct {
+		name               string
+		userID             string
+		groupID            string
+		currentDisplayName string
+	}{
+		{
+			name:               "with simple display name",
+			userID:             "test-user-id",
+			groupID:            "test-group-id",
+			currentDisplayName: "TestIGN",
+		},
+		{
+			name:               "with empty display name",
+			userID:             "another-user-id",
+			groupID:            "another-group-id",
+			currentDisplayName: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			igp := &InGamePanel{
+				userID: tt.userID,
+			}
+
+			modal := igp.createSetIGNModal(tt.userID, tt.groupID, tt.currentDisplayName)
+
+			require.NotNil(t, modal)
+			require.NotNil(t, modal.Data)
+			expectedCustomID := "igp:set_ign_modal:" + tt.userID + ":" + tt.groupID
+			assert.Equal(t, expectedCustomID, modal.Data.CustomID)
+
+			// Verify the CustomID has the correct format with all required parts
+			parts := strings.Split(modal.Data.CustomID, ":")
+			assert.Equal(t, 4, len(parts), "CustomID should have exactly 4 parts (igp, set_ign_modal, userID, groupID), but has %d", len(parts))
+			assert.Equal(t, "igp", parts[0])
+			assert.Equal(t, "set_ign_modal", parts[1])
+			assert.Equal(t, tt.userID, parts[2])
+			assert.Equal(t, tt.groupID, parts[3])
+		})
+	}
+}
+
+func TestHandleSetIGNModalParsing(t *testing.T) {
+	tests := []struct {
+		name          string
+		value         string
+		shouldFail    bool
+		expectedError string
+	}{
+		{
+			name:       "valid format with userID and groupID",
+			value:      "set_ign_modal:userid123:groupid456",
+			shouldFail: false,
+		},
+		{
+			name:          "invalid format without parameters",
+			value:         "set_ign_modal",
+			shouldFail:    true,
+			expectedError: "invalid parameters for set_ign_modal",
+		},
+		{
+			name:          "invalid format with only one parameter",
+			value:         "set_ign_modal:userid123",
+			shouldFail:    true,
+			expectedError: "invalid parameters for set_ign_modal",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			action, value, _ := strings.Cut(tt.value, ":")
+
+			assert.Equal(t, "set_ign_modal", action)
+
+			// Simulate the parsing logic from handleModalSubmit
+			parts := strings.SplitN(value, ":", 2)
+
+			if tt.shouldFail {
+				require.NotEqual(t, 2, len(parts), "Expected parsing to fail")
+			} else {
+				require.Equal(t, 2, len(parts), "Expected parsing to succeed")
+				assert.NotEmpty(t, parts[0]) // targetUserID
+				assert.NotEmpty(t, parts[1]) // groupID
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request improves the robustness and test coverage of the `InGamePanel` logic, especially around Discord interaction handling and the formatting/parsing of modal custom IDs. The most significant changes include additional nil checks to prevent panics, refactoring of the `createSetIGNModal` method to include more context in the modal's custom ID, and the addition of comprehensive unit tests to verify the correct behavior and parsing of modal IDs.

**Reliability and Robustness Improvements:**

* Added nil checks for `interaction` and `p.dg` in several methods (`Stop`, `displayMessage`, and session loop edit) to prevent possible panics if these values are not set. (`server/evr_discord_appbot_igp.go`, [[1]](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802L68-R73) [[2]](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802R124-R130) [[3]](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802L304-R325)
* Refactored `Interaction`, `GuildID`, and related methods to safely handle cases where the underlying value may be nil, returning `nil` or an empty string as appropriate. (`server/evr_discord_appbot_igp.go`, [server/evr_discord_appbot_igp.goL83-R98](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802L83-R98))

**Modal Custom ID Refactoring:**

* Updated `createSetIGNModal` to accept `userID` and `groupID` parameters and format the modal's `CustomID` as `igp:set_ign_modal:<userID>:<groupID>`, providing more context for downstream handling. (`server/evr_discord_appbot_igp.go`, [[1]](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802L578-R599) [[2]](diffhunk://#diff-95b5733a949a594be825f4f0c1edcf820d26b74d7b88c0b9308b8d7793417802L632-R649)

**Testing Enhancements:**

* Added a new test file with comprehensive unit tests for modal custom ID formatting and parsing, ensuring that modal IDs are generated and parsed correctly and that error cases are properly handled. (`server/evr_discord_appbot_igp_test.go`, [server/evr_discord_appbot_igp_test.goR1-R160](diffhunk://#diff-fc5b692f427f255f79fb4183e6e2004ce0373769a22eb89c6d7a158fa021ef13R1-R160))