### PR TITLE
feat: add early quit penalty notifications via SNS messages

### DIFF
--- a/server/evr/core_account.go
+++ b/server/evr/core_account.go
@@ -22,7 +22,7 @@ type ClientProfile struct {
 	Customization      *Customization    `json:"customization,omitempty"`
 	Social             ClientSocial      `json:"social,omitempty"`
 	NewUnlocks         []int64           `json:"newunlocks"`
-	//EarlyQuitFeatures  EarlyQuitFeatures `json:"earlyquit"` // Early quit features
+	EarlyQuitFeatures  EarlyQuitFeatures `json:"earlyquit"` // Early quit features
 }
 
 type EarlyQuitFeatures struct {

--- a/server/evr/core_packet.go
+++ b/server/evr/core_packet.go
@@ -83,8 +83,9 @@ var (
 		0xfb772a4221fc8d70: (*LoggedInUserProfileRequest)(nil),
 		0xfcced6f169822bb8: (*DocumentRequest)(nil),
 		0xff71856af7e0fbd9: (*LobbyEntrantsV0)(nil),
-		//0x080495a43a6b7251: (*EarlyQuitConfig)(nil),
-
+		0x080495a43a6b7251: (*EarlyQuitServiceConfig)(nil),
+		0x1f81b54c35788eaa: (*SNSEarlyQuitUpdateNotification)(nil),
+		0xd9a955895caccac3: (*SNSEarlyQuitFeatureFlags)(nil),
 		// Custom messages
 		0x9ee5107d9e29fd63: (*NEVRProtobufMessageV1)(nil),
 		0xc6b3710cd9c4ef47: (*NEVRProtobufJSONMessageV1)(nil),

--- a/server/evr/core_packet_types.go
+++ b/server/evr/core_packet_types.go
@@ -191,6 +191,12 @@ func NewMessageFromHash(hash uint64) Message {
 		return &DocumentRequest{}
 	case 0xff71856af7e0fbd9:
 		return &LobbyEntrantsV0{}
+	case 0x080495a43a6b7251:
+		return &EarlyQuitServiceConfig{}
+	case 0x1f81b54c35788eaa:
+		return &SNSEarlyQuitUpdateNotification{}
+	case 0xd9a955895caccac3:
+		return &SNSEarlyQuitFeatureFlags{}
 	case 0x9ee5107d9e29fd63:
 		return &NEVRProtobufMessageV1{}
 	case 0xc6b3710cd9c4ef47:

--- a/server/evr/login_earlyquitconfig.go
+++ b/server/evr/login_earlyquitconfig.go
@@ -1,6 +1,9 @@
 package evr
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // EarlyQuitConfig is the player's current early quit penalty state (sent in profile)
 type EarlyQuitConfig struct {
@@ -12,6 +15,14 @@ type EarlyQuitConfig struct {
 
 func (c EarlyQuitConfig) PenaltyTimestampAsTime() time.Time {
 	return time.Unix(c.PenaltyTimestamp, 0)
+}
+
+func (m EarlyQuitConfig) Token() string {
+	return "SNSEarlyQuitConfig"
+}
+
+func (m *EarlyQuitConfig) Symbol() Symbol {
+	return ToSymbol(m.Token())
 }
 
 // EarlyQuitPenaltyLevelConfig defines a single penalty tier configuration
@@ -36,6 +47,31 @@ type EarlyQuitSteadyPlayerLevelConfig struct {
 type EarlyQuitServiceConfig struct {
 	PenaltyLevels      []EarlyQuitPenaltyLevelConfig      `json:"penalty_levels"`
 	SteadyPlayerLevels []EarlyQuitSteadyPlayerLevelConfig `json:"steady_player_levels"`
+}
+
+func (m EarlyQuitServiceConfig) Token() string {
+	return "SNSEarlyQuitConfig"
+}
+
+func (m *EarlyQuitServiceConfig) Symbol() Symbol {
+	return ToSymbol(m.Token())
+}
+
+func (m *EarlyQuitServiceConfig) String() string {
+	return fmt.Sprintf("%s(penalty_levels=%d, steady_levels=%d)",
+		m.Token(), len(m.PenaltyLevels), len(m.SteadyPlayerLevels))
+}
+
+func (m *EarlyQuitServiceConfig) Stream(s *EasyStream) error {
+	return s.StreamJson(m, false, ZlibCompression)
+}
+
+// NewSNSEarlyQuitConfig creates a new SNS message for early quit config
+func NewSNSEarlyQuitConfig(config *EarlyQuitServiceConfig) *EarlyQuitServiceConfig {
+	if config == nil {
+		config = DefaultEarlyQuitServiceConfig()
+	}
+	return config
 }
 
 // DefaultEarlyQuitServiceConfig returns the default early quit config with max penalty active

--- a/server/evr/login_earlyquitfeatureflags.go
+++ b/server/evr/login_earlyquitfeatureflags.go
@@ -1,0 +1,62 @@
+package evr
+
+import (
+	"fmt"
+)
+
+// SNSEarlyQuitFeatureFlags represents the feature flags message for early quit system
+// Server → Client: Controls which early quit features are enabled/disabled
+type SNSEarlyQuitFeatureFlags struct {
+	Enabled             bool     `json:"enabled"`                        // Master enable/disable
+	EnableMMLockout     bool     `json:"enable_mm_lockout"`              // Matchmaking lockout active
+	EnableSpawnLock     bool     `json:"enable_spawn_lock"`              // Spawn lock penalties active
+	EnableAutoReport    bool     `json:"enable_auto_report"`             // Automatic reporting active
+	EnableUICountdown   bool     `json:"enable_ui_countdown"`            // Show countdown timer in UI
+	EnableQueueBlocking bool     `json:"enable_queue_blocking"`          // Block queue during penalty
+	SupportedRegions    []string `json:"supported_regions"`              // Regions where system applies
+	SupportedGameModes  []string `json:"supported_game_modes"`           // Game modes where system applies
+	MaxPenaltyLevel     int32    `json:"max_penalty_level"`              // Max penalty tier
+	PenaltyDecayDays    int32    `json:"penalty_decay_days"`             // Days before penalties reset
+	TierDownGracePeriod int32    `json:"tier_down_grace_period_seconds"` // Grace period for tier restoration
+}
+
+func (m SNSEarlyQuitFeatureFlags) Token() string {
+	return "SNSEarlyQuitFeatureFlags"
+}
+
+func (m *SNSEarlyQuitFeatureFlags) Symbol() Symbol {
+	return ToSymbol(m.Token())
+}
+
+// DefaultEarlyQuitFeatureFlags returns the default enabled feature flags
+func DefaultEarlyQuitFeatureFlags() *SNSEarlyQuitFeatureFlags {
+	return &SNSEarlyQuitFeatureFlags{
+		Enabled:             true,
+		EnableMMLockout:     true,
+		EnableSpawnLock:     true,
+		EnableAutoReport:    true,
+		EnableUICountdown:   true,
+		EnableQueueBlocking: true,
+		SupportedRegions: []string{
+			"us-east",
+			"us-west",
+			"eu-west",
+			"ap-southeast",
+		},
+		SupportedGameModes: []string{
+			"echo_arena",
+		},
+		MaxPenaltyLevel:     3,
+		PenaltyDecayDays:    30,
+		TierDownGracePeriod: 86400, // 1 day in seconds
+	}
+}
+
+func (m *SNSEarlyQuitFeatureFlags) String() string {
+	return fmt.Sprintf("%s(enabled=%v, regions=%v, modes=%v)",
+		m.Token(), m.Enabled, m.SupportedRegions, m.SupportedGameModes)
+}
+
+func (m *SNSEarlyQuitFeatureFlags) Stream(s *EasyStream) error {
+	return s.StreamJson(m, false, ZlibCompression)
+}

--- a/server/evr/login_earlyquitupdatenotification.go
+++ b/server/evr/login_earlyquitupdatenotification.go
@@ -1,0 +1,132 @@
+package evr
+
+import (
+	"fmt"
+	"time"
+)
+
+// SNSEarlyQuitUpdateNotification represents penalty status update notifications
+// Server → Client: Sent when a penalty is applied, expires, or player tier changes
+type SNSEarlyQuitUpdateNotification struct {
+	EventType       UpdateNotificationType `json:"event_type"`         // Type of penalty event
+	PenaltyLevel    int32                  `json:"penalty_level"`      // Current penalty tier
+	DurationSeconds int32                  `json:"duration_seconds"`   // Lockout duration
+	ExpiresAt       int64                  `json:"expires_at"`         // Unix timestamp when penalty expires
+	Reason          string                 `json:"reason"`             // Human-readable reason
+	PreviousTier    int32                  `json:"previous_tier"`      // For tier changes
+	NewTier         int32                  `json:"new_tier"`           // For tier changes
+	MatchID         string                 `json:"match_id,omitempty"` // Match that triggered the penalty
+}
+
+// UpdateNotificationType indicates what type of penalty event occurred
+type UpdateNotificationType string
+
+const (
+	// UpdateNotificationPenaltyApplied: Player received a new penalty (early quit detected)
+	UpdateNotificationPenaltyApplied UpdateNotificationType = "penalty_applied"
+	// UpdateNotificationPenaltyExpired: Player's penalty has expired
+	UpdateNotificationPenaltyExpired UpdateNotificationType = "penalty_expired"
+	// UpdateNotificationTierDegraded: Player moved to worse tier
+	UpdateNotificationTierDegraded UpdateNotificationType = "tier_degraded"
+	// UpdateNotificationTierRestored: Player moved back to better tier
+	UpdateNotificationTierRestored UpdateNotificationType = "tier_restored"
+	// UpdateNotificationLockoutActive: Matchmaking lockout is active
+	UpdateNotificationLockoutActive UpdateNotificationType = "lockout_active"
+	// UpdateNotificationLockoutCleared: Matchmaking lockout has been cleared
+	UpdateNotificationLockoutCleared UpdateNotificationType = "lockout_cleared"
+)
+
+func (m SNSEarlyQuitUpdateNotification) Token() string {
+	return "SNSEarlyQuitUpdateNotification"
+}
+
+func (m *SNSEarlyQuitUpdateNotification) Symbol() Symbol {
+	return ToSymbol(m.Token())
+}
+
+func (m *SNSEarlyQuitUpdateNotification) String() string {
+	return fmt.Sprintf("%s(event=%s, penalty_level=%d, expires_in=%ds)",
+		m.Token(), m.EventType, m.PenaltyLevel, m.RemainingSeconds())
+}
+
+func (m *SNSEarlyQuitUpdateNotification) Stream(s *EasyStream) error {
+	return s.StreamJson(m, false, ZlibCompression)
+}
+
+// NewPenaltyAppliedNotification creates a penalty applied notification
+func NewPenaltyAppliedNotification(penaltyLevel int32, durationSeconds int32, reason string) *SNSEarlyQuitUpdateNotification {
+	expiresAt := time.Now().Add(time.Duration(durationSeconds) * time.Second).Unix()
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:       UpdateNotificationPenaltyApplied,
+		PenaltyLevel:    penaltyLevel,
+		DurationSeconds: durationSeconds,
+		ExpiresAt:       expiresAt,
+		Reason:          reason,
+	}
+}
+
+// NewPenaltyExpiredNotification creates a penalty expired notification
+func NewPenaltyExpiredNotification() *SNSEarlyQuitUpdateNotification {
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:       UpdateNotificationPenaltyExpired,
+		DurationSeconds: 0,
+		ExpiresAt:       time.Now().Unix(),
+		Reason:          "Penalty period has expired",
+	}
+}
+
+// NewTierDegradedNotification creates a tier degraded notification
+func NewTierDegradedNotification(oldTier, newTier int32, reason string) *SNSEarlyQuitUpdateNotification {
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:    UpdateNotificationTierDegraded,
+		PreviousTier: oldTier,
+		NewTier:      newTier,
+		Reason:       reason,
+	}
+}
+
+// NewTierRestoredNotification creates a tier restored notification
+func NewTierRestoredNotification(oldTier, newTier int32, reason string) *SNSEarlyQuitUpdateNotification {
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:    UpdateNotificationTierRestored,
+		PreviousTier: oldTier,
+		NewTier:      newTier,
+		Reason:       reason,
+	}
+}
+
+// NewLockoutActiveNotification creates a lockout active notification
+func NewLockoutActiveNotification(penaltyLevel int32, durationSeconds int32) *SNSEarlyQuitUpdateNotification {
+	expiresAt := time.Now().Add(time.Duration(durationSeconds) * time.Second).Unix()
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:       UpdateNotificationLockoutActive,
+		PenaltyLevel:    penaltyLevel,
+		DurationSeconds: durationSeconds,
+		ExpiresAt:       expiresAt,
+		Reason:          "Matchmaking lockout is active",
+	}
+}
+
+// NewLockoutClearedNotification creates a lockout cleared notification
+func NewLockoutClearedNotification() *SNSEarlyQuitUpdateNotification {
+	return &SNSEarlyQuitUpdateNotification{
+		EventType:       UpdateNotificationLockoutCleared,
+		DurationSeconds: 0,
+		ExpiresAt:       time.Now().Unix(),
+		Reason:          "Matchmaking lockout has been cleared",
+	}
+}
+
+// ExpiresAtTime returns the expiry time as a time.Time object
+func (n *SNSEarlyQuitUpdateNotification) ExpiresAtTime() time.Time {
+	return time.Unix(n.ExpiresAt, 0)
+}
+
+// RemainingSeconds returns the seconds until the penalty expires (or 0 if already expired)
+func (n *SNSEarlyQuitUpdateNotification) RemainingSeconds() int32 {
+	remaining := time.Until(n.ExpiresAtTime()).Seconds()
+	if remaining < 0 {
+		return 0
+	}
+	return int32(remaining)
+}

--- a/server/evr_early_quit_message_trigger.go
+++ b/server/evr_early_quit_message_trigger.go
@@ -1,0 +1,380 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap"
+)
+
+// SNSEarlyQuitMessageTrigger manages sending early quit SNS messages to connected players
+type SNSEarlyQuitMessageTrigger struct {
+	sync.Mutex
+	pipeline *EvrPipeline
+	logger   *zap.Logger
+	nk       runtime.NakamaModule
+	db       *sql.DB
+	stopCh   chan struct{}
+	stopped  bool
+}
+
+// NewSNSEarlyQuitMessageTrigger creates a new message trigger
+func NewSNSEarlyQuitMessageTrigger(pipeline *EvrPipeline, logger *zap.Logger, nk runtime.NakamaModule, db *sql.DB) *SNSEarlyQuitMessageTrigger {
+	return &SNSEarlyQuitMessageTrigger{
+		pipeline: pipeline,
+		logger:   logger,
+		nk:       nk,
+		db:       db,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// getEvrSessions retrieves all EVR sessions for a given user
+func (t *SNSEarlyQuitMessageTrigger) getEvrSessions(userID string) []*sessionWS {
+	var sessions []*sessionWS
+	parsedUserID, err := uuid.FromString(userID)
+	if err != nil {
+		t.logger.Warn("Invalid user ID", zap.String("user_id", userID), zap.Error(err))
+		return sessions
+	}
+
+	t.pipeline.sessionRegistry.Range(func(session Session) bool {
+		if session.UserID() == parsedUserID && session.Format() == SessionFormatEVR {
+			if evrSession, ok := session.(*sessionWS); ok {
+				sessions = append(sessions, evrSession)
+			}
+		}
+		return true
+	})
+
+	return sessions
+}
+
+// SendEvrMessage sends an EVR message directly to all EVR sessions of a user
+func (t *SNSEarlyQuitMessageTrigger) SendEvrMessage(userID string, message evr.Message) bool {
+	sessions := t.getEvrSessions(userID)
+	if len(sessions) == 0 {
+		t.logger.Debug("No EVR sessions found for user",
+			zap.String("user_id", userID))
+		return false
+	}
+
+	for _, session := range sessions {
+		if err := session.SendEvr(message); err != nil {
+			t.logger.Warn("Failed to send message to session",
+				zap.String("user_id", userID),
+				zap.String("session_id", session.ID().String()),
+				zap.Error(err))
+		}
+	}
+	return true
+}
+
+// SendEarlyQuitConfigOnLogin sends the SNSEarlyQuitConfig message when a player logs in
+// This provides the client with the current penalty tier configuration
+func (t *SNSEarlyQuitMessageTrigger) SendEarlyQuitConfigOnLogin(ctx context.Context, session *sessionWS) error {
+	if session == nil {
+		return nil
+	}
+
+	// Get the default configuration from service settings
+	config := evr.DefaultEarlyQuitServiceConfig()
+
+	// Create the SNS message wrapper
+	message := evr.NewSNSEarlyQuitConfig(config)
+
+	// Send to the player
+	if err := session.SendEvr(message); err != nil {
+		t.logger.Warn("Failed to send early quit config on login",
+			zap.String("user_id", session.userID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	t.logger.Debug("Sent SNSEarlyQuitConfig on login",
+		zap.String("user_id", session.userID.String()))
+
+	return nil
+}
+
+// SendFeatureFlagsOnLogin sends the SNSEarlyQuitFeatureFlags message when a player logs in
+// This controls which early quit features are enabled/disabled
+func (t *SNSEarlyQuitMessageTrigger) SendFeatureFlagsOnLogin(ctx context.Context, session *sessionWS) error {
+	if session == nil {
+		return nil
+	}
+
+	// Get the default feature flags
+	flags := evr.DefaultEarlyQuitFeatureFlags()
+
+	// Send to the player
+	if err := session.SendEvr(flags); err != nil {
+		t.logger.Warn("Failed to send early quit feature flags on login",
+			zap.String("user_id", session.userID.String()),
+			zap.Error(err))
+		return err
+	}
+
+	t.logger.Debug("Sent SNSEarlyQuitFeatureFlags on login",
+		zap.String("user_id", session.userID.String()))
+
+	return nil
+}
+
+// SendPenaltyAppliedNotification sends a notification when a player receives a new penalty
+// This is triggered when an early quit is recorded
+func (t *SNSEarlyQuitMessageTrigger) SendPenaltyAppliedNotification(ctx context.Context, userID string, penaltyLevel int32, durationSeconds int32, reason string) error {
+	// Create the notification
+	notification := evr.NewPenaltyAppliedNotification(penaltyLevel, durationSeconds, reason)
+
+	// Send to all sessions for this user
+	if found := t.SendEvrMessage(userID, notification); !found {
+		t.logger.Debug("Player not connected for penalty notification",
+			zap.String("user_id", userID))
+	}
+
+	t.logger.Debug("Sent penalty applied notification",
+		zap.String("user_id", userID),
+		zap.Int32("penalty_level", penaltyLevel),
+		zap.Int32("duration_seconds", durationSeconds))
+
+	return nil
+}
+
+// SendPenaltyExpiredNotification sends a notification when a player's penalty expires
+// This is triggered after the lockout duration has passed
+func (t *SNSEarlyQuitMessageTrigger) SendPenaltyExpiredNotification(ctx context.Context, userID string) error {
+	// Create the notification
+	notification := evr.NewPenaltyExpiredNotification()
+
+	// Send to all sessions for this user
+	if found := t.SendEvrMessage(userID, notification); !found {
+		t.logger.Debug("Player not connected for penalty expired notification",
+			zap.String("user_id", userID))
+	}
+
+	t.logger.Debug("Sent penalty expired notification",
+		zap.String("user_id", userID))
+
+	return nil
+}
+
+// SendTierChangeNotification sends a notification when a player's matchmaking tier changes
+// This is triggered when penalty causes tier degradation or completion causes tier restoration
+func (t *SNSEarlyQuitMessageTrigger) SendTierChangeNotification(ctx context.Context, userID string, oldTier, newTier int32, isDegradation bool) error {
+	var notification *evr.SNSEarlyQuitUpdateNotification
+	if isDegradation {
+		notification = evr.NewTierDegradedNotification(oldTier, newTier, "Your matchmaking tier has been downgraded due to early quitting.")
+	} else {
+		notification = evr.NewTierRestoredNotification(oldTier, newTier, "Your matchmaking tier has been restored.")
+	}
+
+	// Send to all sessions for this user
+	if found := t.SendEvrMessage(userID, notification); !found {
+		t.logger.Debug("Player not connected for tier change notification",
+			zap.String("user_id", userID))
+	}
+
+	eventType := "tier_degraded"
+	if !isDegradation {
+		eventType = "tier_restored"
+	}
+
+	t.logger.Debug("Sent tier change notification",
+		zap.String("user_id", userID),
+		zap.String("event_type", eventType),
+		zap.Int32("old_tier", oldTier),
+		zap.Int32("new_tier", newTier))
+
+	return nil
+}
+
+// SendLockoutNotification sends a notification when matchmaking lockout becomes active or clears
+func (t *SNSEarlyQuitMessageTrigger) SendLockoutNotification(ctx context.Context, userID string, penaltyLevel int32, durationSeconds int32, isActive bool) error {
+	var notification *evr.SNSEarlyQuitUpdateNotification
+	if isActive {
+		notification = evr.NewLockoutActiveNotification(penaltyLevel, durationSeconds)
+	} else {
+		notification = evr.NewLockoutClearedNotification()
+	}
+
+	// Send to all sessions for this user
+	if found := t.SendEvrMessage(userID, notification); !found {
+		t.logger.Debug("Player not connected for lockout notification",
+			zap.String("user_id", userID))
+	}
+
+	eventType := "lockout_active"
+	if !isActive {
+		eventType = "lockout_cleared"
+	}
+
+	t.logger.Debug("Sent lockout notification",
+		zap.String("user_id", userID),
+		zap.String("event_type", eventType),
+		zap.Int32("penalty_level", penaltyLevel),
+		zap.Int32("duration_seconds", durationSeconds))
+
+	return nil
+}
+
+// BroadcastFeatureFlagsUpdate sends updated feature flags to all connected players
+// This is used when feature flags change server-side
+func (t *SNSEarlyQuitMessageTrigger) BroadcastFeatureFlagsUpdate(ctx context.Context, flags *evr.SNSEarlyQuitFeatureFlags) error {
+	if flags == nil {
+		flags = evr.DefaultEarlyQuitFeatureFlags()
+	}
+
+	count := 0
+	// Broadcast to all connected EVR sessions
+	t.pipeline.sessionRegistry.Range(func(session Session) bool {
+		if session.Format() == SessionFormatEVR {
+			if evrSession, ok := session.(*sessionWS); ok {
+				if err := evrSession.SendEvr(flags); err != nil {
+					t.logger.Warn("Failed to broadcast feature flags update",
+						zap.String("user_id", session.UserID().String()),
+						zap.Error(err))
+				} else {
+					count++
+				}
+			}
+		}
+		return true
+	})
+
+	t.logger.Info("Broadcasted feature flags update to players", zap.Int("count", count))
+	return nil
+}
+
+// BroadcastConfigUpdate sends updated penalty configuration to all connected players
+// This is used when penalty tiers change server-side
+func (t *SNSEarlyQuitMessageTrigger) BroadcastConfigUpdate(ctx context.Context, config *evr.EarlyQuitServiceConfig) error {
+	if config == nil {
+		config = evr.DefaultEarlyQuitServiceConfig()
+	}
+
+	message := evr.NewSNSEarlyQuitConfig(config)
+
+	count := 0
+	// Broadcast to all connected EVR sessions
+	t.pipeline.sessionRegistry.Range(func(session Session) bool {
+		if session.Format() == SessionFormatEVR {
+			if evrSession, ok := session.(*sessionWS); ok {
+				if err := evrSession.SendEvr(message); err != nil {
+					t.logger.Warn("Failed to broadcast config update",
+						zap.String("user_id", session.UserID().String()),
+						zap.Error(err))
+				} else {
+					count++
+				}
+			}
+		}
+		return true
+	})
+
+	t.logger.Info("Broadcasted config update to players", zap.Int("count", count))
+	return nil
+}
+
+// StartLockoutExpiryScheduler starts a background goroutine that monitors and sends penalty expiry notifications
+// It checks for expired penalties periodically and sends notifications to connected players
+// Call Stop() to gracefully shutdown the scheduler
+func (t *SNSEarlyQuitMessageTrigger) StartLockoutExpiryScheduler(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(30 * time.Second) // Check every 30 seconds
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-t.stopCh:
+				t.logger.Info("Penalty expiry scheduler stopped")
+				return
+			case <-ticker.C:
+				t.checkAndNotifyExpiredPenalties(ctx)
+			}
+		}
+	}()
+
+	t.logger.Info("Started early quit penalty expiry scheduler")
+}
+
+// Stop gracefully shuts down the penalty expiry scheduler
+func (t *SNSEarlyQuitMessageTrigger) Stop() {
+	t.Lock()
+	defer t.Unlock()
+
+	if !t.stopped {
+		t.stopped = true
+		close(t.stopCh)
+	}
+}
+
+// checkAndNotifyExpiredPenalties checks all connected players' penalties and sends expiry notifications
+// Only notifies players who are currently connected
+func (t *SNSEarlyQuitMessageTrigger) checkAndNotifyExpiredPenalties(ctx context.Context) {
+	// Define lockout durations per tier (in seconds)
+	lockoutDurations := map[int32]int32{
+		1: 0,    // Tier 1: No lockout
+		2: 300,  // Tier 2: 5 minutes
+		3: 900,  // Tier 3: 15 minutes
+		4: 1800, // Tier 4: 30 minutes
+	}
+
+	// Check all connected EVR sessions
+	t.pipeline.sessionRegistry.Range(func(session Session) bool {
+		if session.Format() != SessionFormatEVR {
+			return true
+		}
+
+		_, ok := session.(*sessionWS)
+		if !ok {
+			return true
+		}
+
+		// Get player's early quit config from storage
+		userID := session.UserID().String()
+		eqConfig := NewEarlyQuitConfig()
+		if err := StorableRead(ctx, t.nk, userID, eqConfig, true); err != nil {
+			t.logger.Debug("Failed to load early quit config",
+				zap.String("user_id", userID),
+				zap.Error(err))
+			return true
+		}
+
+		// Check if penalty has expired
+		penaltyLevel := eqConfig.EarlyQuitPenaltyLevel
+		if penaltyLevel <= 0 {
+			return true // No penalty
+		}
+
+		// Get lockout duration for current tier
+		lockoutDuration, ok := lockoutDurations[eqConfig.MatchmakingTier]
+		if !ok {
+			lockoutDuration = 0 // Unknown tier, no lockout
+		}
+
+		if lockoutDuration == 0 {
+			return true // No lockout for this tier
+		}
+
+		// Calculate time since last early quit
+		now := time.Now()
+		timeSinceLastQuit := now.Sub(eqConfig.LastEarlyQuitTime).Seconds()
+
+		// If enough time has passed, send expiry notification
+		if timeSinceLastQuit >= float64(lockoutDuration) {
+			if err := t.SendPenaltyExpiredNotification(ctx, userID); err != nil {
+				t.logger.Warn("Failed to send penalty expired notification",
+					zap.String("user_id", userID),
+					zap.Error(err))
+			}
+		}
+
+		return true
+	})
+}

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -282,6 +282,13 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 		"tier_changed":      tierChanged,
 	}).Info("Reduced early quit penalty: player logged out after early quit")
 
+	// Send tier change notification via SNS message if applicable
+	if tierChanged {
+		if messageTrigger := globalEarlyQuitMessageTrigger.Load(); messageTrigger != nil {
+			messageTrigger.SendTierChangeNotification(ctx, userID, oldTier, newTier, oldTier > newTier)
+		}
+	}
+
 	// Send Discord notification if tier changed
 	if tierChanged {
 		discordID, err := GetDiscordIDByUserID(ctx, db, userID)

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -914,14 +914,6 @@ func (p *EvrPipeline) loggedInUserProfileRequest(ctx context.Context, logger *za
 	}
 
 	clientProfile := NewClientProfile(ctx, params.profile, serverProfile)
-	clientProfile.EarlyQuitFeatures = evr.EarlyQuitFeatures{
-		PenaltyTimestamp:    time.Now().Add(10 * time.Minute).Unix(),
-		NumEarlyQuits:       25,
-		NumSteadyMatches:    10,
-		NumSteadyEarlyQuits: 12,
-		PenaltyLevel:        3,
-		SteadyPlayerLevel:   5,
-	}
 
 	// Check if the user is required to go through community values
 	journal := NewGuildEnforcementJournal(userID)
@@ -930,13 +922,6 @@ func (p *EvrPipeline) loggedInUserProfileRequest(ctx context.Context, logger *za
 	} else if journal.CommunityValuesCompletedAt.IsZero() {
 		clientProfile.Social.CommunityValuesVersion = 0
 	}
-
-	go func() {
-		<-time.After(10 * time.Second)
-		var penaltyLevel int32 = 3
-		var durationSeconds int32 = 300
-		session.SendEvr(evr.NewLockoutActiveNotification(penaltyLevel, durationSeconds))
-	}()
 
 	return session.SendEvr(evr.NewLoggedInUserProfileSuccess(request.EvrID, clientProfile, serverProfile))
 }


### PR DESCRIPTION
## Summary
Implement server-side SNS message system for communicating early quit penalties to players in real-time.

- Add SNSEarlyQuitUpdateNotification messages for penalty events (applied, expired, tier changes)
- Add SNSEarlyQuitFeatureFlags for configurable penalty system control  
- Implement SNSEarlyQuitMessageTrigger to manage sending notifications to connected players
- Send penalty notifications immediately when early quit is detected in matches
- Send tier change notifications when matchmaking tier changes
- Start penalty expiry scheduler to monitor and notify when penalties expire

## Changes
- `server/evr/login_earlyquitupdatenotification.go` - New notification message types and constructors
- `server/evr/login_earlyquitfeatureflags.go` - Feature flags for penalty system configuration
- `server/evr_early_quit_message_trigger.go` - Message trigger implementation with scheduler
- `server/evr_pipeline.go` - Initialize message trigger on startup
- `server/evr_match.go` - Send penalty notifications on early quit detection
- `server/evr_earlyquit.go` - Send tier change notifications when tier is restored
- `server/evr/core_account.go` - Enable early quit features in client profile
- `server/evr/core_packet.go` - Register new message types
- `server/evr/core_packet_types.go` - Add factory methods for new messages