### PR TITLE
Implement detailed early quit history tracking and RPC for player quit statistics

### DIFF
--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -240,7 +240,7 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 		}).Debug("Failed to load early quit history for forgiveness")
 	} else {
 		// Forgive the most recent quit for the last match they quit from
-		if eqconfig.LastEarlyQuitMatchID.IsNil() || history.ForgiveQuit(eqconfig.LastEarlyQuitMatchID) {
+		if !eqconfig.LastEarlyQuitMatchID.IsNil() && history.ForgiveQuit(eqconfig.LastEarlyQuitMatchID) {
 			if err := StorableWrite(ctx, nk, userID, history); err != nil {
 				logger.WithFields(map[string]any{
 					"uid":   userID,

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -231,6 +231,30 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 		return
 	}
 
+	// Load and update the detailed quit history to mark the last quit as forgiven
+	history := NewEarlyQuitHistory(userID)
+	if err := StorableRead(ctx, nk, userID, history, false); err != nil {
+		logger.WithFields(map[string]any{
+			"uid":   userID,
+			"error": err,
+		}).Debug("Failed to load early quit history for forgiveness")
+	} else {
+		// Forgive the most recent quit for the last match they quit from
+		if eqconfig.LastEarlyQuitMatchID.IsNil() || history.ForgiveQuit(eqconfig.LastEarlyQuitMatchID) {
+			if err := StorableWrite(ctx, nk, userID, history); err != nil {
+				logger.WithFields(map[string]any{
+					"uid":   userID,
+					"error": err,
+				}).Warn("Failed to write forgiven early quit history")
+			} else {
+				logger.WithFields(map[string]any{
+					"uid":      userID,
+					"match_id": eqconfig.LastEarlyQuitMatchID.String(),
+				}).Debug("Marked early quit as forgiven in detailed history")
+			}
+		}
+	}
+
 	// Reduce early quit penalty by one level without inflating match completion statistics.
 	// This forgives the early quit since the player logged out entirely rather than
 	// just leaving the match to join another.

--- a/server/evr_earlyquit_detailed.go
+++ b/server/evr_earlyquit_detailed.go
@@ -1,0 +1,256 @@
+package server
+
+import (
+	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+const (
+	StorageCollectionEarlyQuitHistory = "EarlyQuitHistory"
+	StorageKeyEarlyQuitHistory        = "history"
+)
+
+// QuitType represents the type of quit
+type QuitType string
+
+const (
+	QuitTypeEarly   QuitType = "early"   // Left during active gameplay
+	QuitTypePregame QuitType = "pregame" // Left before game started
+)
+
+// QuitRecord represents a single early quit event with full context
+type QuitRecord struct {
+	// Event info
+	MatchID    MatchID   `json:"match_id"`
+	QuitTime   time.Time `json:"quit_time"`
+	QuitType   QuitType  `json:"quit_type"`
+	Forgiven   bool      `json:"forgiven,omitempty"`    // True if quit was forgiven due to full logout
+	ForgivenAt time.Time `json:"forgiven_at,omitempty"` // When the quit was forgiven
+
+	// Player info at time of quit
+	Username    string    `json:"username,omitempty"`
+	DisplayName string    `json:"display_name,omitempty"`
+	Team        TeamIndex `json:"team"`
+	SessionID   string    `json:"session_id,omitempty"`
+
+	// Join state
+	JoinTime             time.Time     `json:"join_time"`
+	ClockRemainingAtJoin time.Duration `json:"clock_remaining_at_join_ns"`
+	GameDurationAtJoin   time.Duration `json:"game_duration_at_join_ns"`
+	ScoresAtJoin         [2]int        `json:"scores_at_join"`
+	TeamSizesAtJoin      [2]int        `json:"team_sizes_at_join"`
+
+	// Quit state
+	ClockRemainingAtQuit time.Duration `json:"clock_remaining_at_quit_ns"`
+	GameDurationAtQuit   time.Duration `json:"game_duration_at_quit_ns"`
+	ScoresAtQuit         [2]int        `json:"scores_at_quit"`
+	TeamSizesAtQuit      [2]int        `json:"team_sizes_at_quit"`
+	DisconnectsAtQuit    int           `json:"disconnects_at_quit"`
+
+	// Match context
+	Mode      string `json:"mode"`
+	Level     string `json:"level,omitempty"`
+	LobbyType string `json:"lobby_type"`
+	GroupID   string `json:"group_id,omitempty"`
+
+	// Additional context
+	PartyID         string   `json:"party_id,omitempty"`
+	PartySize       int      `json:"party_size"`
+	PingBand        PingBand `json:"ping_band"`
+	WasLosingAtQuit bool     `json:"was_losing_at_quit"`
+
+	// Hazard tracking
+	TeamHazardEvents       int  `json:"team_hazard_events"`
+	TeamConsecutiveHazards int  `json:"team_consecutive_hazards"`
+	IsTeamWipeMember       bool `json:"is_team_wipe_member,omitempty"`
+}
+
+// EarlyQuitHistory tracks detailed quit history for a player
+type EarlyQuitHistory struct {
+	UserID  string       `json:"user_id"`
+	Records []QuitRecord `json:"records"`
+
+	version string
+}
+
+func NewEarlyQuitHistory(userID string) *EarlyQuitHistory {
+	return &EarlyQuitHistory{
+		UserID:  userID,
+		Records: make([]QuitRecord, 0),
+	}
+}
+
+func (h *EarlyQuitHistory) StorageMeta() StorableMetadata {
+	return StorableMetadata{
+		Collection:      StorageCollectionEarlyQuitHistory,
+		Key:             StorageKeyEarlyQuitHistory,
+		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+		Version:         h.version,
+	}
+}
+
+func (h *EarlyQuitHistory) SetStorageMeta(meta StorableMetadata) {
+	h.version = meta.Version
+}
+
+func (h *EarlyQuitHistory) GetStorageVersion() string {
+	return h.version
+}
+
+// AddQuitRecord adds a new quit record
+func (h *EarlyQuitHistory) AddQuitRecord(record QuitRecord) {
+	h.Records = append(h.Records, record)
+}
+
+// ForgiveQuit marks a quit as forgiven (player logged out completely)
+func (h *EarlyQuitHistory) ForgiveQuit(matchID MatchID) bool {
+	// Find the most recent unforgiven quit for this match
+	for i := len(h.Records) - 1; i >= 0; i-- {
+		if h.Records[i].MatchID.UUID == matchID.UUID && !h.Records[i].Forgiven {
+			h.Records[i].Forgiven = true
+			h.Records[i].ForgivenAt = time.Now().UTC()
+			return true
+		}
+	}
+	return false
+}
+
+// GetUnforgivenQuitsSince returns unforgiven quits since the given time
+func (h *EarlyQuitHistory) GetUnforgivenQuitsSince(since time.Time) []QuitRecord {
+	var quits []QuitRecord
+	for _, record := range h.Records {
+		if !record.Forgiven && record.QuitTime.After(since) {
+			quits = append(quits, record)
+		}
+	}
+	return quits
+}
+
+// GetRecentQuits returns all quits (forgiven or not) within the given duration
+func (h *EarlyQuitHistory) GetRecentQuits(duration time.Duration) []QuitRecord {
+	since := time.Now().Add(-duration)
+	var quits []QuitRecord
+	for _, record := range h.Records {
+		if record.QuitTime.After(since) {
+			quits = append(quits, record)
+		}
+	}
+	return quits
+}
+
+// CountUnforgivenQuits returns the count of unforgiven quits
+func (h *EarlyQuitHistory) CountUnforgivenQuits() int {
+	count := 0
+	for _, record := range h.Records {
+		if !record.Forgiven {
+			count++
+		}
+	}
+	return count
+}
+
+// CountQuitsByType returns counts of quits by type (optionally only unforgiven)
+func (h *EarlyQuitHistory) CountQuitsByType(unforgivenOnly bool) (early, pregame int) {
+	for _, record := range h.Records {
+		if unforgivenOnly && record.Forgiven {
+			continue
+		}
+		switch record.QuitType {
+		case QuitTypeEarly:
+			early++
+		case QuitTypePregame:
+			pregame++
+		}
+	}
+	return
+}
+
+// GetQuitRate returns the quit rate based on unforgiven quits
+// Returns quits / (quits + completed matches from EarlyQuitConfig)
+func (h *EarlyQuitHistory) GetQuitRate(completedMatches int32) float64 {
+	quits := h.CountUnforgivenQuits()
+	total := quits + int(completedMatches)
+	if total == 0 {
+		return 0.0
+	}
+	return float64(quits) / float64(total)
+}
+
+// PruneOldRecords removes records older than the given duration
+// Returns the number of records removed
+func (h *EarlyQuitHistory) PruneOldRecords(maxAge time.Duration) int {
+	cutoff := time.Now().Add(-maxAge)
+	originalLen := len(h.Records)
+
+	// Keep only records newer than cutoff
+	kept := make([]QuitRecord, 0, originalLen)
+	for _, record := range h.Records {
+		if record.QuitTime.After(cutoff) {
+			kept = append(kept, record)
+		}
+	}
+
+	h.Records = kept
+	return originalLen - len(kept)
+}
+
+// CreateQuitRecordFromParticipation creates a QuitRecord from PlayerParticipation and match state
+func CreateQuitRecordFromParticipation(state *MatchLabel, participation *PlayerParticipation) QuitRecord {
+	if state == nil || participation == nil {
+		return QuitRecord{}
+	}
+
+	// Determine quit type based on game duration
+	quitType := QuitTypeEarly
+	if participation.GameDurationAtLeave < 30*time.Second {
+		quitType = QuitTypePregame
+	}
+
+	// Determine if player was losing at quit
+	wasLosing := false
+	if participation.Team == BlueTeam {
+		wasLosing = participation.ScoresAtLeave[0] < participation.ScoresAtLeave[1]
+	} else if participation.Team == OrangeTeam {
+		wasLosing = participation.ScoresAtLeave[1] < participation.ScoresAtLeave[0]
+	}
+
+	return QuitRecord{
+		MatchID:  state.ID,
+		QuitTime: participation.LeaveTime,
+		QuitType: quitType,
+		Forgiven: false,
+
+		Username:    participation.Username,
+		DisplayName: participation.DisplayName,
+		Team:        participation.Team,
+		SessionID:   participation.SessionID,
+
+		JoinTime:             participation.JoinTime,
+		ClockRemainingAtJoin: participation.ClockRemainingAtJoin,
+		GameDurationAtJoin:   participation.GameDurationAtJoin,
+		ScoresAtJoin:         participation.ScoresAtJoin,
+		TeamSizesAtJoin:      participation.TeamSizesAtJoin,
+
+		ClockRemainingAtQuit: participation.ClockRemainingAtLeave,
+		GameDurationAtQuit:   participation.GameDurationAtLeave,
+		ScoresAtQuit:         participation.ScoresAtLeave,
+		TeamSizesAtQuit:      participation.TeamSizesAtLeave,
+		DisconnectsAtQuit:    participation.DisconnectsAtLeave,
+
+		Mode:      state.Mode.String(),
+		Level:     state.Level.String(),
+		LobbyType: state.LobbyType.String(),
+		GroupID:   state.GetGroupID().String(),
+
+		PartyID:         participation.PartyID,
+		PartySize:       participation.PartySize,
+		PingBand:        participation.PingBand,
+		WasLosingAtQuit: wasLosing,
+
+		TeamHazardEvents:       participation.TeamHazardEvents,
+		TeamConsecutiveHazards: participation.TeamConsecutiveHazards,
+		IsTeamWipeMember:       participation.IsTeamWipeMember,
+	}
+}

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -126,6 +126,7 @@ func InitializeEvrRuntimeModule(ctx context.Context, logger runtime.Logger, db *
 		"forcecheck":                    CheckForceUserRPC,
 		"guildgroup":                    GuildGroupGetRPC,
 		"enforcement/kick":              EnforcementKickRPC,
+		"earlyquit/history":             EarlyQuitHistoryRPC,
 		//"/v1/storage/game/sourcedb/rad15/json/r14/loading_tips.json": StorageLoadingTipsRPC,
 	}
 	for name, rpc := range rpcs {

--- a/server/evr_runtime_rpc_earlyquit_history.go
+++ b/server/evr_runtime_rpc_earlyquit_history.go
@@ -29,8 +29,8 @@ type QuitSummary struct {
 	TotalQuits          int     `json:"total_quits"`
 	UnforgivenQuits     int     `json:"unforgiven_quits"`
 	ForgivenQuits       int     `json:"forgiven_quits"`
-	EarlyQuits          int     `json:"early_quits"`
-	PregameQuits        int     `json:"pregame_quits"`
+	EarlyQuits          int     `json:"early_quits"`   // Total early quits (including forgiven)
+	PregameQuits        int     `json:"pregame_quits"` // Total pregame quits (including forgiven)
 	CurrentPenaltyLevel int32   `json:"current_penalty_level"`
 	CompletedMatches    int32   `json:"completed_matches"`
 	QuitRate            float64 `json:"quit_rate"`
@@ -128,14 +128,8 @@ func EarlyQuitHistoryRPC(ctx context.Context, logger runtime.Logger, db *sql.DB,
 		}
 	}
 
-	// Estimate recent completions (this is approximate since we don't track completion timestamps)
-	recentCompletions := int32(0)
-	if eqconfig.TotalCompletedMatches > 0 {
-		// Rough estimate: assume completions are distributed evenly over time
-		totalDays := 90.0 // We keep 90 days of history
-		recentDays := 7.0
-		recentCompletions = int32(float64(eqconfig.TotalCompletedMatches) * (recentDays / totalDays))
-	}
+	// Get actual recent completions from history
+	recentCompletions := int32(len(history.GetRecentCompletions(7 * 24 * time.Hour)))
 
 	recentTotal := recentQuitCount + int(recentCompletions)
 	recentQuitRate := 0.0

--- a/server/evr_runtime_rpc_earlyquit_history.go
+++ b/server/evr_runtime_rpc_earlyquit_history.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"go.uber.org/zap"
+)
+
+// EarlyQuitHistoryRequest is the request payload for the early quit history RPC
+type EarlyQuitHistoryRequest struct {
+	UserID          string `json:"user_id,omitempty"`          // Target user ID (optional, defaults to caller)
+	IncludeForgiven bool   `json:"include_forgiven,omitempty"` // Include forgiven quits in results
+	DaysBack        int    `json:"days_back,omitempty"`        // Only show quits from last N days (0 = all)
+}
+
+// EarlyQuitHistoryResponse contains detailed quit history and statistics
+type EarlyQuitHistoryResponse struct {
+	UserID  string       `json:"user_id"`
+	Summary QuitSummary  `json:"summary"`
+	Records []QuitRecord `json:"records"`
+}
+
+// QuitSummary provides aggregate statistics
+type QuitSummary struct {
+	TotalQuits          int     `json:"total_quits"`
+	UnforgivenQuits     int     `json:"unforgiven_quits"`
+	ForgivenQuits       int     `json:"forgiven_quits"`
+	EarlyQuits          int     `json:"early_quits"`
+	PregameQuits        int     `json:"pregame_quits"`
+	CurrentPenaltyLevel int32   `json:"current_penalty_level"`
+	CompletedMatches    int32   `json:"completed_matches"`
+	QuitRate            float64 `json:"quit_rate"`
+	MatchmakingTier     int32   `json:"matchmaking_tier"`
+
+	// Recent statistics (last 7 days)
+	RecentQuits       int     `json:"recent_quits_7d"`
+	RecentCompletions int32   `json:"recent_completions_7d"`
+	RecentQuitRate    float64 `json:"recent_quit_rate_7d"`
+}
+
+// EarlyQuitHistoryRPC returns detailed early quit history for a player
+func EarlyQuitHistoryRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	var request EarlyQuitHistoryRequest
+	if err := json.Unmarshal([]byte(payload), &request); err != nil {
+		return "", runtime.NewError("Invalid request payload", StatusInvalidArgument)
+	}
+
+	// Get the caller's user ID from context
+	callerUserID, ok := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
+	if !ok || callerUserID == "" {
+		return "", runtime.NewError("User ID not found in context", StatusUnauthenticated)
+	}
+
+	// Determine target user ID
+	targetUserID := request.UserID
+	if targetUserID == "" {
+		targetUserID = callerUserID
+	}
+
+	// Check if caller has permission to view other users' history
+	if targetUserID != callerUserID {
+		// Check if caller is a global operator
+		isGlobalOperator, err := CheckSystemGroupMembership(ctx, db, callerUserID, GroupGlobalOperators)
+		if err != nil {
+			logger.Error("Failed to check global operator status", zap.Error(err))
+			return "", runtime.NewError("Failed to check permissions", StatusInternalError)
+		}
+		if !isGlobalOperator {
+			return "", runtime.NewError("Only global operators can view other users' quit history", StatusPermissionDenied)
+		}
+	}
+
+	// Load early quit config for summary stats
+	eqconfig := NewEarlyQuitConfig()
+	if err := StorableRead(ctx, nk, targetUserID, eqconfig, false); err != nil {
+		logger.Debug("Failed to load early quit config, using defaults", zap.Error(err))
+	}
+
+	// Load detailed quit history
+	history := NewEarlyQuitHistory(targetUserID)
+	if err := StorableRead(ctx, nk, targetUserID, history, false); err != nil {
+		logger.Debug("No early quit history found, returning empty", zap.Error(err))
+		// Return empty history rather than error
+		history = NewEarlyQuitHistory(targetUserID)
+	}
+
+	// Filter records if needed
+	records := history.Records
+	if request.DaysBack > 0 {
+		cutoff := time.Now().Add(-time.Duration(request.DaysBack) * 24 * time.Hour)
+		filtered := make([]QuitRecord, 0)
+		for _, record := range records {
+			if record.QuitTime.After(cutoff) {
+				filtered = append(filtered, record)
+			}
+		}
+		records = filtered
+	}
+
+	if !request.IncludeForgiven {
+		filtered := make([]QuitRecord, 0)
+		for _, record := range records {
+			if !record.Forgiven {
+				filtered = append(filtered, record)
+			}
+		}
+		records = filtered
+	}
+
+	// Calculate summary statistics
+	totalQuits := len(history.Records)
+	unforgivenQuits := history.CountUnforgivenQuits()
+	forgivenQuits := totalQuits - unforgivenQuits
+	earlyQuits, pregameQuits := history.CountQuitsByType(false)
+
+	quitRate := history.GetQuitRate(eqconfig.TotalCompletedMatches)
+
+	// Calculate recent statistics (last 7 days)
+	recentQuits := history.GetRecentQuits(7 * 24 * time.Hour)
+	recentQuitCount := 0
+	for _, record := range recentQuits {
+		if !record.Forgiven {
+			recentQuitCount++
+		}
+	}
+
+	// Estimate recent completions (this is approximate since we don't track completion timestamps)
+	recentCompletions := int32(0)
+	if eqconfig.TotalCompletedMatches > 0 {
+		// Rough estimate: assume completions are distributed evenly over time
+		totalDays := 90.0 // We keep 90 days of history
+		recentDays := 7.0
+		recentCompletions = int32(float64(eqconfig.TotalCompletedMatches) * (recentDays / totalDays))
+	}
+
+	recentTotal := recentQuitCount + int(recentCompletions)
+	recentQuitRate := 0.0
+	if recentTotal > 0 {
+		recentQuitRate = float64(recentQuitCount) / float64(recentTotal)
+	}
+
+	summary := QuitSummary{
+		TotalQuits:          totalQuits,
+		UnforgivenQuits:     unforgivenQuits,
+		ForgivenQuits:       forgivenQuits,
+		EarlyQuits:          earlyQuits,
+		PregameQuits:        pregameQuits,
+		CurrentPenaltyLevel: eqconfig.EarlyQuitPenaltyLevel,
+		CompletedMatches:    eqconfig.TotalCompletedMatches,
+		QuitRate:            quitRate,
+		MatchmakingTier:     eqconfig.MatchmakingTier,
+		RecentQuits:         recentQuitCount,
+		RecentCompletions:   recentCompletions,
+		RecentQuitRate:      recentQuitRate,
+	}
+
+	response := EarlyQuitHistoryResponse{
+		UserID:  targetUserID,
+		Summary: summary,
+		Records: records,
+	}
+
+	responseData, err := json.Marshal(response)
+	if err != nil {
+		logger.Error("Failed to marshal response", zap.Error(err))
+		return "", runtime.NewError("Failed to create response", StatusInternalError)
+	}
+
+	return string(responseData), nil
+}


### PR DESCRIPTION
Introduce a new RPC for retrieving detailed early quit history and statistics for players. Enhance quit tracking by saving detailed records and providing summary statistics, including forgiven and unforgiven quits. This update improves player insights into their quitting behavior and penalties.