### PR TITLE
Hotfix - Fix default portal base URL

### DIFF
--- a/server/evr_discord_appbot_enforcement.go
+++ b/server/evr_discord_appbot_enforcement.go
@@ -110,7 +110,7 @@ func (d *DiscordAppBot) showEnforcementEditModal(s *discordgo.Session, i *discor
 	if len(record.AuditorNotes) > 200 {
 		portalBaseURL := os.Getenv("NEVR_PORTAL_BASE_URL")
 		if portalBaseURL == "" {
-			portalBaseURL = "https://echovrce.com/portal/"
+			portalBaseURL = "https://echovrce.com/"
 		}
 		// Construct portal link to edit page
 		portalLink := fmt.Sprintf("%ssuspensions?edit=%s&record=%s&guild=%s", portalBaseURL, targetUserID, recordID, groupID)


### PR DESCRIPTION
This is the only place in the nakama repo that still has /portal appended to the echovrce URL. My assumption is that it got missed in the commits made on 2/22/26