### PR TITLE
Improve IGN override prompts and allocator fallback

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -3702,8 +3702,8 @@ func (d *DiscordAppBot) createLookupSetIGNModal(currentDisplayName string, isLoc
 					Components: []discordgo.MessageComponent{
 						discordgo.TextInput{
 							CustomID:    "lock_input",
-							Label:       "Lock In-Game Name? (true/false)",
-							Value:       fmt.Sprintf("%t", !allowPlayerToChangeIGN),
+							Label:       "Allow player to change in-game display name? (true/false)",
+							Value:       fmt.Sprintf("%t", allowPlayerToChangeIGN),
 							Style:       discordgo.TextInputShort,
 							Required:    true,
 							Placeholder: "true or false",


### PR DESCRIPTION
This pull request makes improvements to the Discord bot's user interface and refines the logic for determining which groups a user can allocate matches from. The most significant changes clarify the modal for changing in-game display names and adjust the allocation logic to ensure global operators are handled correctly.

**User Interface Improvements:**
* Updated the label and logic in the `createLookupSetIGNModal` modal to clearly ask if the player is allowed to change their in-game display name, and corrected the value logic to match the label.

**Allocation Logic Refinements:**
* Simplified the logic for determining allocator group IDs in `handleAllocateMatch` by removing redundant global operator checks and ensuring that global operators can always allocate from the current guild group if they have no other allocator groups.