### PR TITLE
refactor(account): move GamePauseSettings into dedicated storage object

### DIFF
--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -43,7 +43,6 @@ type EVRProfile struct {
 	MutedPlayers           []evr.EvrId                `json:"muted_players"`             // The muted players
 	GhostedPlayers         []evr.EvrId                `json:"ghosted_players"`           // The ghosted players
 	NewUnlocks             []int64                    `json:"new_unlocks"`               // The new unlocks
-	GamePauseSettings      *evr.GamePauseSettings     `json:"game_pause_settings"`       // The game settings
 	LegalConsents          evr.LegalConsents          `json:"legal_consents"`            // The legal consents
 	CustomizationPOIs      *evr.Customization         `json:"customization_pois"`        // The customization POIs
 	MatchmakingDivision    string                     `json:"matchmaking_division"`      // The matchmaking division (e.g. bronze, silver, gold, etc.)

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2074,13 +2074,9 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			return editInteractionResponse(s, i, fmt.Sprintf("Next match set to `%s`", matchID))
 		},
 		"throw-settings": func(ctx context.Context, logger runtime.Logger, s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User, member *discordgo.Member, userIDStr string, groupID string) error {
-			metadata, err := EVRProfileLoad(ctx, nk, userIDStr)
+			settings, err := GamePauseSettingsLoad(ctx, nk, userIDStr)
 			if err != nil {
-				return fmt.Errorf("failed to get account metadata: %w", err)
-			}
-
-			if metadata.GamePauseSettings == nil {
-				return fmt.Errorf("GamePauseSettings is nil")
+				return fmt.Errorf("failed to get game pause settings: %w", err)
 			}
 
 			embed := &discordgo.MessageEmbed{
@@ -2089,17 +2085,17 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				Fields: []*discordgo.MessageEmbedField{
 					{
 						Name:   "Grab Deadzone",
-						Value:  strconv.FormatFloat(metadata.GamePauseSettings.GrabDeadZone, 'f', -1, 64),
+						Value:  strconv.FormatFloat(settings.GrabDeadZone, 'f', -1, 64),
 						Inline: true,
 					},
 					{
 						Name:   "Release Distance",
-						Value:  strconv.FormatFloat(metadata.GamePauseSettings.ReleaseDistance, 'f', -1, 64),
+						Value:  strconv.FormatFloat(settings.ReleaseDistance, 'f', -1, 64),
 						Inline: true,
 					},
 					{
 						Name:   "Wrist Angle Offset",
-						Value:  strconv.FormatFloat(metadata.GamePauseSettings.WristAngleOffset, 'f', -1, 64),
+						Value:  strconv.FormatFloat(settings.WristAngleOffset, 'f', -1, 64),
 						Inline: true,
 					},
 				},

--- a/server/evr_game_pause_settings.go
+++ b/server/evr_game_pause_settings.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"context"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+const (
+	StorageCollectionGamePauseSettings = "GameSettings"
+	StorageKeyGamePauseSettings        = "pause_settings"
+)
+
+type GamePauseSettingsStorage struct {
+	evr.GamePauseSettings
+
+	version string
+}
+
+func (s *GamePauseSettingsStorage) StorageMeta() StorableMetadata {
+	return StorableMetadata{
+		Collection:      StorageCollectionGamePauseSettings,
+		Key:             StorageKeyGamePauseSettings,
+		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+		Version:         s.version,
+	}
+}
+
+func (s *GamePauseSettingsStorage) SetStorageMeta(meta StorableMetadata) {
+	s.version = meta.Version
+}
+
+func GamePauseSettingsLoad(ctx context.Context, nk runtime.NakamaModule, userID string) (*GamePauseSettingsStorage, error) {
+	settings := &GamePauseSettingsStorage{}
+	if err := StorableRead(ctx, nk, userID, settings, false); err != nil {
+		return nil, err
+	}
+	return settings, nil
+}
+
+func GamePauseSettingsStore(ctx context.Context, nk runtime.NakamaModule, userID string, settings *GamePauseSettingsStorage) error {
+	return StorableWrite(ctx, nk, userID, settings)
+}

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -216,15 +216,10 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				logger.WithField("error", err).Debug("Failed to get user ID by evr ID")
 				continue
 			}
-			metadata, err := EVRProfileLoad(ctx, nk, userID)
-			if err != nil {
-				logger.WithField("error", err).Warn("Failed to load account metadata")
-				continue
-			}
 
-			metadata.GamePauseSettings = &msg.Settings
-			if err := EVRProfileUpdate(ctx, nk, userID, metadata); err != nil {
-				logger.WithField("error", err).Warn("Failed to set account metadata")
+			settings := &GamePauseSettingsStorage{GamePauseSettings: msg.Settings}
+			if err := GamePauseSettingsStore(ctx, nk, userID, settings); err != nil {
+				logger.WithField("error", err).Warn("Failed to store game pause settings")
 			}
 
 		case *evr.RemoteLogCustomizationMetricsPayload:


### PR DESCRIPTION
## Summary

- Introduces `GamePauseSettingsStorage` (collection `GameSettings`, key `pause_settings`) implementing `StorableAdapter`, replacing the embedded `*evr.GamePauseSettings` field on `EVRProfile`
- Updates `RemoteLogPauseSettings` handler to write directly to the new storage object instead of loading/mutating/saving the full profile
- Updates the `throw-settings` Discord command to load from the new storage object directly