### PR TITLE
Enhance enforcement journal with enforcer Discord ID and global bot support

### DIFF
--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -79,11 +79,18 @@ func EnforcementKickRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		return "", runtime.NewError("Failed to check permissions", StatusInternalError)
 	}
 
+	// Check if the caller is a global bot
+	isGlobalBot, err := CheckSystemGroupMembership(ctx, db, userID, GroupGlobalBots)
+	if err != nil {
+		logger.Error("Failed to check global bot status", zap.Error(err))
+		return "", runtime.NewError("Failed to check permissions", StatusInternalError)
+	}
+
 	// Determine enforcer user ID
 	enforcerUserID := userID
 	if request.EnforcerID != "" {
-		if !isGlobalOperator {
-			return "", runtime.NewError("Only global operators can specify an enforcer_id", StatusPermissionDenied)
+		if !isGlobalOperator && !isGlobalBot {
+			return "", runtime.NewError("Only global operators or global bots can specify an enforcer_id", StatusPermissionDenied)
 		}
 		enforcerUserID = request.EnforcerID
 	}
@@ -152,9 +159,18 @@ func EnforcementKickRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 
 	// Add suspension record or void existing suspensions
 	if addSuspension {
+		// Get enforcer's Discord ID for audit log
+		enforcerDiscordID := ""
+		account, err := nk.AccountGetId(ctx, enforcerUserID)
+		if err != nil {
+			logger.Error("Failed to load enforcer account for Discord ID", zap.Error(err), zap.String("enforcer_user_id", enforcerUserID))
+		} else if account != nil && account.CustomId != "" {
+			enforcerDiscordID = account.CustomId
+		}
+
 		// Add a new suspension record
 		actions = append(actions, fmt.Sprintf("suspension expires <t:%d:R>", suspensionExpiry.UTC().Unix()))
-		record := journal.AddRecord(groupID, enforcerUserID, "", request.UserNotice, request.ModeratorNotes, request.RequireCommunityValues, request.AllowPrivateLobbies, suspensionDuration)
+		record := journal.AddRecord(groupID, enforcerUserID, enforcerDiscordID, request.UserNotice, request.ModeratorNotes, request.RequireCommunityValues, request.AllowPrivateLobbies, suspensionDuration)
 		recordsByGroupID[groupID] = append(recordsByGroupID[groupID], record)
 	} else if voidActiveSuspensions {
 		// Void active suspensions

--- a/server/evr_suspension_profile.go
+++ b/server/evr_suspension_profile.go
@@ -166,11 +166,12 @@ func (s *SuspensionProfile) SyncFromJournal(journal *GuildEnforcementJournal) {
 // SyncJournalAndProfile updates both the enforcement journal and suspension profile in storage
 // This ensures they stay in sync whenever enforcement data changes
 func SyncJournalAndProfile(ctx context.Context, nk runtime.NakamaModule, userID string, journal *GuildEnforcementJournal) error {
-	// Create profile from journal
 	profile := NewSuspensionProfile(userID)
+	if err := StorableRead(ctx, nk, userID, profile, true); err != nil {
+		return err
+	}
 	profile.SyncFromJournal(journal)
 
-	// Write both to storage
 	if err := StorableWrite(ctx, nk, userID, journal); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR enhances the enforcement journal system with:

### Changes
- **Global bot enforcer support**: Allow global bots to specify  when calling the enforcement RPC, expanding enforcement capabilities beyond just global operators
- **Audit trail enhancement**: Add enforcer's Discord ID to enforcement journal records for better audit logging and accountability tracking
- **Data integrity fix**: Fix `SyncJournalAndProfile` to read existing profile before syncing, preventing data loss when updating enforcement records

### Files Changed
- `server/evr_runtime_rpc_enforcement.go`: Added global bot check, enforcer Discord ID retrieval, and journal record updates
- `server/evr_suspension_profile.go`: Fixed profile sync logic to preserve existing data

### Type
Enhancement to enforcement system