### PR TITLE
Enhance/loadout and profile updates

### DIFF
--- a/migrate/sql/20260108000001_migrate_evr_profile_to_storage.sql
+++ b/migrate/sql/20260108000001_migrate_evr_profile_to_storage.sql
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 The Nakama Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- +migrate Up
+-- Migrate EVR profile data from user metadata to storage objects.
+-- This migration copies user metadata to the EVRProfile storage collection,
+-- but only for users who don't already have an EVRProfile storage object.
+-- This ensures we don't clobber existing storage objects.
+
+INSERT INTO storage (collection, key, user_id, value, version, read, write, create_time, update_time)
+SELECT 
+    'EVRProfile' AS collection,
+    'profile' AS key,
+    u.id AS user_id,
+    u.metadata AS value,
+    md5(u.metadata::text) AS version,
+    0 AS read,  -- STORAGE_PERMISSION_NO_READ
+    0 AS write, -- STORAGE_PERMISSION_NO_WRITE
+    now() AS create_time,
+    now() AS update_time
+FROM users u
+WHERE u.id != '00000000-0000-0000-0000-000000000000'  -- Exclude system user
+  AND u.metadata != '{}'::jsonb  -- Only migrate users with metadata
+  AND NOT EXISTS (
+    SELECT 1 FROM storage s 
+    WHERE s.collection = 'EVRProfile' 
+      AND s.key = 'profile' 
+      AND s.user_id = u.id
+  );
+
+-- +migrate Down
+-- Remove EVRProfile storage objects that were created by this migration.
+-- Note: This will remove ALL EVRProfile storage objects, not just migrated ones.
+-- Use with caution.
+DELETE FROM storage 
+WHERE collection = 'EVRProfile' 
+  AND key = 'profile';

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -396,10 +396,8 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 	}
 
 	// Invalidate any cached ServerProfile so it will be regenerated with the updated EVRProfile data.
-	if err := ServerProfileInvalidate(ctx, nk, userID); err != nil {
-		// Log the error but do not change the existing success/failure semantics of this function.
-		nk.Logger(ctx).Error("Failed to invalidate ServerProfile after EVRProfile update", "user_id", userID, "error", err)
-	}
+	_ = ServerProfileInvalidate(ctx, nk, userID)
+
 	// Also update the account metadata to keep it in sync
 	return nk.AccountUpdateId(ctx, userID, "", md.MarshalMap(), "", "", "", "", "")
 }

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -395,6 +395,11 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 		return fmt.Errorf("failed to write profile storage: %w", err)
 	}
 
+	// Invalidate any cached ServerProfile so it will be regenerated with the updated EVRProfile data.
+	if err := ServerProfileInvalidate(ctx, nk, userID); err != nil {
+		// Log the error but do not change the existing success/failure semantics of this function.
+		nk.Logger(ctx).Error("Failed to invalidate ServerProfile after EVRProfile update", "user_id", userID, "error", err)
+	}
 	// Also update the account metadata to keep it in sync
 	return nk.AccountUpdateId(ctx, userID, "", md.MarshalMap(), "", "", "", "", "")
 }

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -16,6 +16,8 @@ import (
 const (
 	StorageCollectionGroupProfile = "GroupProfile"
 	StorageKeyUnlockedItems       = "unlocks"
+	StorageCollectionEVRProfile   = "EVRProfile"
+	StorageKeyEVRProfile          = "profile"
 )
 
 type GroupInGameName struct {
@@ -46,13 +48,45 @@ type EVRProfile struct {
 	account                *api.Account
 }
 
-func BuildEVRProfileFromAccount(account *api.Account) (*EVRProfile, error) {
-	a := &EVRProfile{}
-	if err := json.Unmarshal([]byte(account.User.Metadata), &a); err != nil {
-		return nil, fmt.Errorf("error unmarshalling account metadata: %w", err)
+// EVRProfileStorage is the authoritative storage object for EVR profile data.
+// It is versioned and stored separately from account metadata to prevent staleness.
+// The account metadata is generated from this storage object.
+type EVRProfileStorage struct {
+	EnableAllRemoteLogs    bool                       `json:"enable_all_remote_logs"`
+	InGameNames            map[string]GroupInGameName `json:"group_igns"`
+	ActiveGroupID          string                     `json:"active_group_id"`
+	DiscordDebugMessages   bool                       `json:"discord_debug_messages"`
+	RelayMessagesToDiscord bool                       `json:"relay_messages_to_discord"`
+	TeamName               string                     `json:"team_name"`
+	Options                ProfileOptions             `json:"options"`
+	LoadoutCosmetics       AccountCosmetics           `json:"cosmetic_loadout"`
+	CombatLoadout          CombatLoadout              `json:"combat_loadout"`
+	MutedPlayers           []evr.EvrId                `json:"muted_players"`
+	GhostedPlayers         []evr.EvrId                `json:"ghosted_players"`
+	NewUnlocks             []int64                    `json:"new_unlocks"`
+	GamePauseSettings      *evr.GamePauseSettings     `json:"game_pause_settings"`
+	LegalConsents          evr.LegalConsents          `json:"legal_consents"`
+	CustomizationPOIs      *evr.Customization         `json:"customization_pois"`
+	MatchmakingDivision    string                     `json:"matchmaking_division"`
+	LevelOverride          *int                       `json:"level_override,omitempty"`
+
+	version string // Storage version for optimistic concurrency control
+}
+
+// StorageMeta implements the StorableAdapter interface
+func (s *EVRProfileStorage) StorageMeta() StorableMetadata {
+	return StorableMetadata{
+		Collection:      StorageCollectionEVRProfile,
+		Key:             StorageKeyEVRProfile,
+		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+		Version:         s.version,
 	}
-	a.account = account
-	return a, nil
+}
+
+// SetStorageMeta implements the StorableAdapter interface
+func (s *EVRProfileStorage) SetStorageMeta(meta StorableMetadata) {
+	s.version = meta.Version
 }
 
 func (e EVRProfile) UserID() string {
@@ -333,6 +367,15 @@ func EVRProfileLoad(ctx context.Context, nk runtime.NakamaModule, userID string)
 	if err != nil {
 		return nil, err
 	}
+
+	// Try to load from the new storage system first
+	profileStorage := &EVRProfileStorage{}
+	if err := StorableRead(ctx, nk, userID, profileStorage, false); err == nil {
+		// Successfully loaded from storage, build EVRProfile from it
+		return BuildEVRProfileFromStorage(account, profileStorage), nil
+	}
+
+	// Fall back to loading from account metadata for backward compatibility
 	return BuildEVRProfileFromAccount(account)
 }
 
@@ -343,7 +386,74 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 	if md == nil {
 		return fmt.Errorf("metadata cannot be nil")
 	}
+
+	// Convert EVRProfile to EVRProfileStorage
+	profileStorage := md.ToStorage()
+
+	// Write to the new storage system
+	if err := StorableWrite(ctx, nk, userID, profileStorage); err != nil {
+		return fmt.Errorf("failed to write profile storage: %w", err)
+	}
+
+	// Also update the account metadata to keep it in sync
 	return nk.AccountUpdateId(ctx, userID, "", md.MarshalMap(), "", "", "", "", "")
+}
+
+// BuildEVRProfileFromStorage creates an EVRProfile from account and storage data
+func BuildEVRProfileFromStorage(account *api.Account, storage *EVRProfileStorage) *EVRProfile {
+	profile := &EVRProfile{
+		EnableAllRemoteLogs:    storage.EnableAllRemoteLogs,
+		InGameNames:            storage.InGameNames,
+		ActiveGroupID:          storage.ActiveGroupID,
+		DiscordDebugMessages:   storage.DiscordDebugMessages,
+		RelayMessagesToDiscord: storage.RelayMessagesToDiscord,
+		TeamName:               storage.TeamName,
+		Options:                storage.Options,
+		LoadoutCosmetics:       storage.LoadoutCosmetics,
+		CombatLoadout:          storage.CombatLoadout,
+		MutedPlayers:           storage.MutedPlayers,
+		GhostedPlayers:         storage.GhostedPlayers,
+		NewUnlocks:             storage.NewUnlocks,
+		GamePauseSettings:      storage.GamePauseSettings,
+		LegalConsents:          storage.LegalConsents,
+		CustomizationPOIs:      storage.CustomizationPOIs,
+		MatchmakingDivision:    storage.MatchmakingDivision,
+		LevelOverride:          storage.LevelOverride,
+		account:                account,
+	}
+	return profile
+}
+
+// ToStorage converts an EVRProfile to EVRProfileStorage
+func (e *EVRProfile) ToStorage() *EVRProfileStorage {
+	return &EVRProfileStorage{
+		EnableAllRemoteLogs:    e.EnableAllRemoteLogs,
+		InGameNames:            e.InGameNames,
+		ActiveGroupID:          e.ActiveGroupID,
+		DiscordDebugMessages:   e.DiscordDebugMessages,
+		RelayMessagesToDiscord: e.RelayMessagesToDiscord,
+		TeamName:               e.TeamName,
+		Options:                e.Options,
+		LoadoutCosmetics:       e.LoadoutCosmetics,
+		CombatLoadout:          e.CombatLoadout,
+		MutedPlayers:           e.MutedPlayers,
+		GhostedPlayers:         e.GhostedPlayers,
+		NewUnlocks:             e.NewUnlocks,
+		GamePauseSettings:      e.GamePauseSettings,
+		LegalConsents:          e.LegalConsents,
+		CustomizationPOIs:      e.CustomizationPOIs,
+		MatchmakingDivision:    e.MatchmakingDivision,
+		LevelOverride:          e.LevelOverride,
+	}
+}
+
+func BuildEVRProfileFromAccount(account *api.Account) (*EVRProfile, error) {
+	a := &EVRProfile{}
+	if err := json.Unmarshal([]byte(account.User.Metadata), &a); err != nil {
+		return nil, fmt.Errorf("error unmarshalling account metadata: %w", err)
+	}
+	a.account = account
+	return a, nil
 }
 
 type CombatLoadout struct {
@@ -352,6 +462,7 @@ type CombatLoadout struct {
 	CombatDominantHand uint8  `json:"combat_dominant_hand"`
 	CombatAbility      string `json:"combat_ability"`
 }
+
 type AccountCosmetics struct {
 	JerseyNumber int64               `json:"number"`           // The loadout number (jersey number)
 	Loadout      evr.CosmeticLoadout `json:"cosmetic_loadout"` // The loadout

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -55,7 +55,6 @@ type DiscordAppBot struct {
 	config             Config
 	metrics            Metrics
 	pipeline           *Pipeline
-	profileRegistry    *ProfileCache
 	statusRegistry     StatusRegistry
 	guildGroupRegistry *GuildGroupRegistry
 
@@ -78,7 +77,7 @@ type DiscordAppBot struct {
 	publicMatchRateLimiters  *MapOf[string, *rate.Limiter]
 }
 
-func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, db *sql.DB, metrics Metrics, pipeline *Pipeline, config Config, discordCache *DiscordIntegrator, profileRegistry *ProfileCache, statusRegistry StatusRegistry, dg *discordgo.Session, ipInfoCache *IPInfoCache, guildGroupRegistry *GuildGroupRegistry) (*DiscordAppBot, error) {
+func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, db *sql.DB, metrics Metrics, pipeline *Pipeline, config Config, discordCache *DiscordIntegrator, statusRegistry StatusRegistry, dg *discordgo.Session, ipInfoCache *IPInfoCache, guildGroupRegistry *GuildGroupRegistry) (*DiscordAppBot, error) {
 
 	logger = logger.WithField("system", "discordAppBot")
 
@@ -92,8 +91,7 @@ func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.Nak
 		metrics:  metrics,
 		config:   config,
 
-		profileRegistry: profileRegistry,
-		statusRegistry:  statusRegistry,
+		statusRegistry: statusRegistry,
 
 		dg:                 dg,
 		guildGroupRegistry: guildGroupRegistry,

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -512,8 +512,9 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 		profile.DeveloperFeatures = &evr.DeveloperFeatures{}
 	}
 
-	if _, err := p.profileCache.Store(session.ID(), *profile); err != nil {
-		return fmt.Errorf("failed to cache profile: %w", err)
+	// Store the server profile for later retrieval by other players
+	if err := ServerProfileStore(ctx, p.nk, userID, profile); err != nil {
+		return fmt.Errorf("failed to store profile: %w", err)
 	}
 
 	session.Logger().Info("Authorized access to lobby session", zap.String("gid", groupID), zap.String("display_name", displayName))

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -241,7 +241,7 @@ func (s *MatchLabel) GetEndpoint() evr.Endpoint {
 	return s.GameServer.Endpoint
 }
 
-func (s *MatchLabel) GetEntrantConnectMessage(role int, isPCVR bool, disableEncryption bool, disableMAC bool) *evr.LobbySessionSuccessv5 {
+func (s *MatchLabel) GetEntrantConnectMessage(role int, disableEncryption bool, disableMAC bool) *evr.LobbySessionSuccessv5 {
 	return evr.NewLobbySessionSuccess(s.Mode, s.ID.UUID, s.GetGroupID(), s.GameServer.Endpoint, int16(role), disableEncryption, disableMAC).Version5()
 }
 

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -59,7 +59,6 @@ type EvrPipeline struct {
 	nk              *RuntimeGoNakamaModule
 	runtimeLogger   runtime.Logger
 
-	profileCache *ProfileCache
 	discordCache *DiscordIntegrator
 	appBot       *DiscordAppBot
 
@@ -131,7 +130,6 @@ func NewEvrPipeline(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 	runtimeLogger := NewRuntimeGoLogger(logger)
 	guildGroupRegistry := NewGuildGroupRegistry(ctx, runtimeLogger, nk, db)
 
-	profileRegistry := NewProfileRegistry(nk, db, runtimeLogger, metrics, sessionRegistry)
 	lobbyBuilder := NewLobbyBuilder(logger, nk, sessionRegistry, matchRegistry, tracker, metrics)
 	matchmaker.OnMatchedEntries(lobbyBuilder.handleMatchedEntries)
 
@@ -183,7 +181,7 @@ func NewEvrPipeline(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 	discordIntegrator := NewDiscordIntegrator(ctx, logger, config, metrics, nk, db, dg, guildGroupRegistry)
 	discordIntegrator.Start()
 
-	appBot, err = NewDiscordAppBot(ctx, runtimeLogger, nk, db, metrics, pipeline, config, discordIntegrator, profileRegistry, statusRegistry, dg, ipInfoCache, guildGroupRegistry)
+	appBot, err = NewDiscordAppBot(ctx, runtimeLogger, nk, db, metrics, pipeline, config, discordIntegrator, statusRegistry, dg, ipInfoCache, guildGroupRegistry)
 	if err != nil {
 		logger.Error("Failed to create app bot", zap.Error(err))
 
@@ -231,7 +229,6 @@ func NewEvrPipeline(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 		internalIP:   internalIP,
 		externalIP:   externalIP,
 
-		profileCache:                 profileRegistry,
 		userRemoteLogJournalRegistry: userRemoteLogJournalRegistry,
 		guildGroupRegistry:           guildGroupRegistry,
 		ipInfoCache:                  ipInfoCache,

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -778,6 +778,8 @@ func (p *EvrPipeline) ProcessProtobufRequest(logger *zap.Logger, session Session
 		pipelineFn = p.lobbySessionEvent
 	case *rtapi.Envelope_LobbyEntrantRemoved:
 		pipelineFn = p.lobbyEntrantRemoved
+	case *rtapi.Envelope_GameServerSaveLoadout:
+		pipelineFn = p.gameServerSaveLoadoutProtobuf
 	default:
 		// For all other messages, use the generic protobuf handler
 		return fmt.Errorf("unhandled protobuf message type: %T", in.Message)

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -66,7 +66,7 @@ func sendDiscordError(e error, discordId string, logger *zap.Logger, bot *discor
 }
 
 // sendDiscordServerError sends a formatted error message about a specific game server to the user on discord
-func sendDiscordServerError(endpointID string, serverID uint64, errMsg string, discordId string, logger *zap.Logger, bot *discordgo.Session) {
+func sendDiscordServerError(internalIP net.IP, externalIP net.IP, port uint16, serverID uint64, errMsg string, discordId string, logger *zap.Logger, bot *discordgo.Session) {
 	if bot != nil && discordId != "" {
 		channel, err := bot.UserChannelCreate(discordId)
 		if err != nil {
@@ -80,9 +80,14 @@ func sendDiscordServerError(endpointID string, serverID uint64, errMsg string, d
 			Color:       0xFF0000, // Red color
 			Fields: []*discordgo.MessageEmbedField{
 				{
-					Name:   "Endpoint ID",
-					Value:  fmt.Sprintf("`%s`", endpointID),
-					Inline: false,
+					Name:   "Internal IP",
+					Value:  fmt.Sprintf("`%s:%d`", internalIP.String(), port),
+					Inline: true,
+				},
+				{
+					Name:   "External IP",
+					Value:  fmt.Sprintf("`%s:%d`", externalIP.String(), port),
+					Inline: true,
 				},
 				{
 					Name:   "Server ID",
@@ -262,7 +267,6 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 
 	logger = logger.With(zap.Any("group_ids", hostingGroupIDs), zap.Strings("tags", params.serverTags), zap.Strings("regions", regionCodes))
 
-
 	// Create the broadcaster config
 	config := NewGameServerPresence(session.UserID(), session.id, serverID, internalIP, externalIP, externalPort, hostingGroupIDs, defaultRegion, regionCodes, versionLock, params.serverTags, params.supportedFeatures, request.TimeStepUsecs, ipInfo, params.geoHashPrecision, isNative, request.Version)
 
@@ -301,7 +305,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 			// If the broadcaster is not available, send an error message to the user on discord
 			logger.Error("Broadcaster could not be reached", zap.Error(err))
 			errorMessage := fmt.Sprintf("Broadcaster (Endpoint ID: %s, Server ID: %d) could not be reached. Error: %v", config.Endpoint.String(), config.ServerID, err)
-			go sendDiscordServerError(config.Endpoint.String(), config.ServerID, err.Error(), params.DiscordID(), logger, p.discordCache.dg)
+			go sendDiscordServerError(config.Endpoint.InternalIP, config.Endpoint.ExternalIP, config.Endpoint.Port, config.ServerID, err.Error(), params.DiscordID(), logger, p.discordCache.dg)
 			return errFailedRegistration(session, logger, errors.New(errorMessage), evr.BroadcasterRegistration_Failure)
 		}
 	} else {
@@ -376,7 +380,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 					if err != nil {
 						errMsg = err.Error()
 					}
-					go sendDiscordServerError(config.Endpoint.String(), config.ServerID, errMsg, params.DiscordID(), logger, p.discordCache.dg)
+					go sendDiscordServerError(config.Endpoint.InternalIP, config.Endpoint.ExternalIP, config.Endpoint.Port, config.ServerID, errMsg, params.DiscordID(), logger, p.discordCache.dg)
 				}
 			}
 			// If the game server is alive, check if it is still in a match

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -74,12 +74,12 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		for slotHex, equippedHex := range instance.Items {
 			slotSymbol := evr.ToSymbol(slotHex)
 			if slotSymbol == 0 {
-				logger.Warn("Failed to parse slot hash", zap.String("slot", slotHex), zap.Error(err))
+				logger.Warn("Failed to parse slot hash", zap.String("slot", slotHex))
 				continue
 			}
 			equippedSymbol := evr.ToSymbol(equippedHex)
 			if equippedSymbol == 0 {
-				logger.Warn("Failed to parse equipped hash", zap.String("equipped", equippedHex), zap.Error(err))
+				logger.Warn("Failed to parse equipped hash", zap.String("equipped", equippedHex))
 				continue
 			}
 

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -4,10 +4,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 
+	"github.com/echotools/nevr-common/v4/gen/go/rtapi"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"go.uber.org/zap"
 )
+
+// GameServerLoadoutPayload is the JSON format sent from the game server
+// Format: {"slot":0,"number":8,"loadout_instances":[{"instance_name":"0x...","items":{"0x...":"0x..."}}]}
+type GameServerLoadoutPayload struct {
+	Slot             int                         `json:"slot"`
+	Number           int                         `json:"number"` // Jersey number
+	LoadoutInstances []GameServerLoadoutInstance `json:"loadout_instances"`
+}
+
+type GameServerLoadoutInstance struct {
+	InstanceName string            `json:"instance_name"`
+	Items        map[string]string `json:"items"` // slot_hash -> equipped_hash (both as hex strings)
+}
 
 // gameServerSaveLoadoutRequest handles loadout save requests from the game server.
 // This is triggered when a player updates their loadout at the character customization screen.
@@ -20,15 +35,19 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		zap.String("entrant_session_id", request.EntrantSessionID.String()),
 	)
 
-	// Parse the loadout data
-	var loadoutPayload evr.SaveLoadoutPayload
-	if err := json.Unmarshal(request.Loadout, &loadoutPayload); err != nil {
+	logger.Info("Processing save loadout request", zap.String("raw_json", string(request.Loadout)))
+
+	// Parse the new game server loadout format
+	var payload GameServerLoadoutPayload
+	if err := json.Unmarshal(request.Loadout, &payload); err != nil {
 		logger.Warn("Failed to unmarshal loadout payload", zap.Error(err), zap.String("raw", string(request.Loadout)))
-		// Try to continue with raw JSON if structured parse fails
+		return nil
 	}
 
-	logger.Info("Processing save loadout request",
-		zap.Any("loadout", loadoutPayload))
+	logger.Info("Parsed loadout payload",
+		zap.Int("slot", payload.Slot),
+		zap.Int("jersey_number", payload.Number),
+		zap.Int("instance_count", len(payload.LoadoutInstances)))
 
 	// Look up the user by their EvrID (used as device ID)
 	userID, err := GetUserIDByDeviceID(ctx, p.db, request.EvrID.String())
@@ -47,19 +66,92 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		return fmt.Errorf("failed to load EVR profile: %w", err)
 	}
 
-	// Update the cosmetic loadout in the profile
-	if loadoutPayload.Slots != (evr.CosmeticLoadout{}) {
-		profile.LoadoutCosmetics.Loadout = loadoutPayload.Slots // Updated to match profile structure
-		logger.Debug("Updated loadout slots from structured payload")
-	} else if len(request.Loadout) > 0 {
-		// Try to unmarshal directly into the slots if the structured parse failed
-		var slots evr.CosmeticLoadout
-		if err := json.Unmarshal(request.Loadout, &slots); err == nil {
-			profile.LoadoutCosmetics.Loadout = slots // Updated to match profile structure
-			logger.Debug("Updated loadout slots from raw JSON")
-		} else {
-			logger.Warn("Failed to parse loadout data in any format", zap.Error(err))
+	// Convert the hash-based items to CosmeticLoadout fields
+	loadout := profile.LoadoutCosmetics.Loadout
+
+	// Process each loadout instance
+	for _, instance := range payload.LoadoutInstances {
+		for slotHex, equippedHex := range instance.Items {
+			slotSymbol := evr.ToSymbol(slotHex)
+			if slotSymbol == 0 {
+				logger.Warn("Failed to parse slot hash", zap.String("slot", slotHex), zap.Error(err))
+				continue
+			}
+			equippedSymbol := evr.ToSymbol(equippedHex)
+			if equippedSymbol == 0 {
+				logger.Warn("Failed to parse equipped hash", zap.String("equipped", equippedHex), zap.Error(err))
+				continue
+			}
+
+			// Convert symbols to their string names
+			slotName := slotSymbol.String()
+			equippedName := equippedSymbol.String()
+
+			logger.Debug("Processing loadout item",
+				zap.String("slot_hash", slotHex),
+				zap.String("slot_name", slotName),
+				zap.String("equipped_hash", equippedHex),
+				zap.String("equipped_name", equippedName))
+
+			// Map slot names to CosmeticLoadout fields
+			switch slotName {
+			case "banner":
+				loadout.Banner = equippedName
+			case "booster":
+				loadout.Booster = equippedName
+			case "bracer":
+				loadout.Bracer = equippedName
+			case "chassis":
+				loadout.Chassis = equippedName
+			case "decal":
+				loadout.Decal = equippedName
+			case "decal_body":
+				loadout.DecalBody = equippedName
+			case "decalborder":
+				loadout.DecalBorder = equippedName
+			case "decalback":
+				loadout.DecalBack = equippedName
+			case "emissive":
+				loadout.Emissive = equippedName
+			case "emote":
+				loadout.Emote = equippedName
+			case "goal_fx":
+				loadout.GoalFX = equippedName
+			case "medal":
+				loadout.Medal = equippedName
+			case "pattern":
+				loadout.Pattern = equippedName
+			case "pattern_body":
+				loadout.PatternBody = equippedName
+			case "pip":
+				loadout.PIP = equippedName
+			case "secondemote":
+				loadout.SecondEmote = equippedName
+			case "tag":
+				loadout.Tag = equippedName
+			case "tint":
+				loadout.Tint = equippedName
+			case "tint_alignment_a":
+				loadout.TintAlignmentA = equippedName
+			case "tint_alignment_b":
+				loadout.TintAlignmentB = equippedName
+			case "tint_body":
+				loadout.TintBody = equippedName
+			case "title":
+				loadout.Title = equippedName
+			default:
+				logger.Debug("Unknown slot type", zap.String("slot", slotName))
+			}
 		}
+	}
+
+	// Update profile with new loadout
+	profile.LoadoutCosmetics.Loadout = loadout
+
+	// Update jersey number if present
+	if payload.Number >= 0 {
+		profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
+		logger.Info("Updated jersey number", zap.Int("number", payload.Number))
 	}
 
 	// Save the updated profile
@@ -69,7 +161,164 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 
 	logger.Info("Successfully saved loadout update",
 		zap.String("user_id", userID),
-		zap.String("evr_id", request.EvrID.String()))
+		zap.String("evr_id", request.EvrID.String()),
+		zap.Any("loadout", loadout))
 
 	return nil
+}
+
+// gameServerSaveLoadoutProtobuf handles loadout save requests via protobuf from the game server.
+// This is the new protobuf-based handler that replaces the legacy EVR binary message path.
+func (p *EvrPipeline) gameServerSaveLoadoutProtobuf(logger *zap.Logger, session *sessionWS, in *rtapi.Envelope) error {
+	msg := in.GetGameServerSaveLoadout()
+	if msg == nil {
+		return fmt.Errorf("invalid GameServerSaveLoadout message")
+	}
+
+	logger = logger.With(
+		zap.String("lobby_session_id", msg.LobbySessionId),
+		zap.String("entrant_id", msg.EntrantId),
+		zap.Int32("loadout_slot", msg.LoadoutSlot),
+		zap.Int32("jersey_number", msg.JerseyNumber),
+	)
+
+	logger.Info("Processing protobuf save loadout request")
+
+	ctx := session.Context()
+
+	// Look up the user by their entrant_id (account ID as string)
+	// The entrant_id from the game server is the account ID
+	userID, err := p.lookupUserByEntrantID(ctx, msg.EntrantId)
+	if err != nil {
+		return fmt.Errorf("failed to get user by entrant ID: %w", err)
+	}
+
+	if userID == "" {
+		logger.Warn("No user found for entrant ID", zap.String("entrant_id", msg.EntrantId))
+		return nil
+	}
+
+	// Load the user's profile
+	profile, err := EVRProfileLoad(ctx, p.nk, userID)
+	if err != nil {
+		return fmt.Errorf("failed to load EVR profile: %w", err)
+	}
+
+	// Convert the protobuf loadout instances to CosmeticLoadout fields
+	loadout := profile.LoadoutCosmetics.Loadout
+
+	// Process each loadout instance
+	for _, instance := range msg.LoadoutInstances {
+		for _, item := range instance.Items {
+			// Convert fixed64 symbol IDs to evr.Symbol
+			slotSymbol := evr.Symbol(item.SlotType)
+			equippedSymbol := evr.Symbol(item.EquippedItem)
+
+			// Convert symbols to their string names
+			slotName := slotSymbol.String()
+			equippedName := equippedSymbol.String()
+
+			logger.Debug("Processing loadout item",
+				zap.Uint64("slot_type", item.SlotType),
+				zap.String("slot_name", slotName),
+				zap.Uint64("equipped_item", item.EquippedItem),
+				zap.String("equipped_name", equippedName))
+
+			// Map slot names to CosmeticLoadout fields
+			switch slotName {
+			case "banner":
+				loadout.Banner = equippedName
+			case "booster":
+				loadout.Booster = equippedName
+			case "bracer":
+				loadout.Bracer = equippedName
+			case "chassis":
+				loadout.Chassis = equippedName
+			case "decal":
+				loadout.Decal = equippedName
+			case "decal_body":
+				loadout.DecalBody = equippedName
+			case "decalborder":
+				loadout.DecalBorder = equippedName
+			case "decalback":
+				loadout.DecalBack = equippedName
+			case "emissive":
+				loadout.Emissive = equippedName
+			case "emote":
+				loadout.Emote = equippedName
+			case "goal_fx":
+				loadout.GoalFX = equippedName
+			case "medal":
+				loadout.Medal = equippedName
+			case "pattern":
+				loadout.Pattern = equippedName
+			case "pattern_body":
+				loadout.PatternBody = equippedName
+			case "pip":
+				loadout.PIP = equippedName
+			case "secondemote":
+				loadout.SecondEmote = equippedName
+			case "tag":
+				loadout.Tag = equippedName
+			case "tint":
+				loadout.Tint = equippedName
+			case "tint_alignment_a":
+				loadout.TintAlignmentA = equippedName
+			case "tint_alignment_b":
+				loadout.TintAlignmentB = equippedName
+			case "tint_body":
+				loadout.TintBody = equippedName
+			case "title":
+				loadout.Title = equippedName
+			default:
+				logger.Debug("Unknown slot type", zap.String("slot", slotName))
+			}
+		}
+	}
+
+	// Update profile with new loadout
+	profile.LoadoutCosmetics.Loadout = loadout
+
+	// Update jersey number if present
+	if msg.JerseyNumber >= 0 {
+		profile.LoadoutCosmetics.JerseyNumber = int64(msg.JerseyNumber)
+		logger.Info("Updated jersey number", zap.Int32("number", msg.JerseyNumber))
+	}
+
+	// Save the updated profile
+	if err := EVRProfileUpdate(ctx, p.nk, userID, profile); err != nil {
+		return fmt.Errorf("failed to store EVR profile: %w", err)
+	}
+
+	logger.Info("Successfully saved loadout update via protobuf",
+		zap.String("user_id", userID),
+		zap.Any("loadout", loadout))
+
+	return nil
+}
+
+// lookupUserByEntrantID looks up a Nakama user ID by the entrant's account ID
+func (p *EvrPipeline) lookupUserByEntrantID(ctx context.Context, entrantID string) (string, error) {
+	// The entrant ID is the account ID (uint64 as string)
+	// We need to find the user that has this account linked
+
+	// First, try to find by device ID (EvrID format)
+	// If entrantID is numeric, it might be a platform account ID
+	if _, err := strconv.ParseUint(entrantID, 10, 64); err == nil {
+		// It's a numeric account ID - search by linked device
+		// For now, try looking up by EvrID pattern
+		// This might need adjustment based on how IDs are actually stored
+	}
+
+	// Try device ID lookup with common prefixes
+	prefixes := []string{"STM-", "OVR-", "DMO-", ""}
+	for _, prefix := range prefixes {
+		deviceID := prefix + entrantID
+		userID, err := GetUserIDByDeviceID(ctx, p.db, deviceID)
+		if err == nil && userID != "" {
+			return userID, nil
+		}
+	}
+
+	return "", fmt.Errorf("user not found for entrant ID: %s", entrantID)
 }

--- a/server/evr_pipeline_lobby.go
+++ b/server/evr_pipeline_lobby.go
@@ -68,7 +68,9 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		acceptedIDs = append(acceptedIDs, entrantID)
 	}
 
-	messages := make([]evr.Message, 0, 2)
+	messages := make([]evr.Message, 0, 4)
+
+	// Send protobuf messages first
 	if len(acceptedIDs) > 0 {
 		envelope := &rtapi.Envelope{
 			Message: &rtapi.Envelope_LobbyEntrantsAccept{
@@ -83,7 +85,7 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		}
 		messages = append(messages, message)
 	}
-	if len(rejectedIDs) == 0 {
+	if len(rejectedIDs) > 0 {
 		envelope := &rtapi.Envelope{
 			Message: &rtapi.Envelope_LobbyEntrantReject{
 				LobbyEntrantReject: &rtapi.LobbyEntrantsRejectMessage{
@@ -100,7 +102,7 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		messages = append(messages, message)
 	}
 
-	// Legacy support
+	// Legacy support - send after protobuf messages
 	if len(acceptedIDs) > 0 {
 		uuids := make([]uuid.UUID, 0, len(acceptedIDs))
 		for _, id := range acceptedIDs {
@@ -112,8 +114,8 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		)
 	}
 	if len(rejectedIDs) > 0 {
-		uuids := make([]uuid.UUID, 0, len(acceptedIDs))
-		for _, id := range acceptedIDs {
+		uuids := make([]uuid.UUID, 0, len(rejectedIDs))
+		for _, id := range rejectedIDs {
 			uuids = append(uuids, uuid.FromStringOrNil(id))
 		}
 		messages = append(messages,

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -8,12 +8,10 @@ import (
 	"reflect"
 	"slices"
 	"strings"
-	"sync"
 	"time"
 
 	"maps"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/samber/lo"
@@ -44,97 +42,6 @@ func init() {
 
 type StarterCosmeticLoadouts struct {
 	Loadouts []*StoredCosmeticLoadout `json:"loadouts"`
-}
-
-// ProfileCache is a registry of user evr profiles.
-type ProfileCache struct {
-	sync.RWMutex
-	ctx         context.Context
-	ctxCancelFn context.CancelFunc
-	logger      runtime.Logger
-	db          *sql.DB
-	nk          runtime.NakamaModule
-
-	metrics         Metrics
-	sessionRegistry SessionRegistry
-
-	profileByXPID    map[evr.EvrId]json.RawMessage
-	sessionIDsByXPID map[evr.EvrId]map[uuid.UUID]struct{}
-}
-
-func NewProfileRegistry(nk runtime.NakamaModule, db *sql.DB, logger runtime.Logger, metrics Metrics, sessionRegistry SessionRegistry) *ProfileCache {
-
-	ctx, cancelFn := context.WithCancel(context.Background())
-
-	profileRegistry := &ProfileCache{
-		ctx:         ctx,
-		ctxCancelFn: cancelFn,
-		logger:      logger,
-		db:          db,
-		nk:          nk,
-
-		metrics:         metrics,
-		sessionRegistry: sessionRegistry,
-
-		profileByXPID:    make(map[evr.EvrId]json.RawMessage),
-		sessionIDsByXPID: make(map[evr.EvrId]map[uuid.UUID]struct{}),
-	}
-
-	go func() {
-		ticker := time.NewTicker(time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-profileRegistry.ctx.Done():
-				return
-			case <-ticker.C:
-				profileRegistry.Lock()
-				for xpid, sessionIDs := range profileRegistry.sessionIDsByXPID {
-					for sessionID := range sessionIDs {
-						if profileRegistry.sessionRegistry.Get(sessionID) == nil {
-
-							delete(profileRegistry.sessionIDsByXPID[xpid], sessionID)
-
-							// If there are no more sessions for this xpid, delete the profile
-							if len(profileRegistry.sessionIDsByXPID[xpid]) == 0 {
-								delete(profileRegistry.profileByXPID, xpid)
-							}
-						}
-					}
-				}
-				profileRegistry.Unlock()
-			}
-		}
-	}()
-
-	return profileRegistry
-}
-
-func (r *ProfileCache) Load(xpid evr.EvrId) (json.RawMessage, bool) {
-	r.RLock()
-	defer r.RUnlock()
-	profiles, found := r.profileByXPID[xpid]
-	return profiles, found
-}
-
-func (r *ProfileCache) Store(sessionID uuid.UUID, p evr.ServerProfile) (json.RawMessage, error) {
-	r.Lock()
-	defer r.Unlock()
-
-	data, err := json.Marshal(p)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal profile: %w", err)
-	}
-
-	r.profileByXPID[p.EvrID] = data
-
-	if _, ok := r.sessionIDsByXPID[p.EvrID]; !ok {
-		r.sessionIDsByXPID[p.EvrID] = make(map[uuid.UUID]struct{})
-	}
-
-	r.sessionIDsByXPID[p.EvrID][sessionID] = struct{}{}
-
-	return data, nil
 }
 
 func walletToCosmetics(wallet map[string]int64, unlocks map[string]map[string]bool) map[string]map[string]bool {
@@ -500,26 +407,6 @@ func cosmeticDefaults(enableAll bool) map[string]map[string]bool {
 		return allCosmetics
 	}
 	return defaultCosmetics
-}
-
-func (r *ProfileCache) ValidateArenaUnlockByName(i interface{}, itemName string) (bool, error) {
-	// Lookup the field name by it's item name (json key)
-	fieldName, found := unlocksByItemName[itemName]
-	if !found {
-		return false, fmt.Errorf("unknown item name: %s", itemName)
-	}
-
-	// Lookup the field value by it's field name
-	value := reflect.ValueOf(i)
-	typ := value.Type()
-	for i := 0; i < typ.NumField(); i++ {
-		field := typ.Field(i)
-		if field.Name == fieldName {
-			return value.FieldByName(fieldName).Bool(), nil
-		}
-	}
-
-	return false, fmt.Errorf("unknown unlock field name: %s", fieldName)
 }
 
 type StoredCosmeticLoadout struct {

--- a/server/evr_profile_cache_test.go
+++ b/server/evr_profile_cache_test.go
@@ -7,29 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/heroiclabs/nakama/v3/server/evr"
-	"go.uber.org/zap"
 )
-
-func createTestProfileRegistry(t *testing.T, logger *zap.Logger) (*ProfileCache, error) {
-	runtimeLogger := NewRuntimeGoLogger(logger)
-
-	db := NewDB(t)
-	nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-
-	profileRegistry := NewProfileRegistry(nk, db, runtimeLogger, metrics, nil)
-
-	return profileRegistry, nil
-}
-
-func TestProfileRegistry(t *testing.T) {
-	consoleLogger := loggerForTest(t)
-
-	profileRegistry, err := createTestProfileRegistry(t, consoleLogger)
-	if err != nil {
-		t.Fatalf("error creating test match registry: %v", err)
-	}
-	_ = profileRegistry
-}
 
 func TestConvertWalletToCosmetics(t *testing.T) {
 	tests := []struct {

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -339,6 +339,7 @@ func RegisterIndexes(initializer runtime.Initializer) error {
 		&VRMLPlayerSummary{},
 		&LoginHistory{},
 		&GuildEnforcementJournal{},
+		&ServerProfileStorage{},
 	}
 	for _, s := range storables {
 		for _, idx := range s.StorageIndexes() {

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -302,11 +302,10 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				}
 			}
 
-			/*
-				if _, err := p.profileCache.Store(session.ID(), *serverProfile); err != nil {
-					return fmt.Errorf("failed to cache profile: %w", err)
-				}
-			*/
+			// Store the updated server profile
+			if err := ServerProfileStore(ctx, nk, session.UserID().String(), serverProfile); err != nil {
+				logger.WithField("error", err).Warn("Failed to store server profile")
+			}
 
 		case *evr.RemoteLogRepairMatrix:
 

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -233,6 +233,13 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				continue
 			}
 
+			// NEVR (non-legacy) servers already persist loadout equips themselves.
+			if matchID, _, err := GetMatchIDBySessionID(nk, uuid.FromStringOrNil(s.SessionID)); err == nil && !matchID.IsNil() {
+				if label, err := MatchLabelByID(ctx, nk, matchID); err == nil && label != nil && label.GameServer != nil && label.GameServer.NativeSupport {
+					continue
+				}
+			}
+
 			category, name, err := msg.GetEquippedCustomization()
 			if err != nil {
 				logger.WithField("error", err).Warn("Failed to get equipped customization")

--- a/server/evr_server_profile_storage.go
+++ b/server/evr_server_profile_storage.go
@@ -1,0 +1,166 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap"
+)
+
+const (
+	StorageCollectionServerProfile = "ServerProfile"
+	StorageKeyServerProfile        = "profile"
+	ServerProfileIndexName         = "Index_ServerProfile"
+	ServerProfileMaxEntries        = 1000 // Keep at least 1000 profiles indexed in memory
+)
+
+// ServerProfileStorage stores the generated ServerProfile for quick retrieval.
+// It implements StorableIndexer to maintain an in-memory index of profiles.
+// The profile is stored as raw JSON to avoid marshal/unmarshal overhead when
+// serving profiles to other users via OtherUserProfileRequest.
+type ServerProfileStorage struct {
+	// Indexed field for searching by XPID
+	XPlatformID string `json:"xplatformid"`
+
+	// The actual profile data stored as raw JSON to avoid marshal/unmarshal overhead
+	Profile json.RawMessage `json:"profile"`
+
+	// Private fields for storage metadata
+	userID  string
+	version string
+}
+
+// StorageMeta implements the StorableAdapter interface
+func (s *ServerProfileStorage) StorageMeta() StorableMetadata {
+	return StorableMetadata{
+		Collection:      StorageCollectionServerProfile,
+		Key:             StorageKeyServerProfile,
+		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+		UserID:          s.userID,
+		Version:         s.version,
+	}
+}
+
+// SetStorageMeta implements the StorableAdapter interface
+func (s *ServerProfileStorage) SetStorageMeta(meta StorableMetadata) {
+	s.userID = meta.UserID
+	s.version = meta.Version
+}
+
+// StorageIndexes implements the StorableIndexer interface
+func (s *ServerProfileStorage) StorageIndexes() []StorableIndexMeta {
+	return []StorableIndexMeta{{
+		Name:           ServerProfileIndexName,
+		Collection:     StorageCollectionServerProfile,
+		Key:            StorageKeyServerProfile,
+		Fields:         []string{"xplatformid"}, // Index by XPID for quick lookups
+		SortableFields: nil,
+		MaxEntries:     ServerProfileMaxEntries, // Keep at least 1000 profiles in memory
+		IndexOnly:      false,                   // Return full objects, not just index data
+	}}
+}
+
+// NewServerProfileStorage creates a new ServerProfileStorage from a ServerProfile
+func NewServerProfileStorage(userID string, profile *evr.ServerProfile) (*ServerProfileStorage, error) {
+	profileJSON, err := json.Marshal(profile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal profile: %w", err)
+	}
+	return &ServerProfileStorage{
+		XPlatformID: profile.EvrID.String(),
+		Profile:     profileJSON,
+		userID:      userID,
+		version:     "", // Will be set on write
+	}, nil
+}
+
+// ServerProfileLoad loads a ServerProfile, checking storage first, then generating from EVRProfile
+func ServerProfileLoad(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, userID string, xpID evr.EvrId, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol) (*evr.ServerProfile, error) {
+	// First, try to load from storage (which uses the index if available)
+	storage := &ServerProfileStorage{}
+	if err := StorableRead(ctx, nk, userID, storage, false); err == nil && len(storage.Profile) > 0 {
+		// Found in storage, unmarshal and return
+		profile := &evr.ServerProfile{}
+		if err := json.Unmarshal(storage.Profile, profile); err != nil {
+			logger.Warn("Failed to unmarshal cached server profile, regenerating", zap.Error(err))
+		} else {
+			return profile, nil
+		}
+	}
+
+	// Not in storage, generate from EVRProfile
+	evrProfile, err := EVRProfileLoad(ctx, nk, userID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load EVR profile: %w", err)
+	}
+
+	displayName := evrProfile.GetGroupIGN(groupID)
+
+	// Generate the server profile
+	serverProfile, err := NewUserServerProfile(ctx, logger, db, nk, evrProfile, xpID, groupID, modes, dailyWeeklyMode, displayName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate server profile: %w", err)
+	}
+
+	// Store the generated profile
+	if err := ServerProfileStore(ctx, nk, userID, serverProfile); err != nil {
+		// Log but don't fail - we have the profile even if we can't cache it
+		logger.Warn("Failed to store generated server profile", zap.Error(err))
+	}
+
+	return serverProfile, nil
+}
+
+// ServerProfileStore stores a ServerProfile to storage
+func ServerProfileStore(ctx context.Context, nk runtime.NakamaModule, userID string, profile *evr.ServerProfile) error {
+	storage, err := NewServerProfileStorage(userID, profile)
+	if err != nil {
+		return err
+	}
+	return StorableWrite(ctx, nk, userID, storage)
+}
+
+// ServerProfileLoadByXPID searches for a ServerProfile by XPID using the storage index.
+// Returns the raw JSON profile data to avoid unnecessary marshal/unmarshal when
+// the profile will be sent as json.RawMessage to other users.
+func ServerProfileLoadByXPID(ctx context.Context, nk runtime.NakamaModule, xpID evr.EvrId) (json.RawMessage, string, error) {
+	// Search the storage index for the XPID
+	query := fmt.Sprintf("+xplatformid:%s", xpID.String())
+
+	objects, _, err := nk.StorageIndexList(ctx, SystemUserID, ServerProfileIndexName, query, 1, nil, "")
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to search server profile index: %w", err)
+	}
+
+	if len(objects.Objects) == 0 {
+		return nil, "", nil // Not found
+	}
+
+	obj := objects.Objects[0]
+	storage := &ServerProfileStorage{}
+	if err := json.Unmarshal([]byte(obj.Value), storage); err != nil {
+		return nil, "", fmt.Errorf("failed to unmarshal server profile storage: %w", err)
+	}
+
+	return storage.Profile, obj.UserId, nil
+}
+
+// ServerProfileDelete removes a ServerProfile from storage
+func ServerProfileDelete(ctx context.Context, nk runtime.NakamaModule, userID string) error {
+	return nk.StorageDelete(ctx, []*runtime.StorageDelete{{
+		Collection: StorageCollectionServerProfile,
+		Key:        StorageKeyServerProfile,
+		UserID:     userID,
+	}})
+}
+
+// ServerProfileInvalidate invalidates a cached server profile by deleting it
+// This should be called whenever the EVRProfile or related data changes
+func ServerProfileInvalidate(ctx context.Context, nk runtime.NakamaModule, userID string) error {
+	return ServerProfileDelete(ctx, nk, userID)
+}


### PR DESCRIPTION
This pull request introduces a major migration and refactor for EVR profile data management, shifting from storing user profile data in account metadata to a dedicated storage object (`EVRProfileStorage`). It also updates Discord bot interactions and several game server flows to support this new storage model and improve user experience. The most significant changes are grouped below.

**EVR Profile Storage Migration and Refactor:**

* Added a SQL migration (`migrate/sql/20260108000001_migrate_evr_profile_to_storage.sql`) to move EVR profile data from user metadata to a new `EVRProfile` storage collection, ensuring existing storage objects are not overwritten. Includes a reversible down migration.
* Refactored `EVRProfile` handling in `server/evr_account.go` by introducing the `EVRProfileStorage` type, implementing storage read/write logic, and updating profile loading/updating to use the new storage system with backward compatibility. [[1]](diffhunk://#diff-5aafc55cf53896c740b01cef50cdeadd599f942252f6451d06001668a8d368fbL49-R89) [[2]](diffhunk://#diff-5aafc55cf53896c740b01cef50cdeadd599f942252f6451d06001668a8d368fbR370-R378) [[3]](diffhunk://#diff-5aafc55cf53896c740b01cef50cdeadd599f942252f6451d06001668a8d368fbR389-R465)
* Updated constants for the new storage collection and key identifiers (`StorageCollectionEVRProfile`, `StorageKeyEVRProfile`).

**Game Server Logic Updates:**

* Changed lobby join flow in `server/evr_lobby_joinentrant.go` to send protobuf-encoded lobby session success messages using the new envelope format, improving protocol consistency.
* Updated server-side profile caching to use the new storage-based profile system.
* Modified match leave logic in `server/evr_match.go` to send protobuf-encoded reject messages and simplified early quit tracking for public matches. [[1]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL623-R626) [[2]](diffhunk://#diff-c8643a6b5d20c95cec4b012972fc0f1013f0305eae14abec73553f609f6fc18dL712-R736)

**Discord Bot Improvements:**

* Improved ephemeral moderator feedback in the Discord bot's kick player handler, sending the same embed as an ephemeral response and tracking whether it's sent. [[1]](diffhunk://#diff-8cf4f2e7f039326df1bf884ffcd8eaf0c380e8161ac26ad5489260a6a1c7c766R737) [[2]](diffhunk://#diff-8cf4f2e7f039326df1bf884ffcd8eaf0c380e8161ac26ad5489260a6a1c7c766R917-R935) [[3]](diffhunk://#diff-8cf4f2e7f039326df1bf884ffcd8eaf0c380e8161ac26ad5489260a6a1c7c766L995-R1015)
* Enhanced profile request handling to conditionally add a player lookup button only if the base URL is properly configured, and always attach the raw profile data as a file. [[1]](diffhunk://#diff-0060402b80c13a370fd489cc86c54c93cf6fc37ce1fd62e443542e1aa1dcaf10L882-R898) [[2]](diffhunk://#diff-0060402b80c13a370fd489cc86c54c93cf6fc37ce1fd62e443542e1aa1dcaf10L900-R914)
* Removed unused `ProfileCache` from the Discord bot constructor and struct. [[1]](diffhunk://#diff-b64463a5f4ca8d225acb00bbb345404462161433e8c3f1c518a95d1cc6b163b6L58) [[2]](diffhunk://#diff-b64463a5f4ca8d225acb00bbb345404462161433e8c3f1c518a95d1cc6b163b6L81-R80) [[3]](diffhunk://#diff-b64463a5f4ca8d225acb00bbb345404462161433e8c3f1c518a95d1cc6b163b6L95)

**Miscellaneous:**

* Added missing protobuf import for new message types in the lobby join flow.

These changes collectively modernize profile data management, improve protocol robustness, and enhance Discord moderation and user lookup features.