### PR TITLE
Feat/direct join bypasses lock

### DIFF
--- a/server/evr_gameserver_presence.go
+++ b/server/evr_gameserver_presence.go
@@ -24,6 +24,7 @@ type GameServerPresence struct {
 	Endpoint        evr.Endpoint `json:"endpoint,omitempty"`         // The endpoint data used for connections.
 	VersionLock     evr.Symbol   `json:"version_lock,omitempty"`     // The game build version. (EVR)
 	AppID           string       `json:"app_id,omitempty"`           // The game app id. (EVR)
+	DefaultRegion   string       `json:"default_region,omitempty"`   // The default region code for the server.
 	RegionCodes     []string     `json:"region_codes,omitempty"`     // The region the match is hosted in. (Matching Only) (EVR)
 	ServerID        uint64       `json:"server_id,omitempty"`        // The server id of the server. (EVR)
 	Features        []string     `json:"features,omitempty"`         // The features of the server.
@@ -95,7 +96,7 @@ func (g *GameServerPresence) IsPriorityFor(mode evr.Symbol) bool {
 	return slices.Contains(g.DesignatedModes, mode)
 }
 
-func NewGameServerPresence(userId, sessionId uuid.UUID, serverId uint64, internalIP, externalIP net.IP, port uint16, groupIDs []uuid.UUID, regionCodes []string, versionLock evr.Symbol, tags, features []string, timeStepUsecs uint32, ipInfo IPInfo, geoPrecision int, isNative bool, nativeVersion string) *GameServerPresence {
+func NewGameServerPresence(userId, sessionId uuid.UUID, serverId uint64, internalIP, externalIP net.IP, port uint16, groupIDs []uuid.UUID, defaultRegion string, regionCodes []string, versionLock evr.Symbol, tags, features []string, timeStepUsecs uint32, ipInfo IPInfo, geoPrecision int, isNative bool, nativeVersion string) *GameServerPresence {
 
 	var asn int
 	var lat, lon float64
@@ -126,6 +127,7 @@ func NewGameServerPresence(userId, sessionId uuid.UUID, serverId uint64, interna
 			ExternalIP: externalIP,
 			Port:       port,
 		},
+		DefaultRegion: defaultRegion,
 		RegionCodes:   regionCodes,
 		VersionLock:   versionLock,
 		GroupIDs:      groupIDs,

--- a/server/evr_gamestate.go
+++ b/server/evr_gamestate.go
@@ -14,17 +14,17 @@ type TeamMetadata struct {
 type GameState struct {
 	BlueScore              int                        `json:"blue_score"`                        // The score for the blue team
 	OrangeScore            int                        `json:"orange_score"`                      // The score for the orange team
-	RoundClock             *RoundClock                `json:"round_clock,omitempty"`             // The round clock
+	SessionScoreboard      *SessionScoreboard         `json:"session_scoreboard,omitempty"`      // The session scoreboard
 	MatchOver              bool                       `json:"match_over,omitempty"`              // Whether the round is over
 	EquilibriumCoefficient float64                    `json:"equilibrium_coefficient,omitempty"` // The equilibrium coefficient for the game (how much the game is balanced)
 	Teams                  map[TeamIndex]TeamMetadata `json:"teams,omitempty"`                   // Metadata for each team
 }
 
-func (g *GameState) GetRoundClock() *RoundClock {
-	if g.RoundClock == nil {
+func (g *GameState) GetSessionScoreboard() *SessionScoreboard {
+	if g.SessionScoreboard == nil {
 		return nil
 	}
-	return g.RoundClock
+	return g.SessionScoreboard
 }
 
 func NewGameState() *GameState {

--- a/server/evr_gamestate_clock.go
+++ b/server/evr_gamestate_clock.go
@@ -3,11 +3,11 @@ package server
 import "time"
 
 type SessionScoreboard struct {
-	GameTime      time.Duration `json:"game_time_ms"`                // The time on the game clock in milliseconds
-	RoundDuration time.Duration `json:"round_duration_ms"`           // The duration of the round in milliseconds
+	GameTime      time.Duration `json:"game_time_ns"`                // The time on the game clock in milliseconds
+	RoundDuration time.Duration `json:"round_duration_ns"`           // The duration of the round in milliseconds
 	UpdatedAt     time.Time     `json:"updated_at"`                  // The time at which the scoreboard was last updated
 	PausedAt      *time.Time    `json:"paused_at,omitempty"`         // The time at which the game was paused
-	PauseDuration time.Duration `json:"pause_duration_ms,omitempty"` // The duration of the pause in milliseconds
+	PauseDuration time.Duration `json:"pause_duration_ns,omitempty"` // The duration of the pause in milliseconds
 }
 
 func NewSessionScoreboard(duration time.Duration, startAt time.Time) *SessionScoreboard {

--- a/server/evr_gamestate_clock.go
+++ b/server/evr_gamestate_clock.go
@@ -2,19 +2,19 @@ package server
 
 import "time"
 
-type RoundClock struct {
-	GameTime      time.Duration `json:"game_time"`      // The time on the game clock
-	RoundDuration time.Duration `json:"round_duration"` // The duration of the round
-	UpdatedAt     time.Time     `json:"updated_at"`     // The time at which the round clock was last updated
-	PausedAt      time.Time     `json:"paused_at"`      // The time at which the game was paused
-	PauseDuration time.Duration `json:"pause_duration"` // The duration of the pause
+type SessionScoreboard struct {
+	GameTime      time.Duration `json:"game_time_ms"`                // The time on the game clock in milliseconds
+	RoundDuration time.Duration `json:"round_duration_ms"`           // The duration of the round in milliseconds
+	UpdatedAt     time.Time     `json:"updated_at"`                  // The time at which the scoreboard was last updated
+	PausedAt      *time.Time    `json:"paused_at,omitempty"`         // The time at which the game was paused
+	PauseDuration time.Duration `json:"pause_duration_ms,omitempty"` // The duration of the pause in milliseconds
 }
 
-func NewRoundClock(duration time.Duration, startAt time.Time) *RoundClock {
+func NewSessionScoreboard(duration time.Duration, startAt time.Time) *SessionScoreboard {
 	if duration <= 0 {
 		return nil
 	}
-	c := &RoundClock{
+	c := &SessionScoreboard{
 		RoundDuration: duration,
 		UpdatedAt:     time.Now(),
 	}
@@ -25,11 +25,11 @@ func NewRoundClock(duration time.Duration, startAt time.Time) *RoundClock {
 	return c
 }
 
-func (r *RoundClock) LatestAsNewClock() *RoundClock {
+func (r *SessionScoreboard) LatestAsNewScoreboard() *SessionScoreboard {
 	if r == nil {
 		return nil
 	}
-	return &RoundClock{
+	return &SessionScoreboard{
 		RoundDuration: r.RoundDuration,
 		GameTime:      r.Elapsed(),
 		UpdatedAt:     time.Now(),
@@ -37,7 +37,7 @@ func (r *RoundClock) LatestAsNewClock() *RoundClock {
 	}
 }
 
-func (r *RoundClock) Elapsed() time.Duration {
+func (r *SessionScoreboard) Elapsed() time.Duration {
 	// If the game is over return the round duration
 	if r.IsOver() {
 		return r.RoundDuration
@@ -51,21 +51,21 @@ func (r *RoundClock) Elapsed() time.Duration {
 	return r.GameTime + time.Since(r.UpdatedAt)
 }
 
-func (r *RoundClock) RemainingTime() time.Duration {
+func (r *SessionScoreboard) RemainingTime() time.Duration {
 	if r == nil {
 		return 0
 	}
 	return max(0, r.RoundDuration-r.Elapsed())
 }
 
-func (r *RoundClock) IsPaused() bool {
+func (r *SessionScoreboard) IsPaused() bool {
 	if r == nil {
 		return false
 	}
-	return !r.PausedAt.IsZero() && time.Since(r.PausedAt) < r.PauseDuration
+	return r.PausedAt != nil && !r.PausedAt.IsZero() && time.Since(*r.PausedAt) < r.PauseDuration
 }
 
-func (r *RoundClock) IsOver() bool {
+func (r *SessionScoreboard) IsOver() bool {
 	if r == nil {
 		return false
 	}
@@ -78,12 +78,12 @@ func (r *RoundClock) IsOver() bool {
 		elapsed = r.GameTime
 	}
 
-	// Otherwise return the game time plus the time since the last updat
+	// Otherwise return the game time plus the time since the last update
 
 	return elapsed >= r.RoundDuration
 }
 
-func (r *RoundClock) Update(gameTime time.Duration) {
+func (r *SessionScoreboard) Update(gameTime time.Duration) {
 	r.UpdatedAt = time.Now()
 
 	// If the elapsed time has increased, update it
@@ -91,7 +91,7 @@ func (r *RoundClock) Update(gameTime time.Duration) {
 		r.GameTime = gameTime
 		// Clear any pause state
 		r.PauseDuration = 0
-		r.PausedAt = time.Time{}
+		r.PausedAt = nil
 		return
 	}
 	// Otherwise, just update the updated at time
@@ -99,16 +99,17 @@ func (r *RoundClock) Update(gameTime time.Duration) {
 	r.GameTime = gameTime
 }
 
-func (r *RoundClock) UpdateWithPause(elapsed time.Duration, pauseDuration time.Duration) {
+func (r *SessionScoreboard) UpdateWithPause(elapsed time.Duration, pauseDuration time.Duration) {
 	r.GameTime = elapsed
 	r.UpdatedAt = time.Now()
 	r.PauseDuration = pauseDuration
-	r.PausedAt = time.Now()
+	now := time.Now()
+	r.PausedAt = &now
 }
 
-func (r *RoundClock) Unpause(elapsed time.Duration) {
+func (r *SessionScoreboard) Unpause(elapsed time.Duration) {
 	r.GameTime = elapsed
 	r.UpdatedAt = time.Now()
 	r.PauseDuration = 0
-	r.PausedAt = time.Time{}
+	r.PausedAt = nil
 }

--- a/server/evr_gamestate_clock.go
+++ b/server/evr_gamestate_clock.go
@@ -95,7 +95,6 @@ func (r *SessionScoreboard) Update(gameTime time.Duration) {
 		return
 	}
 	// Otherwise, just update the updated at time
-	r.UpdatedAt = time.Now()
 	r.GameTime = gameTime
 }
 

--- a/server/evr_gamestate_test.go
+++ b/server/evr_gamestate_test.go
@@ -59,9 +59,9 @@ func TestGameState_Update(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &GameState{
-				RoundClock:  NewRoundClock(10*time.Minute, time.Now()),
-				BlueScore:   0,
-				OrangeScore: 0}
+				SessionScoreboard: NewSessionScoreboard(10*time.Minute, time.Now()),
+				BlueScore:         0,
+				OrangeScore:       0}
 
 			g.Update(tt.goals)
 			if g.BlueScore != tt.wantBlue {

--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/heroiclabs/nakama-common/runtime"
 	"go.uber.org/atomic"
-	"go.uber.org/zap"
 )
 
 const (
@@ -216,7 +215,7 @@ func FixDefaultServiceSettings(logger runtime.Logger, data *ServiceSettingsData)
 		for key := range data.SkillRating.TeamStatMultipliers {
 			if !ValidTeamStatFields[key] {
 				if logger != nil {
-          logger.WithField("key", key).Warn("Removing invalid team stat multiplier key from configuration")
+					logger.WithField("key", key).Warn("Removing invalid team stat multiplier key from configuration")
 				}
 				delete(data.SkillRating.TeamStatMultipliers, key)
 			}
@@ -235,7 +234,7 @@ func FixDefaultServiceSettings(logger runtime.Logger, data *ServiceSettingsData)
 		for key := range data.SkillRating.PlayerStatMultipliers {
 			if !ValidTeamStatFields[key] {
 				if logger != nil {
-					 logger.WithField("key", key).Warn("Removing invalid player stat multiplier key from configuration")
+					logger.WithField("key", key).Warn("Removing invalid player stat multiplier key from configuration")
 				}
 				delete(data.SkillRating.PlayerStatMultipliers, key)
 			}

--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -60,6 +60,7 @@ type GlobalMatchmakingSettings struct {
 	FailsafeTimeoutSecs            int                     `json:"failsafe_timeout_secs"`               // The failsafe timeout
 	FallbackTimeoutSecs            int                     `json:"fallback_timeout_secs"`               // The fallback timeout
 	DisableArenaBackfill           bool                    `json:"disable_arena_backfill"`              // Disable backfilling for arena matches
+	ArenaBackfillMaxAgeSecs        int                     `json:"arena_backfill_max_age_secs"`         // Maximum age of arena matches to backfill (default 270s)
 	QueryAddons                    QueryAddons             `json:"query_addons"`                        // Additional queries to add to matchmaking queries
 	MaxServerRTT                   int                     `json:"max_server_rtt"`                      // The maximum RTT to allow
 	EnableSBMM                     bool                    `json:"enable_skill_based_mm"`               // Disable SBMM
@@ -168,6 +169,10 @@ func FixDefaultServiceSettings(data *ServiceSettingsData) {
 
 	if data.Matchmaking.MaxServerRTT == 0 {
 		data.Matchmaking.MaxServerRTT = 180
+	}
+
+	if data.Matchmaking.ArenaBackfillMaxAgeSecs == 0 {
+		data.Matchmaking.ArenaBackfillMaxAgeSecs = 270 // Default to 270 seconds (4.5 minutes)
 	}
 
 	if data.Matchmaking.SBMMMinPlayerCount == 0 {

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -403,6 +403,15 @@ func (p *LobbySessionParameters) BackfillSearchQuery(includeMMR bool, includeMax
 		p.BackfillQueryAddon,
 	}
 
+	// For arena public matches, exclude matches older than the configured max age
+	if p.Mode == evr.ModeArenaPublic {
+		maxAgeSecs := ServiceSettings().Matchmaking.ArenaBackfillMaxAgeSecs
+		if maxAgeSecs > 0 {
+			// Exclude matches that started more than maxAgeSecs ago
+			qparts = append(qparts, fmt.Sprintf("-label.start_time:<=%d", time.Now().UTC().Add(-time.Duration(maxAgeSecs)*time.Second).Unix()))
+		}
+	}
+
 	if !p.CurrentMatchID.IsNil() {
 		// Do not backfill into the same match
 		qparts = append(qparts, fmt.Sprintf("-label.id:%s", Query.QuoteStringValue(p.CurrentMatchID.String())))

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -408,7 +408,7 @@ func (p *LobbySessionParameters) BackfillSearchQuery(includeMMR bool, includeMax
 		maxAgeSecs := ServiceSettings().Matchmaking.ArenaBackfillMaxAgeSecs
 		if maxAgeSecs > 0 {
 			// Exclude matches that started more than maxAgeSecs ago
-			qparts = append(qparts, fmt.Sprintf("-label.start_time:<=%d", time.Now().UTC().Add(-time.Duration(maxAgeSecs)*time.Second).Unix()))
+			qparts = append(qparts, fmt.Sprintf("-label.start_time:<%d", time.Now().UTC().Add(-time.Duration(maxAgeSecs)*time.Second).Unix()))
 		}
 	}
 

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -746,7 +746,6 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 					if state.LockedAt == nil {
 						now := time.Now().UTC()
 						state.LockedAt = &now
-						state.Open = false
 						logger.Info("Locking public match on round over")
 					}
 				}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -429,11 +429,11 @@ func (m *EvrMatch) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql
 			delete(state.TeamAlignments, p.GetUserId())
 		}
 
-		// If the round clock is being used, set the join clock time
-		if state.GameState != nil && state.GameState.RoundClock != nil {
+		// If the session scoreboard is being used, set the join clock time
+		if state.GameState != nil && state.GameState.SessionScoreboard != nil {
 			// Do not overwrite an existing value
 			if _, ok := state.joinTimeMilliseconds[p.GetSessionId()]; !ok {
-				state.joinTimeMilliseconds[p.GetSessionId()] = state.GameState.RoundClock.Elapsed().Milliseconds()
+				state.joinTimeMilliseconds[p.GetSessionId()] = state.GameState.SessionScoreboard.Elapsed().Milliseconds()
 			}
 		}
 		isBackfill := time.Now().After(state.StartTime.Add(PublicMatchWaitTime))
@@ -734,6 +734,24 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				continue
 			}
 
+			isPublicMatch := state.Mode == evr.ModeArenaPublic || state.Mode == evr.ModeCombatPublic
+
+			if isPublicMatch {
+				// Close public matches on round over
+				if update.MatchOver && state.Open {
+					logger.Info("Received round over for public match, locking match.")
+					state.GameState.MatchOver = true
+					state.Open = false
+
+					if state.LockedAt == nil {
+						now := time.Now().UTC()
+						state.LockedAt = &now
+						state.Open = false
+						logger.Info("Locking public match on round over")
+					}
+				}
+			}
+
 			if state.GameState != nil {
 				logger.WithField("update", update).Debug("Received match update message.")
 				gs := state.GameState
@@ -743,16 +761,12 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 					state.goals = append(state.goals, u.Goals...)
 				}
 
-				if update.MatchOver {
-					state.GameState.MatchOver = true
-				}
-
-				if state.GameState.RoundClock != nil {
+				if state.GameState.SessionScoreboard != nil {
 					if u.CurrentGameClock != 0 {
 						if u.PauseDuration != 0 {
-							gs.RoundClock.UpdateWithPause(u.CurrentGameClock, u.PauseDuration)
+							gs.SessionScoreboard.UpdateWithPause(u.CurrentGameClock, u.PauseDuration)
 						} else {
-							gs.RoundClock.Update(u.CurrentGameClock)
+							gs.SessionScoreboard.Update(u.CurrentGameClock)
 						}
 					}
 				}
@@ -883,7 +897,7 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	}
 
 	// Lock the match if it is open and the lock time has passed.
-	if state.Open && !state.LockedAt.IsZero() && time.Now().After(state.LockedAt) {
+	if state.Open && state.LockedAt != nil && !state.LockedAt.IsZero() && time.Now().After(*state.LockedAt) {
 		logger.Info("Closing the match in response to a lock.")
 		state.Open = false
 		updateLabel = true
@@ -1273,14 +1287,8 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 		}
 
 	case SignalLockSession:
-
-		switch state.Mode {
-		case evr.ModeCombatPublic:
-			logger.Debug("Ignoring lock signal for combat public match.")
-		default:
-			logger.Debug("Locking session")
-			state.LockedAt = time.Now().UTC()
-		}
+		// Lock signals are logged but have no effect - matches are locked via round over events
+		logger.Info("Lock signal received (no effect)")
 
 	case SignalUnlockSession:
 
@@ -1290,7 +1298,7 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 		default:
 			logger.Debug("Unlocking session")
 			if state.GameState != nil {
-				state.LockedAt = time.Time{}
+				state.LockedAt = nil
 			}
 			state.Open = true
 		}
@@ -1346,11 +1354,11 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 	switch state.Mode {
 	case evr.ModeArenaPublic:
 		state.GameState = &GameState{
-			RoundClock: NewRoundClock(RoundDuration, time.Now().Add(PublicMatchWaitTime)),
+			SessionScoreboard: NewSessionScoreboard(RoundDuration, time.Now().Add(PublicMatchWaitTime)),
 		}
 	case evr.ModeArenaPrivate:
 		state.GameState = &GameState{
-			RoundClock: NewRoundClock(0, time.Time{}),
+			SessionScoreboard: NewSessionScoreboard(0, time.Time{}),
 		}
 	}
 

--- a/server/evr_match_early_quit.go
+++ b/server/evr_match_early_quit.go
@@ -32,7 +32,7 @@ func PingToBand(ping int) PingBand {
 }
 
 func NewPlayerDisconnectInfo(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, state *MatchLabel, userID string) *PlayerDisconnectInfo {
-	if state == nil || state.GameState == nil || state.GameState.RoundClock == nil {
+	if state == nil || state.GameState == nil || state.GameState.SessionScoreboard == nil {
 		return nil
 	}
 	player := state.GetPlayerByUserID(userID)
@@ -63,8 +63,8 @@ func NewPlayerDisconnectInfo(ctx context.Context, logger runtime.Logger, db *sql
 		PartySize:            partySize,
 		PingBand:             PingToBand(player.PingMillis),
 		JoinTime:             time.Now(),
-		ClockRemainingAtJoin: state.GameState.RoundClock.RemainingTime(),
-		GameDurationAtJoin:   state.GameState.RoundClock.Elapsed(),
+		ClockRemainingAtJoin: state.GameState.SessionScoreboard.RemainingTime(),
+		GameDurationAtJoin:   state.GameState.SessionScoreboard.Elapsed(),
 		ScoresAtJoin:         [2]int{state.GameState.BlueScore, state.GameState.OrangeScore},
 		DisadvantageAtJoin:   state.RoleCount(teamID) - state.RoleCount(otherTeamID),
 		DisconnectsAtJoin:    totalLeaves,
@@ -123,13 +123,13 @@ func (p *PlayerDisconnectInfo) LeaveEvent(state *MatchLabel) {
 	if p == nil {
 		return
 	}
-	if state == nil || state.GameState == nil || state.GameState.RoundClock == nil {
+	if state == nil || state.GameState == nil || state.GameState.SessionScoreboard == nil {
 		return
 	}
 	p.IsAbandoner = !state.GameState.MatchOver
 	p.LeaveTime = time.Now()
-	p.ClockRemainingAtLeave = state.GameState.RoundClock.RemainingTime()
-	p.GameDurationAtLeave = state.GameState.RoundClock.Elapsed()
+	p.ClockRemainingAtLeave = state.GameState.SessionScoreboard.RemainingTime()
+	p.GameDurationAtLeave = state.GameState.SessionScoreboard.Elapsed()
 	p.ScoresAtLeave = [2]int{state.GameState.BlueScore, state.GameState.OrangeScore}
 	p.TeamSizesAtLeave = [2]int{state.RoleCount(0), state.RoleCount(1)}
 
@@ -152,7 +152,7 @@ func (p *PlayerDisconnectInfo) LeaveEvent(state *MatchLabel) {
 }
 
 func (p *PlayerDisconnectInfo) LogEarlyQuitMetrics(nk runtime.NakamaModule, state *MatchLabel) {
-	if state == nil || state.GameState == nil || state.GameState.RoundClock == nil {
+	if state == nil || state.GameState == nil || state.GameState.SessionScoreboard == nil {
 		return
 	}
 

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -503,6 +503,12 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 		}
 	}
 
+	// Get the default region code from the game server
+	var defaultRegion string
+	if l.GameServer != nil && len(l.GameServer.RegionCodes) > 0 {
+		defaultRegion = l.GameServer.RegionCodes[0]
+	}
+
 	v := &MatchLabel{
 		LobbyType:        l.LobbyType,
 		ID:               l.ID,
@@ -522,14 +528,14 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 		PlayerLimit:      l.PlayerLimit,
 		TeamSize:         l.TeamSize,
 		GameServer: &GameServerPresence{
-			OperatorID:  l.GameServer.OperatorID,
-			GroupIDs:    l.GameServer.GroupIDs,
-			VersionLock: l.GameServer.VersionLock,
-			//RegionCodes: l.GameServer.RegionCodes,
-			Tags:        l.GameServer.Tags,
-			Features:    l.GameServer.Features,
-			Region:      l.GameServer.Region,
-			CountryCode: l.GameServer.CountryCode,
+			OperatorID:    l.GameServer.OperatorID,
+			GroupIDs:      l.GameServer.GroupIDs,
+			VersionLock:   l.GameServer.VersionLock,
+			DefaultRegion: defaultRegion,
+			Tags:          l.GameServer.Tags,
+			Features:      l.GameServer.Features,
+			Region:        l.GameServer.Region,
+			CountryCode:   l.GameServer.CountryCode,
 		},
 		Players:  make([]PlayerInfo, 0),
 		RatingMu: l.RatingMu,

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -498,8 +498,8 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 			OrangeScore: l.GameState.OrangeScore,
 			Teams:       l.GameState.Teams,
 		}
-		if l.GameState.RoundClock != nil {
-			gs.RoundClock = l.GameState.RoundClock.LatestAsNewClock()
+		if l.GameState.SessionScoreboard != nil {
+			gs.SessionScoreboard = l.GameState.SessionScoreboard.LatestAsNewScoreboard()
 		}
 	}
 

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -26,7 +26,7 @@ type slotReservation struct {
 type MatchLabel struct {
 	ID          MatchID      `json:"id"`                   // The Session Id used by EVR (the same as match id)
 	Open        bool         `json:"open"`                 // Whether the lobby is open to new players (Matching Only)
-	LockedAt    time.Time    `json:"locked_at,omitempty"`  // The time the match was locked.
+	LockedAt    *time.Time   `json:"locked_at,omitempty"`  // The time the match was locked.
 	LobbyType   LobbyType    `json:"lobby_type"`           // The type of lobby (Public, Private, Unassigned) (EVR)
 	Mode        evr.Symbol   `json:"mode,omitempty"`       // The mode of the lobby (Arena, Combat, Social, etc.) (EVR)
 	Level       evr.Symbol   `json:"level,omitempty"`      // The level to play on (EVR).
@@ -111,7 +111,7 @@ func (s *MatchLabel) IsPublicMatch() bool {
 }
 
 func (s *MatchLabel) IsLocked() bool {
-	if !s.Open || !s.LockedAt.IsZero() {
+	if !s.Open || (s.LockedAt != nil && !s.LockedAt.IsZero()) {
 		return true
 	}
 	return false

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -503,12 +503,6 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 		}
 	}
 
-	// Get the default region code from the game server
-	var defaultRegion string
-	if l.GameServer != nil && len(l.GameServer.RegionCodes) > 0 {
-		defaultRegion = l.GameServer.RegionCodes[0]
-	}
-
 	v := &MatchLabel{
 		LobbyType:        l.LobbyType,
 		ID:               l.ID,
@@ -531,7 +525,7 @@ func (l *MatchLabel) PublicView() *MatchLabel {
 			OperatorID:    l.GameServer.OperatorID,
 			GroupIDs:      l.GameServer.GroupIDs,
 			VersionLock:   l.GameServer.VersionLock,
-			DefaultRegion: defaultRegion,
+			DefaultRegion: l.GameServer.DefaultRegion,
 			Tags:          l.GameServer.Tags,
 			Features:      l.GameServer.Features,
 			Region:        l.GameServer.Region,

--- a/server/evr_match_player.go
+++ b/server/evr_match_player.go
@@ -13,7 +13,7 @@ type PlayerInfo struct {
 	PartyID       string     `json:"party_id,omitempty"`
 	IsReservation bool       `json:"is_reservation,omitempty"`
 	Team          TeamIndex  `json:"team"`
-	JoinTime      int64      `json:"join_time_ms,omitempty"` // The time on the round clock that the player joined
+	JoinTime      int64      `json:"join_time_ns,omitempty"` // The time on the round clock that the player joined
 	RatingMu      float64    `json:"rating_mu,omitempty"`
 	RatingSigma   float64    `json:"rating_sigma,omitempty"`
 	Username      string     `json:"username,omitempty"`

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -198,7 +198,13 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 	// Get the default region from urlparam if specified
 	defaultRegion := params.defaultRegion
 
-	
+	// Validate region codes: no spaces, all lowercase
+	for _, r := range params.serverRegions {
+		validated := strings.ToLower(strings.ReplaceAll(r, " ", ""))
+		if validated != "" {
+			regionCodes = append(regionCodes, validated)
+		}
+	}
 
 	if len(regionCodes) == 0 {
 		regionCodes = append(regionCodes, "default")

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -195,12 +195,14 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 	// Configure the region codes to use for finding the game server
 	regionCodes := make([]string, 0, len(params.serverRegions))
 
-	if len(params.serverRegions) == 0 {
+	// Get the default region from urlparam if specified
+	defaultRegion := params.defaultRegion
+
+	
+
+	if len(regionCodes) == 0 {
 		regionCodes = append(regionCodes, "default")
 	}
-
-	// Add the server regions specified in the config.json
-	regionCodes = append(regionCodes, params.serverRegions...)
 
 	switch regionHash {
 
@@ -235,17 +237,33 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 	if err != nil {
 		logger.Warn("Failed to get IPQS data", zap.Error(err))
 	} else if ipInfo != nil {
+		ipqsRegion := LocationToRegionCode(ipInfo.CountryCode(), ipInfo.Region(), ipInfo.City())
+		ipqsRegionShort := LocationToRegionCode(ipInfo.CountryCode(), ipInfo.Region(), "")
+		ipqsCountry := LocationToRegionCode(ipInfo.CountryCode(), "", "")
+
+		// If default region is not set via urlparam, use IPQS region
+		if defaultRegion == "" {
+			defaultRegion = ipqsRegion
+		}
+
+		// Ensure IPQS-derived region codes are first in the list (after removing duplicates)
 		if slices.Contains(regionCodes, "default") {
-			regionCodes = append(regionCodes,
-				LocationToRegionCode(ipInfo.CountryCode(), ipInfo.Region(), ipInfo.City()),
-				LocationToRegionCode(ipInfo.CountryCode(), ipInfo.Region(), ""),
-				LocationToRegionCode(ipInfo.CountryCode(), "", ""),
-			)
+			// Build new region codes list with IPQS regions first
+			newRegionCodes := []string{ipqsRegion, ipqsRegionShort, ipqsCountry}
+			for _, r := range regionCodes {
+				if r != "default" && !slices.Contains(newRegionCodes, r) {
+					newRegionCodes = append(newRegionCodes, r)
+				}
+			}
+			regionCodes = newRegionCodes
 		}
 	}
 
+	// Validate default region (no spaces, lowercase)
+	defaultRegion = strings.ToLower(strings.ReplaceAll(defaultRegion, " ", ""))
+
 	// Create the broadcaster config
-	config := NewGameServerPresence(session.UserID(), session.id, serverID, internalIP, externalIP, externalPort, hostingGroupIDs, regionCodes, versionLock, params.serverTags, params.supportedFeatures, request.TimeStepUsecs, ipInfo, params.geoHashPrecision, isNative, request.Version)
+	config := NewGameServerPresence(session.UserID(), session.id, serverID, internalIP, externalIP, externalPort, hostingGroupIDs, defaultRegion, regionCodes, versionLock, params.serverTags, params.supportedFeatures, request.TimeStepUsecs, ipInfo, params.geoHashPrecision, isNative, request.Version)
 
 	logger = logger.With(zap.String("internal_ip", internalIP.String()), zap.String("external_ip", externalIP.String()), zap.Uint16("port", externalPort))
 

--- a/server/evr_runtime_rpc.go
+++ b/server/evr_runtime_rpc.go
@@ -1113,9 +1113,9 @@ func AuthenticatePasswordRPC(ctx context.Context, logger runtime.Logger, db *sql
 		// If the user requests intents, they must be a global developer
 		if request.IntentStr != "" {
 			// Check if they have the required intents
-			if isMember, err := CheckGroupMembershipByName(ctx, db, userID, GroupGlobalDevelopers, "system"); err != nil {
+			if isGlobalDeveloper, err := CheckGroupMembershipByName(ctx, db, userID, GroupGlobalDevelopers, "system"); err != nil {
 				return "", err
-			} else if isMember {
+			} else if isGlobalDeveloper {
 				sessionVars.Intents.UnmarshalText([]byte(request.IntentStr))
 			}
 		}

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -38,6 +38,7 @@ type SessionParameters struct {
 	serverTags          []string            // []string of the server tags
 	serverGuilds        []string            // []string of the server guilds
 	serverRegions       []string            // []string of the server regions
+	defaultRegion       string              // The default region code for the server
 	urlParameters       map[string][]string // The URL parameters
 
 	profile                      *EVRProfile                      // The account

--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -190,6 +190,7 @@ func NewSessionWS(logger *zap.Logger, config Config, format SessionFormat, sessi
 		serverTags:           parseUserQueryCommaDelimited(&request, "tags", 32, tagsPattern),
 		serverGuilds:         parseUserQueryCommaDelimited(&request, "guilds", 32, guildPattern),
 		serverRegions:        parseUserQueryCommaDelimited(&request, "regions", 32, regionPattern),
+		defaultRegion:        parseUserQueryFunc(&request, "default_region", 32, regionPattern),
 		relayOutgoing:        parseUserQueryFunc(&request, "verbose", 5, nil) == "true",
 		enableAllRemoteLogs:  parseUserQueryFunc(&request, "debug", 5, nil) == "true",
 		urlParameters:        urlParams,


### PR DESCRIPTION
This pull request introduces several important changes to the game server's session and match management, primarily focused on improving how game time and match locking are handled, as well as refining matchmaking controls. The main highlights are the replacement of the old `RoundClock` with a more flexible `SessionScoreboard`, updates to match locking logic for public matches, and improvements to matchmaking backfill behavior.

**Session and Game State Refactoring:**

- Replaced the `RoundClock` struct with a new `SessionScoreboard` struct, updating all relevant methods and usages to reflect this change (including serialization fields, method names, and logic for paused/elapsed time). This improves clarity and extensibility for session timing and scoreboard management. [[1]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L5-R17) [[2]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L28-R40) [[3]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L54-R68) [[4]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L81-R114) [[5]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L81-R114) [[6]](diffhunk://#diff-ebc9a38b8699392840a79c19c440b7b8bd3a0259cb8bfc76c6eb193443da1e06L81-R114) [[7]](diffhunk://#diff-ced1fb094c538399eb5052cbd464a22cd8139cf10777af5ed4bf87e4e51f83edL62-R62) [[8]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL432-R436) [[9]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL746-R769) [[10]](diffhunk://#diff-a49a0387507dc2cc124f5e9eab1335134d4bf5b93e645dc38657acee9ee3b548L35-R35) [[11]](diffhunk://#diff-a49a0387507dc2cc124f5e9eab1335134d4bf5b93e645dc38657acee9ee3b548L66-R67) [[12]](diffhunk://#diff-a49a0387507dc2cc124f5e9eab1335134d4bf5b93e645dc38657acee9ee3b548L126-R132) [[13]](diffhunk://#diff-a49a0387507dc2cc124f5e9eab1335134d4bf5b93e645dc38657acee9ee3b548L155-R155) [[14]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL1349-R1361) [[15]](diffhunk://#diff-296b78353ad677285c1b3d85d71bb4b8480cdf989e343946d1b9f71bc9866d6dL17-R27)

- Updated the `GameState` struct and related code to use `SessionScoreboard` instead of `RoundClock`, and renamed methods accordingly (e.g., `GetSessionScoreboard`).

**Match Locking and Public Match Handling:**

- Changed match locking logic so that public matches are now locked automatically when the round is over, rather than via explicit lock signals. The `LockedAt` field is now a pointer (`*time.Time`) to better represent unset/zero states, and all related logic has been updated for this change. [[1]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dR737-R754) [[2]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL886-R900) [[3]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL1276-R1291) [[4]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L29-R29) [[5]](diffhunk://#diff-c6d06f22aeb337b00b1045395987a6b29f79a9d195101c8bf8322e4d8bd06dd1L114-R114) [[6]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL1293-R1301)

- Lock signals are now logged but have no effect; matches are locked/unlocked based on round events and scoreboard state.

**Matchmaking and Backfill Improvements:**

- Added a new `ArenaBackfillMaxAgeSecs` setting to `GlobalMatchmakingSettings`, with a default value of 270 seconds. This limits how old an arena match can be to be eligible for backfill, reducing the chance of late, unbalanced joins. [[1]](diffhunk://#diff-625b7f28a0a83941b00a5f8688aea6524d35e90f6aafff52cfdf42567227a3fdR63) [[2]](diffhunk://#diff-625b7f28a0a83941b00a5f8688aea6524d35e90f6aafff52cfdf42567227a3fdR174-R177) [[3]](diffhunk://#diff-173690671d66057a2ee027138ab93af5f28c8cef0d27530cd0121dc1adf21024R406-R414)

- The backfill search query now excludes matches older than the configured max age for arena public matches.

**Game Server Presence Enhancements:**

- Added a `DefaultRegion` field to `GameServerPresence` and updated the constructor to accept this value, improving region tracking for servers. [[1]](diffhunk://#diff-9b087b7125bb3ae39cc09c1030dcfbd67ba7439fade1b29ab5fe80efd77ff43fR27) [[2]](diffhunk://#diff-9b087b7125bb3ae39cc09c1030dcfbd67ba7439fade1b29ab5fe80efd77ff43fL98-R99) [[3]](diffhunk://#diff-9b087b7125bb3ae39cc09c1030dcfbd67ba7439fade1b29ab5fe80efd77ff43fR130)

These changes collectively modernize the handling of session timing, improve match state management, and refine matchmaking behavior for a better player experience.