### PR TITLE
Refactor: Move early quit enforcement from server to client

### DIFF
--- a/server/evr/login_earlyquitfeatureflags.go
+++ b/server/evr/login_earlyquitfeatureflags.go
@@ -5,14 +5,14 @@ import (
 )
 
 // SNSEarlyQuitFeatureFlags represents the feature flags message for early quit system
-// Server → Client: Controls which early quit features are enabled/disabled
+// Server → Client: Informs client which early quit features it should implement client-side
 type SNSEarlyQuitFeatureFlags struct {
 	Enabled             bool     `json:"enabled"`                        // Master enable/disable
-	EnableMMLockout     bool     `json:"enable_mm_lockout"`              // Matchmaking lockout active
-	EnableSpawnLock     bool     `json:"enable_spawn_lock"`              // Spawn lock penalties active
-	EnableAutoReport    bool     `json:"enable_auto_report"`             // Automatic reporting active
-	EnableUICountdown   bool     `json:"enable_ui_countdown"`            // Show countdown timer in UI
-	EnableQueueBlocking bool     `json:"enable_queue_blocking"`          // Block queue during penalty
+	EnableMMLockout     bool     `json:"enable_mm_lockout"`              // Client should enforce matchmaking tier separation
+	EnableSpawnLock     bool     `json:"enable_spawn_lock"`              // Client should prevent spawn requests during penalty
+	EnableAutoReport    bool     `json:"enable_auto_report"`             // Server auto-flags players at max penalty level
+	EnableUICountdown   bool     `json:"enable_ui_countdown"`            // Client should show countdown timer in UI
+	EnableQueueBlocking bool     `json:"enable_queue_blocking"`          // Client should disable queue button during penalty
 	SupportedRegions    []string `json:"supported_regions"`              // Regions where system applies
 	SupportedGameModes  []string `json:"supported_game_modes"`           // Game modes where system applies
 	MaxPenaltyLevel     int32    `json:"max_penalty_level"`              // Max penalty tier

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -126,49 +126,21 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 		<-time.After(3 * time.Second)
 	}
 	serviceSettings := ServiceSettings()
-	// Only Apply the early quit penalty if it's a public arena match.
 	if lobbyParams.Mode == evr.ModeArenaPublic && lobbyParams.EarlyQuitPenaltyLevel > 0 && serviceSettings.Matchmaking.EnableEarlyQuitPenalty {
+		eqConfig := NewEarlyQuitConfig()
+		if err := StorableRead(ctx, p.nk, lobbyParams.UserID.String(), eqConfig, true); err != nil {
+			logger.Debug("Failed to load early quit config for logging", zap.Error(err))
+		} else {
+			timeSinceLastQuit := time.Since(eqConfig.LastEarlyQuitTime)
+			lockoutDuration := GetLockoutDuration(lobbyParams.EarlyQuitPenaltyLevel)
 
-		interval := GetLockoutDuration(lobbyParams.EarlyQuitPenaltyLevel)
-
-		// Check if QueueBlocking is enabled (default is true)
-		featureFlags := evr.DefaultEarlyQuitFeatureFlags()
-		if featureFlags.EnableQueueBlocking {
-			eqConfig := NewEarlyQuitConfig()
-			if err := StorableRead(ctx, p.nk, lobbyParams.UserID.String(), eqConfig, true); err != nil {
-				logger.Warn("Failed to load early quit config for QueueBlocking check", zap.Error(err))
-			} else {
-				timeSinceLastQuit := time.Since(eqConfig.LastEarlyQuitTime)
-				lockoutDuration := interval
-
-				if timeSinceLastQuit < lockoutDuration {
-					remainingTime := lockoutDuration - timeSinceLastQuit
-					message := fmt.Sprintf("Matchmaking blocked due to early quit penalty. %s remaining.", remainingTime)
-					return NewLobbyError(ServerIsLocked, message)
-				}
-				// Past lockout window, allow matchmaking
-				interval = 1 * time.Second
+			if timeSinceLastQuit < lockoutDuration {
+				remainingTime := lockoutDuration - timeSinceLastQuit
+				logger.Info("Player queueing with active early quit penalty (client-side enforcement expected)",
+					zap.String("user_id", lobbyParams.UserID.String()),
+					zap.Int("penalty_level", lobbyParams.EarlyQuitPenaltyLevel),
+					zap.Duration("remaining", remainingTime))
 			}
-		}
-
-		if !serviceSettings.Matchmaking.SilentEarlyQuitSystem {
-			// Notify the user that they are an early quitter.
-			message := fmt.Sprintf("Your early quit penalty is active (level %d), your matchmaking has been delayed by %d seconds.", lobbyParams.EarlyQuitPenaltyLevel, int(interval.Seconds()))
-			if _, err := SendUserMessage(ctx, p.appBot.dg, lobbyParams.DiscordID, message); err != nil {
-				logger.Warn("Failed to send message to user", zap.Error(err))
-			}
-			if guildGroup := p.guildGroupRegistry.Get(lobbyParams.GroupID.String()); guildGroup != nil {
-				// Send an audit log message to the guild group.
-				content := fmt.Sprintf("notified early quitter <@!%s> (%s): %s ", lobbyParams.DiscordID, session.Username(), message)
-				if _, err = AuditLogSendGuild(p.appBot.dg, guildGroup, content); err != nil {
-					logger.Warn("Failed to send audit log message", zap.Error(err))
-				}
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(interval):
 		}
 	}
 


### PR DESCRIPTION
## Summary
Refactor the early quit penalty system to move enforcement logic from server-side to client-side, while maintaining the server as the authoritative source of penalty data and messaging system.

## Changes

### Server Enforcement Removed
- **Spawn Lock Removal** (`evr_match.go`)
  - Server no longer blocks spawn attempts for penalized players
  - Changed to logging-only for metrics tracking
  
- **Queue Blocking Removal** (`evr_lobby_find.go`)
  - Server no longer returns `ServerIsLocked` errors
  - Removed artificial `time.After()` delays on matchmaking requests
  - Removed Discord DM notifications for queue blocking

### Documentation Updates
- **Feature Flag Documentation** (`login_earlyquitfeatureflags.go`)
  - Updated comments to clarify flags are client-side guidance, not server enforcement
  - `EnableSpawnLock`: Client should prevent spawn requests during penalty
  - `EnableQueueBlocking`: Client should disable queue button during penalty

## Server Still Provides

The server continues to:
- ✅ Track penalty statistics (`EarlyQuitPenaltyLevel`, `LastEarlyQuitTime`, etc.)
- ✅ Send SNS messages with penalty data:
  - `SNSEarlyQuitConfig` (tier configuration on login)
  - `SNSEarlyQuitFeatureFlags` (which features to implement)
  - `SNSEarlyQuitUpdateNotification` (real-time state changes)
- ✅ Run background expiry scheduler for `penalty_expired` notifications
- ✅ Enforce matchmaking tier segregation (Tier 1 vs Tier 2 queues)

## Architecture

**Before:**
- Server enforces spawn blocking
- Server enforces queue blocking with delays
- Server sends Discord DMs
- Client receives commands to follow

**After:**
- Server provides penalty information via SNS messages
- Client decides when to enable/disable UI elements
- Client shows countdown timers
- Client prevents spawn/queue actions during penalties
- Server remains authoritative for penalty data

## Benefits

1. **Proper separation of concerns** - UI logic belongs on the client
2. **Better UX** - Client can provide immediate feedback without round-trip delays
3. **Reduced server load** - No artificial delays or blocking operations
4. **Maintains data integrity** - Server still tracks and validates penalty state

## Testing

- [x] LSP diagnostics clean on all modified files
- [ ] Client implementation needed to enforce penalties based on SNS messages

## Related

This addresses the architectural issue where "Spawn lock" and other client-facing features were implemented server-side.

---

**Files Changed:** 3  
**Lines Added:** 23  
**Lines Removed:** 55  
**Net:** -32 lines