### PR TITLE
Fix/matchmaker crashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ release: build
 bench-baseline:
 	@echo "Creating benchmark baseline (this takes ~30 seconds)..."
 	@mkdir -p _benchmarks
-	@go test -run='^$$' -bench='BenchmarkPredictOutcomes$$' -benchmem -count=5 ./server/ 2>&1 | \
+	@go test -run='^$$' -bench='BenchmarkPredictOutcomes$$' -benchmem -count=6 ./server/ 2>&1 | \
 		grep -E '^(goos|goarch|pkg|cpu|Benchmark|PASS|ok)' > _benchmarks/predict_outcomes_baseline.txt
 	@echo "Baseline saved to _benchmarks/predict_outcomes_baseline.txt"
 	@$$(go env GOPATH)/bin/benchstat _benchmarks/predict_outcomes_baseline.txt || \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PWD=$(shell pwd)
 
 DEBUG_FLAGS=-trimpath -mod=vendor -gcflags "-trimpath $(PWD)" -gcflags="all=-N -l" -asmflags "-trimpath $(PWD)"
 RELEASE_FLAGS=-trimpath -mod=vendor -gcflags "-trimpath $(PWD)" -asmflags "-trimpath $(PWD)"
-.PHONY: all dev release push
+.PHONY: all dev release push bench-baseline bench-compare bench-check
 
 all: nakama
 
@@ -35,3 +35,20 @@ release: build
 			--build-arg VERSION=$(GIT_DESCRIBE) \
 			-t echotools/nakama:latest . -f build/Dockerfile.local; \
 	fi
+
+# Benchmark targets
+bench-baseline:
+	@echo "Creating benchmark baseline (this takes ~30 seconds)..."
+	@mkdir -p _benchmarks
+	@go test -run='^$$' -bench='BenchmarkPredictOutcomes$$' -benchmem -count=5 ./server/ 2>&1 | \
+		grep -E '^(goos|goarch|pkg|cpu|Benchmark|PASS|ok)' > _benchmarks/predict_outcomes_baseline.txt
+	@echo "Baseline saved to _benchmarks/predict_outcomes_baseline.txt"
+	@$$(go env GOPATH)/bin/benchstat _benchmarks/predict_outcomes_baseline.txt || \
+		(echo "Installing benchstat..." && go install golang.org/x/perf/cmd/benchstat@latest && \
+		$$(go env GOPATH)/bin/benchstat _benchmarks/predict_outcomes_baseline.txt)
+
+bench-compare:
+	@./scripts/bench-compare.sh
+
+bench-check: bench-compare
+	@echo "Benchmark regression check passed"

--- a/_benchmarks/README.md
+++ b/_benchmarks/README.md
@@ -72,7 +72,7 @@ This will fail the build if performance regresses beyond the threshold.
 
 ## Notes
 
-- Benchmarks use `-count=6` for statistical reliability
+- Benchmarks use `-count=5` for statistical reliability
 - Default regression threshold is 10%
 - Results may vary slightly between runs due to system load
 - Compare benchmarks on the same machine for accurate results

--- a/_benchmarks/README.md
+++ b/_benchmarks/README.md
@@ -1,0 +1,78 @@
+# Performance Benchmarks
+
+This directory contains baseline benchmark results for performance regression testing.
+
+## Quick Start
+
+### Check for Performance Regressions
+
+```bash
+make bench-check
+```
+
+This will:
+1. Run the benchmarks (takes ~30-40 seconds)
+2. Compare against the baseline
+3. Fail if performance regresses by more than 10%
+
+### Update Baseline
+
+After making intentional performance improvements:
+
+```bash
+make bench-baseline
+```
+
+### Custom Threshold
+
+To use a different regression threshold (e.g., 5%):
+
+```bash
+./scripts/bench-compare.sh 5
+```
+
+## Current Baseline
+
+**File:** `predict_outcomes_baseline.txt`
+
+**Benchmark:** `BenchmarkPredictOutcomes`
+
+| Metric | Baseline Value |
+|--------|----------------|
+| **Time** | ~6.45 sec/op |
+| **Candidates** | 735,471 |
+| **Predictions** | 1,470,942 |
+| **Memory** | ~2.0 GiB/op |
+| **Allocations** | ~28.7M allocs/op |
+
+## Understanding Results
+
+When you run `make bench-check`, `benchstat` will show:
+
+- `~` = No significant change
+- `+X%` = Performance regression (slower)
+- `-X%` = Performance improvement (faster)
+- `(p=0.xxx n=N)` = Statistical confidence
+
+## CI Integration
+
+Add to your CI pipeline:
+
+```yaml
+- name: Performance Regression Check
+  run: make bench-check
+```
+
+This will fail the build if performance regresses beyond the threshold.
+
+## Files
+
+- `predict_outcomes_baseline.txt` - Baseline for matchmaker prediction benchmarks
+- `README.md` - This file
+
+## Notes
+
+- Benchmarks use `-count=6` for statistical reliability
+- Default regression threshold is 10%
+- Results may vary slightly between runs due to system load
+- Compare benchmarks on the same machine for accurate results

--- a/_benchmarks/predict_outcomes_baseline.txt
+++ b/_benchmarks/predict_outcomes_baseline.txt
@@ -1,0 +1,11 @@
+goos: linux
+goarch: amd64
+pkg: github.com/heroiclabs/nakama/v3/server
+cpu: AMD Ryzen 9 5950X 16-Core Processor            
+BenchmarkPredictOutcomes-32    	       1	6567758386 ns/op	    735471 candidates	   1470942 predictions	2156336856 B/op	28685526 allocs/op
+BenchmarkPredictOutcomes-32    	       1	6448382986 ns/op	    735471 candidates	   1470942 predictions	2156330936 B/op	28685518 allocs/op
+BenchmarkPredictOutcomes-32    	       1	6483013616 ns/op	    735471 candidates	   1470942 predictions	2156331256 B/op	28685519 allocs/op
+BenchmarkPredictOutcomes-32    	       1	6383245779 ns/op	    735471 candidates	   1470942 predictions	2156330216 B/op	28685509 allocs/op
+BenchmarkPredictOutcomes-32    	       1	6438625639 ns/op	    735471 candidates	   1470942 predictions	2156330040 B/op	28685510 allocs/op
+PASS
+ok  	github.com/heroiclabs/nakama/v3/server	32.766s

--- a/scripts/bench-compare.sh
+++ b/scripts/bench-compare.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Script to compare benchmark results against baseline and detect regressions
+# Usage: ./scripts/bench-compare.sh [threshold_percent]
+
+set -e
+
+THRESHOLD=${1:-10}  # Default to 10% regression threshold
+BASELINE_FILE="_benchmarks/predict_outcomes_baseline.txt"
+NEW_BENCH_FILE="/tmp/bench_new_$$.txt"
+BENCHSTAT=$(go env GOPATH)/bin/benchstat
+
+# Check if benchstat is installed
+if [ ! -f "$BENCHSTAT" ]; then
+    echo "Installing benchstat..."
+    go install golang.org/x/perf/cmd/benchstat@latest
+fi
+
+# Check if baseline exists
+if [ ! -f "$BASELINE_FILE" ]; then
+    echo "ERROR: Baseline file not found: $BASELINE_FILE"
+    echo "Run 'make bench-baseline' to create one"
+    exit 1
+fi
+
+echo "Running benchmarks (this may take a while)..."
+go test -run='^$' -bench='BenchmarkPredictOutcomes$' -benchmem -count=6 ./server/ 2>&1 | \
+  grep -E '^(goos|goarch|pkg|cpu|Benchmark|PASS|ok)' > "$NEW_BENCH_FILE"
+
+echo ""
+echo "Comparing against baseline..."
+echo "Regression threshold: ${THRESHOLD}%"
+echo "================================================"
+
+# Run benchstat and capture output
+COMPARISON=$("$BENCHSTAT" "$BASELINE_FILE" "$NEW_BENCH_FILE")
+echo "$COMPARISON"
+
+# Parse for regressions in time (sec/op)
+REGRESSION=$(echo "$COMPARISON" | grep -A1 "sec/op" | grep "PredictOutcomes" | awk '{print $4}')
+
+if [ -n "$REGRESSION" ]; then
+    # Extract percentage if present (e.g., "+12.5%")
+    if [[ "$REGRESSION" =~ \+([0-9.]+)% ]]; then
+        PERCENT="${BASH_REMATCH[1]}"
+        # Use bc for floating point comparison
+        if (( $(echo "$PERCENT > $THRESHOLD" | bc -l) )); then
+            echo ""
+            echo "❌ PERFORMANCE REGRESSION DETECTED: +${PERCENT}%"
+            echo "   This exceeds the threshold of ${THRESHOLD}%"
+            rm -f "$NEW_BENCH_FILE"
+            exit 1
+        else
+            echo ""
+            echo "✅ Performance change within acceptable threshold: +${PERCENT}% (limit: ${THRESHOLD}%)"
+        fi
+    elif [[ "$REGRESSION" =~ -([0-9.]+)% ]]; then
+        echo ""
+        echo "✅ Performance IMPROVED: ${REGRESSION}"
+    else
+        echo ""
+        echo "✅ No significant performance change detected"
+    fi
+else
+    echo ""
+    echo "✅ No significant performance change detected"
+fi
+
+rm -f "$NEW_BENCH_FILE"
+exit 0

--- a/server/evr_matchmaker_balance_test.go
+++ b/server/evr_matchmaker_balance_test.go
@@ -143,7 +143,7 @@ func TestCharacterizationTeamFormation_SequentialFilling(t *testing.T) {
 
 			// Process through prediction
 			var result PredictedMatch
-			for p := range predictCandidateOutcomes(candidates) {
+			for p := range predictCandidateOutcomesWithConfig(candidates, defaultPredictionConfig()) {
 				result = p
 			}
 
@@ -161,7 +161,7 @@ func TestCharacterizationTeamFormation_SequentialFilling(t *testing.T) {
 			t.Logf("Description: %s", tt.description)
 			t.Logf("Team A strength: %.1f (players: %v)", strengthA, getPlayerMus(teamA))
 			t.Logf("Team B strength: %.1f (players: %v)", strengthB, getPlayerMus(teamB))
-			t.Logf("Draw probability: %.3f", result.Draw)
+			t.Logf("Draw probability: %.3f", result.DrawProb)
 
 			// Calculate imbalance ratio
 			totalStrength := strengthA + strengthB
@@ -216,7 +216,7 @@ func TestCharacterizationTeamFormation_PartiesKeptTogether(t *testing.T) {
 	candidates := [][]runtime.MatchmakerEntry{entries}
 
 	var result PredictedMatch
-	for p := range predictCandidateOutcomes(candidates) {
+	for p := range predictCandidateOutcomesWithConfig(candidates, defaultPredictionConfig()) {
 		result = p
 	}
 
@@ -300,8 +300,8 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 		{
 			name: "Larger match wins",
 			predictions: []PredictedMatch{
-				{Candidate: candidateA, Size: 8, Draw: 0.5, OldestTicketTimestamp: 100},
-				{Candidate: candidateB, Size: 6, Draw: 0.6, OldestTicketTimestamp: 100}, // Smaller
+				{Candidate: candidateA, Size: 8, DrawProb: 0.5, OldestTicketTimestamp: 100},
+				{Candidate: candidateB, Size: 6, DrawProb: 0.6, OldestTicketTimestamp: 100}, // Smaller
 			},
 			wantFirst: 0,
 			reason:    "Size takes priority",
@@ -309,8 +309,8 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 		{
 			name: "Older ticket wins when same size",
 			predictions: []PredictedMatch{
-				{Candidate: candidateA, Size: 8, Draw: 0.5, OldestTicketTimestamp: 200},
-				{Candidate: candidateB, Size: 8, Draw: 0.5, OldestTicketTimestamp: 100}, // Older
+				{Candidate: candidateA, Size: 8, DrawProb: 0.5, OldestTicketTimestamp: 200},
+				{Candidate: candidateB, Size: 8, DrawProb: 0.5, OldestTicketTimestamp: 100}, // Older
 			},
 			wantFirst: 1,
 			reason:    "Older ticket timestamp has priority",
@@ -318,8 +318,8 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 		{
 			name: "Fewer divisions wins when same size and age",
 			predictions: []PredictedMatch{
-				{Candidate: candidateA, Size: 8, Draw: 0.5, OldestTicketTimestamp: 100, DivisionCount: 3},
-				{Candidate: candidateB, Size: 8, Draw: 0.5, OldestTicketTimestamp: 100, DivisionCount: 2}, // Fewer divisions
+				{Candidate: candidateA, Size: 8, DrawProb: 0.5, OldestTicketTimestamp: 100, DivisionCount: 3},
+				{Candidate: candidateB, Size: 8, DrawProb: 0.5, OldestTicketTimestamp: 100, DivisionCount: 2}, // Fewer divisions
 			},
 			wantFirst: 1,
 			reason:    "Fewer divisions preferred for balanced matches",
@@ -327,8 +327,8 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 		{
 			name: "Higher draw probability wins as final tiebreaker",
 			predictions: []PredictedMatch{
-				{Candidate: candidateA, Size: 8, Draw: 0.4, OldestTicketTimestamp: 100, DivisionCount: 2},
-				{Candidate: candidateB, Size: 8, Draw: 0.6, OldestTicketTimestamp: 100, DivisionCount: 2}, // Higher draw
+				{Candidate: candidateA, Size: 8, DrawProb: 0.4, OldestTicketTimestamp: 100, DivisionCount: 2},
+				{Candidate: candidateB, Size: 8, DrawProb: 0.6, OldestTicketTimestamp: 100, DivisionCount: 2}, // Higher draw
 			},
 			wantFirst: 1,
 			reason:    "Higher draw probability means more balanced match",
@@ -350,7 +350,7 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 				if tt.predictions[i].DivisionCount != tt.predictions[j].DivisionCount {
 					return tt.predictions[i].DivisionCount < tt.predictions[j].DivisionCount
 				}
-				return tt.predictions[i].Draw > tt.predictions[j].Draw
+				return tt.predictions[i].DrawProb > tt.predictions[j].DrawProb
 			})
 
 			matches := m.assembleUniqueMatches(tt.predictions)
@@ -366,7 +366,7 @@ func TestCharacterizationAssembleUniqueMatches(t *testing.T) {
 
 			t.Logf("Reason for selection: %s", tt.reason)
 			t.Logf("First match size=%d, draw=%.2f, age=%d, divisions=%d",
-				tt.predictions[0].Size, tt.predictions[0].Draw,
+				tt.predictions[0].Size, tt.predictions[0].DrawProb,
 				tt.predictions[0].OldestTicketTimestamp, tt.predictions[0].DivisionCount)
 		})
 	}
@@ -437,12 +437,12 @@ func TestBalancedTeamFormation_SnakeDraft(t *testing.T) {
 	t.Logf("Sequential filling:")
 	t.Logf("  Team A: %v = %.1f", getPlayerMus(seqTeamA), seqStrengthA)
 	t.Logf("  Team B: %v = %.1f", getPlayerMus(seqTeamB), seqStrengthB)
-	t.Logf("  Imbalance: %.2f%%, Draw: %.3f", seqImbalance, sequentialResult.Draw)
+	t.Logf("  Imbalance: %.2f%%, Draw: %.3f", seqImbalance, sequentialResult.DrawProb)
 
 	t.Logf("Snake draft:")
 	t.Logf("  Team A: %v = %.1f", getPlayerMus(snakeTeamA), snakeStrengthA)
 	t.Logf("  Team B: %v = %.1f", getPlayerMus(snakeTeamB), snakeStrengthB)
-	t.Logf("  Imbalance: %.2f%%, Draw: %.3f", snakeImbalance, snakeDraftResult.Draw)
+	t.Logf("  Imbalance: %.2f%%, Draw: %.3f", snakeImbalance, snakeDraftResult.DrawProb)
 
 	// Snake draft should produce more balanced teams (lower imbalance)
 	if snakeImbalance >= seqImbalance {
@@ -451,9 +451,9 @@ func TestBalancedTeamFormation_SnakeDraft(t *testing.T) {
 	}
 
 	// Snake draft should have higher draw probability
-	if snakeDraftResult.Draw <= sequentialResult.Draw {
+	if snakeDraftResult.DrawProb <= sequentialResult.DrawProb {
 		t.Errorf("Snake draft should have higher draw probability (snake=%.3f vs seq=%.3f)",
-			snakeDraftResult.Draw, sequentialResult.Draw)
+			snakeDraftResult.DrawProb, sequentialResult.DrawProb)
 	}
 }
 
@@ -463,8 +463,8 @@ func TestPartySkillBoost(t *testing.T) {
 
 	// Solo player
 	solo := MatchmakerEntries{createTestEntry("t1", "p1", 20.0, 3.0)}
-	soloRatings := solo.Ratings()
-	soloRatingsWithBoost := solo.RatingsWithPartyBoost(0.10)
+	soloRatings := solo.Ratings(nil)
+	soloRatingsWithBoost := solo.RatingsWithPartyBoost(0.10, nil)
 
 	// Solo should NOT get boost
 	if soloRatings[0].Mu != soloRatingsWithBoost[0].Mu {
@@ -485,8 +485,8 @@ func TestPartySkillBoost(t *testing.T) {
 		partyEntries = append(partyEntries, e)
 	}
 
-	partyRatings := partyEntries.Ratings()
-	partyRatingsWithBoost := partyEntries.RatingsWithPartyBoost(0.10)
+	partyRatings := partyEntries.Ratings(nil)
+	partyRatingsWithBoost := partyEntries.RatingsWithPartyBoost(0.10, nil)
 
 	// Party SHOULD get 10% boost
 	expectedBoostedMu1 := 20.0 * 1.10
@@ -613,7 +613,7 @@ func TestVariantSelection_SharedPlayers(t *testing.T) {
 		}
 
 		t.Logf("Prediction %d [%s]: Draw=%.3f, Imbalance=%.2f%%, Size=%d",
-			i, variantName, p.Draw, imbalance, p.Size)
+			i, variantName, p.DrawProb, imbalance, p.Size)
 		t.Logf("  Team A: %v = %.1f", getPlayerMus(teamA), strengthA)
 		t.Logf("  Team B: %v = %.1f", getPlayerMus(teamB), strengthB)
 	}
@@ -632,7 +632,7 @@ func TestVariantSelection_SharedPlayers(t *testing.T) {
 		if predictions[i].DivisionCount != predictions[j].DivisionCount {
 			return predictions[i].DivisionCount < predictions[j].DivisionCount
 		}
-		return predictions[i].Draw > predictions[j].Draw
+		return predictions[i].DrawProb > predictions[j].DrawProb
 	})
 
 	matches := m.assembleUniqueMatches(predictions)
@@ -678,7 +678,7 @@ func BenchmarkTeamFormation(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for range predictCandidateOutcomes(candidates) {
+		for range predictCandidateOutcomesWithConfig(candidates, defaultPredictionConfig()) {
 			// consume
 		}
 	}

--- a/server/evr_matchmaker_balance_test.go
+++ b/server/evr_matchmaker_balance_test.go
@@ -400,7 +400,8 @@ func TestBalancedTeamFormation_SnakeDraft(t *testing.T) {
 
 	var sequentialResult PredictedMatch
 	for p := range predictCandidateOutcomesWithConfig(seqCandidates, PredictionConfig{
-		Variants: []RosterVariant{RosterVariantSequential},
+		Variants:         []RosterVariant{RosterVariantSequential},
+		OpenSkillOptions: &types.OpenSkillOptions{},
 	}) {
 		sequentialResult = p
 	}
@@ -416,7 +417,8 @@ func TestBalancedTeamFormation_SnakeDraft(t *testing.T) {
 
 	var snakeDraftResult PredictedMatch
 	for p := range predictCandidateOutcomesWithConfig(snakeCandidates, PredictionConfig{
-		Variants: []RosterVariant{RosterVariantSnakeDraft},
+		Variants:         []RosterVariant{RosterVariantSnakeDraft},
+		OpenSkillOptions: &types.OpenSkillOptions{},
 	}) {
 		snakeDraftResult = p
 	}
@@ -588,6 +590,7 @@ func TestVariantSelection_SharedPlayers(t *testing.T) {
 	predictions := []PredictedMatch{}
 	for p := range predictCandidateOutcomesWithConfig(candidates, PredictionConfig{
 		EnableRosterVariants: true,
+		OpenSkillOptions:     &types.OpenSkillOptions{},
 	}) {
 		predictions = append(predictions, p)
 	}

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -45,6 +45,15 @@ func (g MatchmakerEntries) Len() int {
 }
 
 func (g MatchmakerEntries) Ratings(opts *types.OpenSkillOptions) []types.Rating {
+	// Use default rating if opts is nil
+	if opts == nil {
+		defaultRating := NewDefaultRating()
+		opts = &types.OpenSkillOptions{
+			Mu:    &defaultRating.Mu,
+			Sigma: &defaultRating.Sigma,
+			Z:     &defaultRating.Z,
+		}
+	}
 	ratings := make([]types.Rating, len(g))
 	for i, e := range g {
 		props := e.GetProperties()
@@ -67,6 +76,15 @@ func (g MatchmakerEntries) Ratings(opts *types.OpenSkillOptions) []types.Rating 
 
 // RatingsInto fills the provided ratings slice with no allocations
 func (g MatchmakerEntries) RatingsInto(ratings []types.Rating, opts *types.OpenSkillOptions) {
+	// Use default rating if opts is nil
+	if opts == nil {
+		defaultRating := NewDefaultRating()
+		opts = &types.OpenSkillOptions{
+			Mu:    &defaultRating.Mu,
+			Sigma: &defaultRating.Sigma,
+			Z:     &defaultRating.Z,
+		}
+	}
 	for i, e := range g {
 		props := e.GetProperties()
 		mu, ok := props["rating_mu"].(float64)
@@ -87,6 +105,15 @@ func (g MatchmakerEntries) RatingsInto(ratings []types.Rating, opts *types.OpenS
 
 // RatingsWithPartyBoost returns ratings with an optional boost for parties (groups with multiple members)
 func (g MatchmakerEntries) RatingsWithPartyBoost(boostPercent float64, opts *types.OpenSkillOptions) []types.Rating {
+	// Use default rating if opts is nil
+	if opts == nil {
+		defaultRating := NewDefaultRating()
+		opts = &types.OpenSkillOptions{
+			Mu:    &defaultRating.Mu,
+			Sigma: &defaultRating.Sigma,
+			Z:     &defaultRating.Z,
+		}
+	}
 	ratings := make([]types.Rating, len(g))
 	isParty := len(g) > 1
 	for i, e := range g {

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -26,6 +26,7 @@ type PredictionConfig struct {
 	EnableRosterVariants   bool            // Generate multiple roster variants for better match selection
 	UseSnakeDraftFormation bool            // Use snake draft instead of sequential filling
 	Variants               []RosterVariant // Pre-computed list of variants to generate (if set, overrides other variant settings)
+	DefaultRating          types.Rating    // Default rating to use if none found
 }
 
 type PredictedMatch struct {
@@ -47,11 +48,32 @@ func (g MatchmakerEntries) Ratings() []types.Rating {
 	ratings := make([]types.Rating, len(g))
 	for i, e := range g {
 		props := e.GetProperties()
-		mu := props["rating_mu"].(float64)
+		mu, ok := props["rating_mu"].(float64)
+		if !ok {
+			mu = 10.0
+		}
 		sigma := props["rating_sigma"].(float64)
+		if !ok {
+			sigma = 10.0 / 3.0
+		}
 		ratings[i] = NewRating(0, mu, sigma)
 	}
 	return ratings
+}
+
+// Return the rating at a given index
+func (g MatchmakerEntries) RatingAt(index int) types.Rating {
+	e := g[index]
+	props := e.GetProperties()
+	mu, ok := props["rating_mu"].(float64)
+	if !ok {
+		return types.Rating{}
+	}
+	sigma, ok := props["rating_sigma"].(float64)
+	if !ok {
+		return types.Rating{}
+	}
+	return NewRating(0, mu, sigma)
 }
 
 // RatingsWithPartyBoost returns ratings with an optional boost for parties (groups with multiple members)
@@ -60,8 +82,14 @@ func (g MatchmakerEntries) RatingsWithPartyBoost(boostPercent float64) []types.R
 	isParty := len(g) > 1
 	for i, e := range g {
 		props := e.GetProperties()
-		mu := props["rating_mu"].(float64)
-		sigma := props["rating_sigma"].(float64)
+		mu, ok := props["rating_mu"].(float64)
+		if !ok {
+			mu = 10.0
+		}
+		sigma, ok := props["rating_sigma"].(float64)
+		if !ok {
+			sigma = 10.0 / 3.0
+		}
 		// Apply party boost to Mu for rank prediction purposes
 		if isParty && boostPercent > 0 {
 			mu = mu * (1 + boostPercent)
@@ -97,14 +125,6 @@ func (g MatchmakerEntries) TeamOrdinal() float64 {
 	return rating.TeamOrdinal(g.TeamRating())
 }
 
-func (g MatchmakerEntries) Strength() float64 {
-	var strength float64
-	for _, e := range g {
-		strength += e.GetProperties()["rating_mu"].(float64)
-	}
-	return strength
-}
-
 func HashMatchmakerEntries[E runtime.MatchmakerEntry](entries []E) uint64 {
 
 	// Sort entries based on their ticket strings directly.
@@ -131,24 +151,29 @@ func predictCandidateOutcomes(candidates [][]runtime.MatchmakerEntry) <-chan Pre
 		config.PartyBoostPercent = settings.Matchmaking.PartySkillBoostPercent
 		config.EnableRosterVariants = settings.Matchmaking.EnableRosterVariants
 		config.UseSnakeDraftFormation = settings.Matchmaking.UseSnakeDraftTeamFormation
+		config.DefaultRating = types.Rating{
+			Mu:    settings.SkillRating.Defaults.Mu,
+			Sigma: settings.SkillRating.Defaults.Sigma,
+			Z:     settings.SkillRating.Defaults.Z,
+		}
 	}
 
 	return predictCandidateOutcomesWithConfig(candidates, config)
 }
 
 // predictCandidateOutcomesWithConfig allows testing with specific settings
-func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, config PredictionConfig) <-chan PredictedMatch {
+func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, cfg PredictionConfig) <-chan PredictedMatch {
 	// Generate roster variants based on config if not already specified
-	variants := config.Variants
+	variants := cfg.Variants
 	if len(variants) == 0 {
-		if config.UseSnakeDraftFormation {
+		if cfg.UseSnakeDraftFormation {
 			variants = append(variants, RosterVariantSnakeDraft)
 		} else {
 			variants = append(variants, RosterVariantSequential)
 		}
 		// If roster variants are enabled, generate both types
-		if config.EnableRosterVariants {
-			if config.UseSnakeDraftFormation {
+		if cfg.EnableRosterVariants {
+			if cfg.UseSnakeDraftFormation {
 				variants = append(variants, RosterVariantSequential)
 			} else {
 				variants = append(variants, RosterVariantSnakeDraft)
@@ -156,69 +181,69 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 		}
 	}
 
-	predictCh := make(chan PredictedMatch)
+	out := make(chan PredictedMatch)
 
 	go func() {
-		defer close(predictCh)
+		defer close(out)
 		// Count valid candidates
-		validCandidates := 0
-		for _, c := range candidates {
-			if c != nil {
-				validCandidates++
+		validCount := 0
+		for _, candidate := range candidates {
+			if candidate != nil {
+				validCount++
 			}
 		}
 
 		var (
-			candidateHashSet    = make(map[uint64]struct{}, validCandidates)
-			ratingsByGroup      = make([]types.Team, 0, 10)
-			candidateTickets    = make(map[string]MatchmakerEntries, 10)
-			groups              = make([]MatchmakerEntries, 0, 10)
-			teamA               = make(MatchmakerEntries, 0, 10)
-			teamB               = make(MatchmakerEntries, 0, 10)
-			teamRatingsA        = make([]types.Rating, 0, 5)
-			teamRatingsB        = make([]types.Rating, 0, 5)
-			actualTeamRatingsA  = make([]types.Rating, 0, 5)
-			actualTeamRatingsB  = make([]types.Rating, 0, 5)
-			ratingsByTicket     = make(map[string]types.Team, 40)
-			divisionSetByTicket = make(map[string]map[string]struct{}, 40)
-			ageByTicket         = make(map[string]float64, 40)
-			divisionSet         = make(map[string]struct{}, 10)
+			seen          = make(map[uint64]struct{}, validCount)
+			groupRatings  = make([]types.Team, 0, 10)
+			ticketGroups  = make(map[string]MatchmakerEntries, 10)
+			groups        = make([]MatchmakerEntries, 0, 10)
+			blueTeam      = make(MatchmakerEntries, 0, 10)
+			orangeTeam    = make(MatchmakerEntries, 0, 10)
+			blueRatings   = make([]types.Rating, 0, 5)
+			orangeRatings = make([]types.Rating, 0, 5)
+			blueActual    = make([]types.Rating, 0, 5)
+			orangeActual  = make([]types.Rating, 0, 5)
+			ticketRatings = make(map[string]types.Team, 40)
+			ticketDivs    = make(map[string]map[string]struct{}, 40)
+			ticketAge     = make(map[string]float64, 40)
+			divs          = make(map[string]struct{}, 10)
 		)
 
-		for _, c := range candidates {
-			if c == nil {
+		for _, candidate := range candidates {
+			if candidate == nil {
 				continue
 			}
 
 			// Skip duplicate candidates
-			hash := HashMatchmakerEntries(c)
-			if _, found := candidateHashSet[hash]; found {
+			h := HashMatchmakerEntries(candidate)
+			if _, ok := seen[h]; ok {
 				continue
 			}
-			candidateHashSet[hash] = struct{}{}
+			seen[h] = struct{}{}
 
-			// Clear candidateTickets map
-			for k := range candidateTickets {
-				delete(candidateTickets, k)
+			// Clear ticketGroups map
+			for k := range ticketGroups {
+				delete(ticketGroups, k)
 			}
 
 			// Collect tickets efficiently - group entries by ticket
-			for _, e := range c {
-				ticket := e.GetTicket()
-				candidateTickets[ticket] = append(candidateTickets[ticket], e)
+			for _, entry := range candidate {
+				ticket := entry.GetTicket()
+				ticketGroups[ticket] = append(ticketGroups[ticket], entry)
 			}
 
 			// Skip if no groups formed
-			if len(candidateTickets) == 0 {
+			if len(ticketGroups) == 0 {
 				continue
 			}
 
-			for ticket, entries := range candidateTickets {
+			for ticket, entries := range ticketGroups {
 				// Check cache to avoid recomputing identical tickets
-				if _, ok := ratingsByTicket[ticket]; !ok {
+				if _, ok := ticketRatings[ticket]; !ok {
 					// Use boosted ratings for parties when calculating ranks
-					ratingsByTicket[ticket] = entries.RatingsWithPartyBoost(config.PartyBoostPercent)
-					divisionSetByTicket[ticket] = entries.DivisionSet()
+					ticketRatings[ticket] = entries.RatingsWithPartyBoost(cfg.PartyBoostPercent)
+					ticketDivs[ticket] = entries.DivisionSet()
 				}
 				oldest := float64(time.Now().UTC().Unix())
 				for _, entry := range entries {
@@ -227,21 +252,21 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 						oldest = st
 					}
 				}
-				ageByTicket[ticket] = oldest
+				ticketAge[ticket] = oldest
 			}
 
 			// Reuse groups slice
 			groups = groups[:0]
-			for _, entries := range candidateTickets {
+			for _, entries := range ticketGroups {
 				groups = append(groups, entries)
 			}
 
-			ratingsByGroup = ratingsByGroup[:0]
-			for _, entries := range groups {
-				ratingsByGroup = append(ratingsByGroup, ratingsByTicket[entries[0].GetTicket()])
+			groupRatings = groupRatings[:0]
+			for _, g := range groups {
+				groupRatings = append(groupRatings, ticketRatings[g[0].GetTicket()])
 			}
 
-			ranks, _ := rating.PredictRank(ratingsByGroup, nil)
+			ranks, _ := rating.PredictRank(groupRatings, nil)
 
 			// Sort groups by best rating first
 			sort.SliceStable(groups, func(i, j int) bool {
@@ -249,32 +274,32 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 			})
 
 			// Collect division set - reuse map from cache
-			for k := range divisionSet {
-				delete(divisionSet, k)
+			for k := range divs {
+				delete(divs, k)
 			}
-			for _, entries := range groups {
-				ticket := entries[0].GetTicket()
-				maps.Copy(divisionSet, divisionSetByTicket[ticket])
+			for _, g := range groups {
+				ticket := g[0].GetTicket()
+				maps.Copy(divs, ticketDivs[ticket])
 			}
 
-			teamSize := len(c) / 2
+			teamSize := len(candidate) / 2
 
 			for _, variant := range variants {
 				// Create teams based on variant
-				teamA, teamB = teamA[:0], teamB[:0]
-				teamRatingsA, teamRatingsB = teamRatingsA[:0], teamRatingsB[:0]
+				blueTeam, orangeTeam = blueTeam[:0], orangeTeam[:0]
+				blueRatings, orangeRatings = blueRatings[:0], orangeRatings[:0]
 
 				switch variant {
 				case RosterVariantSequential:
-					// Original sequential filling (best groups fill Team A first)
-					for _, entries := range groups {
-						ticket := entries[0].GetTicket()
-						if len(teamA)+len(entries) <= teamSize {
-							teamA = append(teamA, entries...)
-							teamRatingsA = append(teamRatingsA, ratingsByTicket[ticket]...)
+					// Original sequential filling (best groups fill blue team first)
+					for _, g := range groups {
+						ticket := g[0].GetTicket()
+						if len(blueTeam)+len(g) <= teamSize {
+							blueTeam = append(blueTeam, g...)
+							blueRatings = append(blueRatings, ticketRatings[ticket]...)
 						} else {
-							teamB = append(teamB, entries...)
-							teamRatingsB = append(teamRatingsB, ratingsByTicket[ticket]...)
+							orangeTeam = append(orangeTeam, g...)
+							orangeRatings = append(orangeRatings, ticketRatings[ticket]...)
 						}
 					}
 
@@ -283,80 +308,93 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 					// Pattern for 8 picks: A, B, B, A, A, B, B, A (creates balance by giving
 					// the weaker team consecutive picks)
 					// For groups sorted by rank (best first):
-					// - 1st (best) → A
-					// - 2nd, 3rd → B
-					// - 4th, 5th → A
-					// - 6th, 7th → B
-					// - 8th → A
-					for groupIndex, entries := range groups {
-						ticket := entries[0].GetTicket()
+					// - 1st (best) → Blue
+					// - 2nd, 3rd → Orange
+					// - 4th, 5th → Blue
+					// - 6th, 7th → Orange
+					// - 8th → Blue
+					for idx, g := range groups {
+						ticket := g[0].GetTicket()
 
 						// Determine which team gets this group using snake pattern
-						// Group index 0: A, 1-2: B, 3-4: A, 5-6: B, 7: A
+						// Group index 0: Blue, 1-2: Orange, 3-4: Blue, 5-6: Orange, 7: Blue
 						// General snake draft assignment for any group size
 						// For two teams: alternate direction every round of 2 picks
 						roundSize := 2
-						round := groupIndex / roundSize
-						posInRound := groupIndex % roundSize
-						var assignToA bool
+						round := idx / roundSize
+						pos := idx % roundSize
+						var assignToBlue bool
 						if round%2 == 0 {
-							assignToA = (posInRound == 0)
+							assignToBlue = (pos == 0)
 						} else {
-							assignToA = (posInRound == 1)
+							assignToBlue = (pos == 1)
 						}
 
 						// Check if assignment would exceed team size, flip if needed
-						if assignToA && len(teamA)+len(entries) > teamSize {
-							assignToA = false
-						} else if !assignToA && len(teamB)+len(entries) > teamSize {
-							assignToA = true
+						if assignToBlue && len(blueTeam)+len(g) > teamSize {
+							assignToBlue = false
+						} else if !assignToBlue && len(orangeTeam)+len(g) > teamSize {
+							assignToBlue = true
 						}
 
-						if assignToA {
-							teamA = append(teamA, entries...)
-							teamRatingsA = append(teamRatingsA, ratingsByTicket[ticket]...)
+						if assignToBlue {
+							blueTeam = append(blueTeam, g...)
+							blueRatings = append(blueRatings, ticketRatings[ticket]...)
 						} else {
-							teamB = append(teamB, entries...)
-							teamRatingsB = append(teamRatingsB, ratingsByTicket[ticket]...)
+							orangeTeam = append(orangeTeam, g...)
+							orangeRatings = append(orangeRatings, ticketRatings[ticket]...)
 						}
 					}
 				}
 
-				if len(teamA) != len(teamB) {
+				if len(blueTeam) != len(orangeTeam) {
 					continue
 				}
 
 				// Create a copy of the candidate slice for this variant
-				variantCandidate := make([]runtime.MatchmakerEntry, len(c))
-				copy(variantCandidate[:len(teamA)], teamA)
-				copy(variantCandidate[len(teamA):], teamB)
+				match := make([]runtime.MatchmakerEntry, len(candidate))
+				copy(match[:len(blueTeam)], blueTeam)
+				copy(match[len(blueTeam):], orangeTeam)
 
 				// Get actual (non-boosted) ratings for draw probability calculation - reuse slices
-				actualTeamRatingsA = actualTeamRatingsA[:0]
-				actualTeamRatingsB = actualTeamRatingsB[:0]
-				for _, e := range teamA {
-					props := e.GetProperties()
-					mu := props["rating_mu"].(float64)
-					sigma := props["rating_sigma"].(float64)
-					actualTeamRatingsA = append(actualTeamRatingsA, NewRating(0, mu, sigma))
+				blueActual = blueActual[:0]
+				orangeActual = orangeActual[:0]
+
+				for _, entry := range blueTeam {
+					props := entry.GetProperties()
+					mu, ok := props["rating_mu"].(float64)
+					if !ok {
+						mu = cfg.DefaultRating.Mu
+					}
+					sigma, ok := props["rating_sigma"].(float64)
+					if !ok {
+						sigma = cfg.DefaultRating.Sigma
+					}
+					blueActual = append(blueActual, NewRating(0, mu, sigma))
 				}
-				for _, e := range teamB {
-					props := e.GetProperties()
-					mu := props["rating_mu"].(float64)
-					sigma := props["rating_sigma"].(float64)
-					actualTeamRatingsB = append(actualTeamRatingsB, NewRating(0, mu, sigma))
+				for _, entry := range orangeTeam {
+					props := entry.GetProperties()
+					mu, ok := props["rating_mu"].(float64)
+					if !ok {
+						mu = cfg.DefaultRating.Mu
+					}
+					sigma, ok := props["rating_sigma"].(float64)
+					if !ok {
+						sigma = cfg.DefaultRating.Sigma
+					}
+					orangeActual = append(orangeActual, NewRating(0, mu, sigma))
 				}
 
-				predictCh <- PredictedMatch{
-					Candidate:             variantCandidate,
-					Draw:                  float32(rating.PredictDraw([]types.Team{actualTeamRatingsA, actualTeamRatingsB}, nil)),
-					Size:                  int8(len(variantCandidate)),
-					DivisionCount:         int8(len(divisionSet)),
-					OldestTicketTimestamp: int64(ageByTicket[variantCandidate[0].GetTicket()]),
+				out <- PredictedMatch{
+					Candidate:             match,
+					Draw:                  float32(rating.PredictDraw([]types.Team{blueActual, orangeActual}, nil)),
+					Size:                  int8(len(match)),
+					DivisionCount:         int8(len(divs)),
+					OldestTicketTimestamp: int64(ticketAge[match[0].GetTicket()]),
 					Variant:               variant,
 				}
 			}
 		}
 	}()
-	return predictCh
+	return out
 }

--- a/server/evr_matchmaker_prediction_test.go
+++ b/server/evr_matchmaker_prediction_test.go
@@ -475,6 +475,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig(b *testing.B) {
 				PartyBoostPercent:      0.0,
 				EnableRosterVariants:   false,
 				UseSnakeDraftFormation: false,
+				OpenSkillOptions:       &types.OpenSkillOptions{},
 			},
 		},
 		{
@@ -483,6 +484,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig(b *testing.B) {
 				PartyBoostPercent:      0.0,
 				EnableRosterVariants:   false,
 				UseSnakeDraftFormation: true,
+				OpenSkillOptions:       &types.OpenSkillOptions{},
 			},
 		},
 		{
@@ -491,6 +493,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig(b *testing.B) {
 				PartyBoostPercent:      0.0,
 				EnableRosterVariants:   true,
 				UseSnakeDraftFormation: false,
+				OpenSkillOptions:       &types.OpenSkillOptions{},
 			},
 		},
 		{
@@ -499,6 +502,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig(b *testing.B) {
 				PartyBoostPercent:      0.10,
 				EnableRosterVariants:   false,
 				UseSnakeDraftFormation: true,
+				OpenSkillOptions:       &types.OpenSkillOptions{},
 			},
 		},
 		{
@@ -507,6 +511,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig(b *testing.B) {
 				PartyBoostPercent:      0.10,
 				EnableRosterVariants:   true,
 				UseSnakeDraftFormation: true,
+				OpenSkillOptions:       &types.OpenSkillOptions{},
 			},
 		},
 	}
@@ -544,7 +549,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig_Throughput(b *testing.B) {
 		PartyBoostPercent:      0.10,
 		EnableRosterVariants:   true,
 		UseSnakeDraftFormation: true,
-		OpenSkillOptions:       &OpenSkillOptions{},
+		OpenSkillOptions:       &types.OpenSkillOptions{},
 	}
 
 	b.ReportAllocs()
@@ -642,6 +647,7 @@ done:
 		PartyBoostPercent:      0.10,
 		EnableRosterVariants:   true,
 		UseSnakeDraftFormation: true,
+		OpenSkillOptions:       &types.OpenSkillOptions{},
 	}
 
 	b.ReportAllocs()
@@ -671,6 +677,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig_DuplicateFiltering(b *testing.B
 		PartyBoostPercent:      0.0,
 		EnableRosterVariants:   false,
 		UseSnakeDraftFormation: true,
+		OpenSkillOptions:       &types.OpenSkillOptions{},
 	}
 
 	b.Run("WithDuplicates", func(b *testing.B) {

--- a/server/evr_matchmaker_prediction_test.go
+++ b/server/evr_matchmaker_prediction_test.go
@@ -544,6 +544,7 @@ func BenchmarkPredictCandidateOutcomesWithConfig_Throughput(b *testing.B) {
 		PartyBoostPercent:      0.10,
 		EnableRosterVariants:   true,
 		UseSnakeDraftFormation: true,
+		OpenSkillOptions:       &OpenSkillOptions{},
 	}
 
 	b.ReportAllocs()

--- a/server/evr_matchmaker_priority_test.go
+++ b/server/evr_matchmaker_priority_test.go
@@ -48,7 +48,7 @@ func TestOldestTicketPriority(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-c"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 10,
 		},
@@ -57,7 +57,7 @@ func TestOldestTicketPriority(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-a"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 100,
 		},
@@ -66,7 +66,7 @@ func TestOldestTicketPriority(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-b"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 50,
 		},
@@ -88,7 +88,7 @@ func TestOldestTicketPriority(t *testing.T) {
 			return predictions[i].DivisionCount < predictions[j].DivisionCount
 		}
 
-		return predictions[i].Draw > predictions[j].Draw
+		return predictions[i].DrawProb > predictions[j].DrawProb
 	})
 
 	// The oldest ticket should be first
@@ -127,7 +127,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-3"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 30,
 		},
@@ -136,7 +136,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-1"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 10,
 		},
@@ -145,7 +145,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-5"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 50,
 		},
@@ -154,7 +154,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-2"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 20,
 		},
@@ -163,7 +163,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 				&mockMatchmakerEntry{ticket: "player-4"},
 			},
 			Size:                  1,
-			Draw:                  0.5,
+			DrawProb:              0.5,
 			DivisionCount:         1,
 			OldestTicketTimestamp: now - 40,
 		},
@@ -185,7 +185,7 @@ func TestOldestTicketPriorityMultiplePlayers(t *testing.T) {
 			return predictions[i].DivisionCount < predictions[j].DivisionCount
 		}
 
-		return predictions[i].Draw > predictions[j].Draw
+		return predictions[i].DrawProb > predictions[j].DrawProb
 	})
 
 	// Expected order: player-5 (50s), player-4 (40s), player-3 (30s), player-2 (20s), player-1 (10s)


### PR DESCRIPTION
This pull request introduces a comprehensive performance benchmarking framework for the matchmaker system, along with several refactors and minor improvements to the matchmaker's test and prediction logic. The main focus is on enabling automated detection of performance regressions using new Makefile targets, scripts, and baseline data, as well as improving the flexibility of rating calculations.

**Performance Benchmarking Framework:**

* Added new Makefile targets (`bench-baseline`, `bench-compare`, `bench-check`) to automate running, comparing, and enforcing performance benchmarks for the matchmaker. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L12-R12) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R38-R54)
* Added `_benchmarks/README.md` and a sample baseline file to document and store benchmark results, including instructions for usage and CI integration. [[1]](diffhunk://#diff-73f50c195dc309a8ab64fe08f1e29709c393708a8d70c22f8f0e17cd114d7705R1-R78) [[2]](diffhunk://#diff-35c212a545b1b0d01a8a5acbdf10a021f63a887bacbe5af5a1cc7577cf0dce8bR1-R11)
* Introduced the `scripts/bench-compare.sh` script to compare current benchmark runs against the baseline, fail the build if regressions exceed a configurable threshold, and provide user-friendly output.

**Matchmaker Rating and Prediction Refactors:**

* Refactored the rating calculation methods in `MatchmakerEntries` to accept an `OpenSkillOptions` parameter, allowing for default values and more flexible configuration. This affects methods like `Ratings`, `RatingsWithPartyBoost`, `TeamRating`, and `TeamOrdinal`. [[1]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1R29-R34) [[2]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1L46-R110) [[3]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1L92-R138)
* Added a new `RatingsInto` method for efficient rating population without allocations.

**Testing Improvements:**

* Updated tests in `server/evr_matchmaker_balance_test.go` to use the new rating methods and renamed the `Draw` field to `DrawProb` in the `PredictedMatch` struct for clarity. [[1]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L146-R146) [[2]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L164-R164) [[3]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L219-R219) [[4]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L303-R331) [[5]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L353-R353) [[6]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L369-R369) [[7]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L440-R445) [[8]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L454-R456) [[9]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L466-R467) [[10]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L488-R489) [[11]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L616-R616) [[12]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L635-R635) [[13]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L681-R681) [[14]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1R29-R34)

**Summary of Most Important Changes:**

**Performance Benchmarking Framework**
- Added Makefile targets and scripts for automated performance regression testing, including baseline creation, comparison, and CI integration. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L12-R12) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R38-R54) [[3]](diffhunk://#diff-10e0fd8c1ecb3a88adf99b7158acd57acfe9d74ffa9b0673f04c9529bdd820beR1-R69)
- Added documentation and sample baseline data in the `_benchmarks` directory to guide users and store results. [[1]](diffhunk://#diff-73f50c195dc309a8ab64fe08f1e29709c393708a8d70c22f8f0e17cd114d7705R1-R78) [[2]](diffhunk://#diff-35c212a545b1b0d01a8a5acbdf10a021f63a887bacbe5af5a1cc7577cf0dce8bR1-R11)

**Matchmaker Rating and Prediction Refactors**
- Refactored rating methods to accept `OpenSkillOptions`, improving flexibility and robustness of rating calculations. [[1]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1R29-R34) [[2]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1L46-R110) [[3]](diffhunk://#diff-4fba86f4c3a20eb1c57c0188a68e2c02641be73eee5f03e969c15c180a04c9e1L92-R138)
- Renamed `Draw` to `DrawProb` in the `PredictedMatch` struct for clarity and consistency.

**Testing Improvements**
- Updated tests to use the new rating methods and field names, ensuring consistency with the refactored code. [[1]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L146-R146) [[2]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L164-R164) [[3]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L219-R219) [[4]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L303-R331) [[5]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L353-R353) [[6]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L369-R369) [[7]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L440-R445) [[8]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L454-R456) [[9]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L466-R467) [[10]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L488-R489) [[11]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L616-R616) [[12]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L635-R635) [[13]](diffhunk://#diff-fd10ecb2a61c96703dea6fa3b80296380bbefc73ff1c624ec920bc8a409cc707L681-R681)