### PR TITLE
fix(enforcement): re-read journals at join time to catch mid-session suspensions

### DIFF
--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -525,7 +525,8 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 
 	params.ignoreDisabledAlternates = loginHistory.IgnoreDisabledAlternates
 	firstIDs, _ := loginHistory.AlternateIDs()
-	journals, err := EnforcementJournalsLoad(ctx, p.nk, append(firstIDs, params.profile.ID()))
+	params.enforcementUserIDs = append(firstIDs, params.profile.ID())
+	journals, err := EnforcementJournalsLoad(ctx, p.nk, params.enforcementUserIDs)
 	if err != nil {
 		return fmt.Errorf("failed to load enforcement journals: %w", err)
 	}

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -50,6 +50,7 @@ type SessionParameters struct {
 	latencyHistory               *atomic.Pointer[LatencyHistory]  // The latency history
 	isIGPOpen                    *atomic.Bool                     // The user has IGPU open
 	gameModeSuspensionsByGroupID ActiveGuildEnforcements          // The active suspension records
+	enforcementUserIDs           []string                         // User IDs (self + alts) used for enforcement journal queries
 	ignoreDisabledAlternates     bool                             // Ignore disabled
 }
 


### PR DESCRIPTION
## Problem

`lobbyAuthorize()` checked enforcement suspensions using journal data loaded at login time. A suspension issued after login but before a subsequent `lobbyAuthorize()` call could be missed entirely if the write raced against the read.

### Incident Evidence (r3wdog3, 2026-02-XX)

| Timestamp | Event |
|---|---|
| `07:08:40.415Z` | `kick-player` issued — 180-day suspension journal entry written for r3wdog3 |
| `07:08:40.979Z` | r3wdog3's `lobbyAuthorize()` **passes** — reads stale login-time journal, suspension not yet visible |
| `07:08:41.440Z` | Match kick fires — r3wdog3 removed from social lobby |
| `07:08:41.502Z` | r3wdog3's match session closed |
| `07:08:41.637Z` | r3wdog3's websocket closed |

The suspension write and the `lobbyAuthorize()` read raced within a **564ms window**. The authorize won the race: r3wdog3 was already admitted to the matchmaking queue before the kick landed. The 180-day enforcement journal entry had no effect on that join.

## Root Cause

In `authorizeSession()` (login), the enforcement journal is loaded once and cached in `SessionParameters.gameModeSuspensionsByGroupID`. `lobbyAuthorize()` then reads from that cached field. Any suspension written to storage after login is invisible to subsequent `lobbyAuthorize()` calls for that session.

## Fix

Store the enforcement user ID list (`self + alt accounts`) in `SessionParameters.enforcementUserIDs` at login. In `lobbyAuthorize()`, call `EnforcementJournalsLoad` fresh from storage every time, replacing the cached `gameModeSuspensionsByGroupID` lookup for the suspension check.

If the fresh journal read fails, the join is **denied** (fail-closed), rather than falling through to a potentially stale allow.

## Changes

- **`evr_session_parameters.go`**: Add `enforcementUserIDs []string` field.
- **`evr_pipeline_login.go`**: Populate `params.enforcementUserIDs` at login so it is available for later joins.
- **`evr_lobby_joinentrant.go`**: Re-read enforcement journals from storage in `lobbyAuthorize()` on every call; fail-closed on storage error.

## Regression Test

`TestMidSessionSuspension_StaleEnforcementsMissPostLoginKick` in `evr_enforcement_journal_test.go` directly models the incident:

1. Session logs in — journals loaded and cached.
2. Suspension is written to storage mid-session (simulating `kick-player`).
3. `lobbyAuthorize()` is called — asserts the fresh journal read catches the new suspension and the join is rejected.

Without the fix, this test fails (old cached data passes the suspended user). With the fix it passes.