### PR TITLE
fix(enforcement): add retry logic for concurrent enforcement record writes

### DIFF
--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -191,8 +191,8 @@ func EnforcementKickRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		}
 	}
 
-	// Save the enforcement journal and sync to profile
-	if err := SyncJournalAndProfile(ctx, nk, targetUserID, journal); err != nil {
+	// Save the enforcement journal and sync to profile with retry logic for concurrent writes
+	if err := SyncJournalAndProfileWithRetry(ctx, nk, targetUserID, journal); err != nil {
 		logger.Error("Failed to write enforcement data", zap.Error(err))
 		return "", runtime.NewError("Failed to save enforcement data", StatusInternalError)
 	}
@@ -526,10 +526,10 @@ func EnforcementRecordEditRPC(ctx context.Context, logger runtime.Logger, db *sq
 		return "", runtime.NewError("Failed to edit enforcement record", StatusInternalError)
 	}
 
-	// Save the journal
-	if err := StorableWrite(ctx, nk, request.TargetUserID, journal); err != nil {
-		logger.Error("Failed to write enforcement journal", zap.Error(err))
-		return "", runtime.NewError("Failed to save enforcement record", StatusInternalError)
+	// Save the journal and sync to profile with retry logic for concurrent writes
+	if err := SyncJournalAndProfileWithRetry(ctx, nk, request.TargetUserID, journal); err != nil {
+		logger.Error("Failed to write enforcement data", zap.Error(err))
+		return "", runtime.NewError("Failed to save enforcement data", StatusInternalError)
 	}
 
 	// Log the edit


### PR DESCRIPTION
## Problem
Concurrent modifications to enforcement records result in 'Storage write rejected - version check failed' errors when editing enforcement records. This occurs because the EnforcementRecordEditRPC was only writing the journal without syncing the SuspensionProfile, and lacked retry logic for handling version conflicts.

## Solution
- Added **SyncJournalAndProfileWithRetry()** function with exponential backoff retry logic (3 attempts, 10ms-40ms delays)
- Updated **EnforcementRecordEditRPC** to use the retry-capable sync function (fixes the bug)
- Updated **EnforcementKickRPC** to use retry version for consistency
- Fresh journal/profile data is reread on each retry attempt

## Changes
- `server/evr_suspension_profile.go`: Add new SyncJournalAndProfileWithRetry function
- `server/evr_runtime_rpc_enforcement.go`: Update both kick and edit RPCs to use retry logic

## Testing
Concurrent enforcement record edits should no longer fail with version check errors.