### PR TITLE
fix(rpc): allow global operators to terminate any match regardless of lobby type

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -989,6 +989,14 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	}
 
 	if state.LobbyType == UnassignedLobby {
+		// Parking matches with a server that are never allocated should time out.
+		if state.server != nil {
+			state.emptyTicks++
+			if state.emptyTicks > 120*state.tickRate { // 2 minutes
+				logger.Warn("Unassigned parking match with server has not been allocated. Shutting down.")
+				return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
+			}
+		}
 		return state
 	}
 
@@ -1200,8 +1208,11 @@ func (m *EvrMatch) MatchShutdown(ctx context.Context, logger runtime.Logger, db 
 	state.terminateTick = tick + int64(graceSeconds)*state.tickRate
 
 	if err := m.updateLabel(logger, dispatcher, state); err != nil {
-		logger.Error("failed to update label: %v", err)
-		return nil
+		logger.Error("failed to update label during shutdown (continuing): %v", err)
+		// Do NOT return nil here. Returning nil kills the match immediately without
+		// going through MatchTerminate, which means the game server session is never
+		// disconnected. This leaves the monitoring goroutine alive, which then creates
+		// a new parking match in an infinite loop, causing match accumulation.
 	}
 
 	if err := StoreMatchLabel(ctx, nk, state); err != nil {

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -989,14 +989,6 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	}
 
 	if state.LobbyType == UnassignedLobby {
-		// Parking matches with a server that are never allocated should time out.
-		if state.server != nil {
-			state.emptyTicks++
-			if state.emptyTicks > 120*state.tickRate { // 2 minutes
-				logger.Warn("Unassigned parking match with server has not been allocated. Shutting down.")
-				return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
-			}
-		}
 		return state
 	}
 

--- a/server/evr_match_loop_blocking_test.go
+++ b/server/evr_match_loop_blocking_test.go
@@ -1,0 +1,169 @@
+package server
+
+// Regression test for the bug introduced after v3.27.2-evr.245:
+// allocatePostMatchSocialLobby calls nk.MatchSignal synchronously inside MatchLoop,
+// blocking the single match goroutine for up to 10 seconds per tick.
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// blockingMatchSignalNK is a NakamaModule stub whose MatchSignal blocks until the test
+// releases it, simulating a slow or hung target match.
+type blockingMatchSignalNK struct {
+	runtime.NakamaModule
+	entered        chan struct{}
+	unblock        chan struct{}
+	fakeMatchLabel string
+}
+
+func newBlockingMatchSignalNK(fakeTargetLabel string) *blockingMatchSignalNK {
+	return &blockingMatchSignalNK{
+		entered:        make(chan struct{}),
+		unblock:        make(chan struct{}),
+		fakeMatchLabel: fakeTargetLabel,
+	}
+}
+
+func (m *blockingMatchSignalNK) MatchSignal(_ context.Context, _ string, _ string) (string, error) {
+	select {
+	case <-m.entered:
+	default:
+		close(m.entered)
+	}
+	<-m.unblock
+	return `{"success":false}`, nil
+}
+
+func (m *blockingMatchSignalNK) MatchList(_ context.Context, _ int, _ bool, _ string, _, _ *int, _ string) ([]*api.Match, error) {
+	return []*api.Match{
+		{
+			MatchId:       uuid.Must(uuid.NewV4()).String() + ".testnode",
+			Authoritative: true,
+			Label:         &wrapperspb.StringValue{Value: m.fakeMatchLabel},
+		},
+	}, nil
+}
+
+func (m *blockingMatchSignalNK) MetricsCounterAdd(_ string, _ map[string]string, _ int64)          {}
+func (m *blockingMatchSignalNK) MetricsTimerRecord(_ string, _ map[string]string, _ time.Duration) {}
+func (m *blockingMatchSignalNK) MetricsGaugeSet(_ string, _ map[string]string, _ float64)          {}
+func (m *blockingMatchSignalNK) StorageWrite(_ context.Context, _ []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	return nil, nil
+}
+func (m *blockingMatchSignalNK) StorageRead(_ context.Context, _ []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	return nil, nil
+}
+
+type noopDispatcher struct{}
+
+
+func (d *noopDispatcher) BroadcastMessage(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return nil
+}
+func (d *noopDispatcher) BroadcastMessageDeferred(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return nil
+}
+func (d *noopDispatcher) MatchKick(_ []runtime.Presence) error { return nil }
+func (d *noopDispatcher) MatchLabelUpdate(_ string) error      { return nil }
+
+// TestMatchLoop_AllocatePostMatchSocialLobby_Blocks confirms that MatchLoop blocks the
+// calling goroutine inside nk.MatchSignal when allocatePostMatchSocialLobby is triggered.
+//
+// Trigger conditions (evr_match.go):
+//
+//	state.Mode == evr.ModeArenaPrivate
+//	tick % (2*tickRate) == 0
+//	state.GameState != nil && state.GameState.MatchOver
+//	!state.matchSummarySent
+func TestMatchLoop_AllocatePostMatchSocialLobby_Blocks(t *testing.T) {
+	t.Parallel()
+
+	settings := &ServiceSettingsData{}
+	settings.Matchmaking.QueryAddons.Create = "+label.open:T"
+	ServiceSettingsUpdate(settings)
+	t.Cleanup(func() { ServiceSettingsUpdate(nil) })
+
+	targetMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	fakeServerLabel, err := json.Marshal(&MatchLabel{
+		ID:        targetMatchID,
+		LobbyType: UnassignedLobby,
+		GameServer: &GameServerPresence{
+			SessionID:  uuid.Must(uuid.NewV4()),
+			EndpointID: "testendpoint",
+			Endpoint: evr.Endpoint{
+				ExternalIP: net.ParseIP("127.0.0.1"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal fake server label: %v", err)
+	}
+
+	nk := newBlockingMatchSignalNK(string(fakeServerLabel))
+
+	groupID := uuid.Must(uuid.NewV4())
+	player := &EvrMatchPresence{
+		SessionID:     uuid.Must(uuid.NewV4()),
+		UserID:        uuid.Must(uuid.NewV4()),
+		Node:          "testnode",
+		RoleAlignment: evr.TeamBlue,
+	}
+	state := &MatchLabel{
+		ID:               MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"},
+		Mode:             evr.ModeArenaPrivate,
+		GroupID:          &groupID,
+		tickRate:         10,
+		GameState:        &GameState{MatchOver: true},
+		matchSummarySent: false,
+		presenceMap: map[string]*EvrMatchPresence{
+			player.SessionID.String(): player,
+		},
+		presenceByEvrID: make(map[evr.EvrId]*EvrMatchPresence),
+		joinTimestamps:  make(map[string]time.Time),
+		participations:  make(map[string]*PlayerParticipation),
+		reservationMap:  make(map[string]*slotReservation),
+	}
+
+	m := &EvrMatch{}
+	logger := NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_MATCH_ID, state.ID.String())
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_NODE, "testnode")
+
+	// tick=20 satisfies 20 % (2*10) == 0
+	const testTick int64 = 20
+
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		m.MatchLoop(ctx, logger, nil, nk, &noopDispatcher{}, testTick, state, nil)
+	}()
+
+	select {
+	case <-nk.entered:
+
+	case <-loopDone:
+		t.Fatal("MatchLoop returned before blocking in nk.MatchSignal: trigger conditions not met or bug is fixed")
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for MatchLoop to enter nk.MatchSignal")
+	}
+
+	close(nk.unblock)
+	select {
+	case <-loopDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("MatchLoop did not return after nk.MatchSignal was unblocked")
+	}
+}

--- a/server/evr_match_preemption.go
+++ b/server/evr_match_preemption.go
@@ -200,20 +200,20 @@ func (pm *MatchPreemptionManager) sendPreemptionNotification(ctx context.Context
 	return pm.nk.NotificationSend(ctx, userID, "Match Preempted", content, NotificationCodeMatchPreempted, "", true)
 }
 
-// shutdownMatch shuts down a match
+// shutdownMatch shuts down a match using the proper SignalMatch envelope.
 func (pm *MatchPreemptionManager) shutdownMatch(ctx context.Context, matchID, reason string) error {
-	// Send shutdown signal to the match
-	data := map[string]interface{}{
-		"action": "shutdown",
-		"reason": reason,
+	mID := MatchIDFromStringOrNil(matchID)
+	if mID.IsNil() {
+		return fmt.Errorf("invalid match ID: %s", matchID)
 	}
 
-	dataBytes, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("failed to marshal shutdown data: %w", err)
+	payload := SignalShutdownPayload{
+		GraceSeconds:         30,
+		DisconnectGameServer: false,
+		DisconnectUsers:      true,
 	}
 
-	_, err = pm.nk.MatchSignal(ctx, matchID, string(dataBytes))
+	_, err := SignalMatch(ctx, pm.nk, mID, SignalShutdown, payload)
 	return err
 }
 

--- a/server/evr_runtime_rpc_match.go
+++ b/server/evr_runtime_rpc_match.go
@@ -252,46 +252,42 @@ type shutdownMatchResponse struct {
 }
 
 func shutdownMatchRpc(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
-
 	r := NewRuntimeContext(ctx)
-
 	request := &shutdownMatchRequest{}
 	if err := json.Unmarshal([]byte(payload), request); err != nil {
-		return "", err
+		return "", runtime.NewError("invalid request payload: "+err.Error(), StatusInvalidArgument)
 	}
 
-	label, err := MatchLabelByID(ctx, nk, request.MatchID)
-	if err != nil {
-		return "", err
+	if !request.MatchID.IsValid() {
+		return "", runtime.NewError("match_id is required", StatusInvalidArgument)
 	}
 
-	if label.LobbyType == UnassignedLobby {
-		return "", fmt.Errorf("match %s is not in a lobby", request.MatchID)
+	// Verify the match exists. Global operators may terminate any match regardless of lobby type.
+	if _, err := MatchLabelByID(ctx, nk, request.MatchID); err != nil {
+		return "", err
 	}
 	if request.GraceSeconds <= 0 {
 		request.GraceSeconds = 10
 	}
-
 	env := NewSignalEnvelope(r.UserID, SignalShutdown, SignalShutdownPayload{
 		GraceSeconds:         request.GraceSeconds,
 		DisconnectGameServer: false,
 		DisconnectUsers:      false,
 	})
-
+	if env == nil {
+		return "", runtime.NewError("failed to create shutdown signal", StatusInternalError)
+	}
 	signalResponse, err := nk.MatchSignal(ctx, request.MatchID.String(), env.String())
 	if err != nil {
 		return "", err
 	}
-
 	response := &shutdownMatchResponse{
 		Success:  true,
 		Response: signalResponse,
 	}
-
 	jsonData, err := json.Marshal(response)
 	if err != nil {
 		return "", err
 	}
-
 	return string(jsonData), nil
 }

--- a/server/evr_runtime_rpc_match_test.go
+++ b/server/evr_runtime_rpc_match_test.go
@@ -1,0 +1,211 @@
+package server
+
+// Tests for shutdownMatchRpc.
+//
+// Regression: before this fix, the handler rejected matches with LobbyType == UnassignedLobby,
+// preventing global operators from terminating parked/unassigned game servers.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// shutdownNK is a minimal NakamaModule stub for shutdownMatchRpc tests.
+type shutdownNK struct {
+	runtime.NakamaModule
+	matchLabel string // JSON label to return from MatchGet; "" means "not found"
+	signalErr  error  // error to return from MatchSignal, nil means success
+}
+
+func (n *shutdownNK) MatchGet(_ context.Context, matchID string) (*api.Match, error) {
+	if n.matchLabel == "" {
+		return nil, runtime.ErrMatchNotFound
+	}
+	return &api.Match{
+		MatchId:       matchID,
+		Authoritative: true,
+		Label:         &wrapperspb.StringValue{Value: n.matchLabel},
+	}, nil
+}
+
+func (n *shutdownNK) MatchSignal(_ context.Context, _ string, _ string) (string, error) {
+	if n.signalErr != nil {
+		return "", n.signalErr
+	}
+	return SignalResponse{Success: true}.String(), nil
+}
+
+// makeMatchLabel builds a JSON-marshalled MatchLabel for the given lobby type.
+func makeMatchLabel(t *testing.T, matchID MatchID, lobbyType LobbyType) string {
+	t.Helper()
+	label := &MatchLabel{
+		ID:        matchID,
+		LobbyType: lobbyType,
+	}
+	b, err := json.Marshal(label)
+	if err != nil {
+		t.Fatalf("marshal match label: %v", err)
+	}
+	return string(b)
+}
+
+// operatorCtx returns a context carrying a user ID (simulating an authenticated global operator).
+// Authorization is handled by middleware; this just supplies the user ID that the handler reads.
+func operatorCtx() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_USER_ID, uuid.Must(uuid.NewV4()).String())
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_NODE, "testnode")
+	return ctx
+}
+
+func TestShutdownMatchRpc_InvalidPayload(t *testing.T) {
+	nk := &shutdownNK{}
+	_, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, "not-json")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON payload, got nil")
+	}
+}
+
+func TestShutdownMatchRpc_MissingMatchID(t *testing.T) {
+	nk := &shutdownNK{}
+	payload := `{}`
+	_, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, payload)
+	if err == nil {
+		t.Fatal("expected error for missing match_id, got nil")
+	}
+	if !strings.Contains(err.Error(), "match_id") {
+		t.Errorf("error should mention match_id, got: %v", err)
+	}
+}
+
+func TestShutdownMatchRpc_MatchNotFound(t *testing.T) {
+	nk := &shutdownNK{matchLabel: ""} // MatchGet returns "not found"
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	payload, _ := json.Marshal(shutdownMatchRequest{MatchID: matchID})
+
+	_, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, string(payload))
+	if err == nil {
+		t.Fatal("expected error for non-existent match, got nil")
+	}
+}
+
+// TestShutdownMatchRpc_UnassignedLobby is the primary regression test:
+// a global operator must be able to terminate an unassigned (parked) game server.
+// Before the fix, this returned "match %s is not in a lobby".
+func TestShutdownMatchRpc_UnassignedLobby(t *testing.T) {
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	nk := &shutdownNK{matchLabel: makeMatchLabel(t, matchID, UnassignedLobby)}
+	payload, _ := json.Marshal(shutdownMatchRequest{MatchID: matchID, GraceSeconds: 5})
+
+	result, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, string(payload))
+	if err != nil {
+		t.Fatalf("global operator must be able to terminate unassigned match; got error: %v", err)
+	}
+
+	var resp shutdownMatchResponse
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("expected Success=true, got: %+v", resp)
+	}
+}
+
+func TestShutdownMatchRpc_PublicLobby(t *testing.T) {
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	nk := &shutdownNK{matchLabel: makeMatchLabel(t, matchID, PublicLobby)}
+	payload, _ := json.Marshal(shutdownMatchRequest{MatchID: matchID})
+
+	result, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, string(payload))
+	if err != nil {
+		t.Fatalf("global operator must be able to terminate public match; got error: %v", err)
+	}
+
+	var resp shutdownMatchResponse
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("expected Success=true, got: %+v", resp)
+	}
+}
+
+func TestShutdownMatchRpc_PrivateLobby(t *testing.T) {
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	nk := &shutdownNK{matchLabel: makeMatchLabel(t, matchID, PrivateLobby)}
+	payload, _ := json.Marshal(shutdownMatchRequest{MatchID: matchID})
+
+	result, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, nk, string(payload))
+	if err != nil {
+		t.Fatalf("global operator must be able to terminate private match; got error: %v", err)
+	}
+
+	var resp shutdownMatchResponse
+	if err := json.Unmarshal([]byte(result), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("expected Success=true, got: %+v", resp)
+	}
+}
+
+// TestShutdownMatchRpc_DefaultGraceSeconds verifies that omitting grace_seconds defaults to 10.
+func TestShutdownMatchRpc_DefaultGraceSeconds(t *testing.T) {
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	var capturedSignalData string
+	captureNK := &captureSignalNK{
+		matchLabel: makeMatchLabel(t, matchID, PublicLobby),
+		onSignal: func(data string) {
+			capturedSignalData = data
+		},
+	}
+
+	payload, _ := json.Marshal(shutdownMatchRequest{MatchID: matchID}) // no GraceSeconds
+	_, err := shutdownMatchRpc(operatorCtx(), &mockLogger{}, nil, captureNK, string(payload))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Decode the envelope and check GraceSeconds == 10
+	var env SignalEnvelope
+	if err := json.Unmarshal([]byte(capturedSignalData), &env); err != nil {
+		t.Fatalf("unmarshal signal envelope: %v", err)
+	}
+	var sdPayload SignalShutdownPayload
+	if err := json.Unmarshal(env.Payload, &sdPayload); err != nil {
+		t.Fatalf("unmarshal shutdown payload: %v", err)
+	}
+	if sdPayload.GraceSeconds != 10 {
+		t.Errorf("expected GraceSeconds=10, got %d", sdPayload.GraceSeconds)
+	}
+}
+
+// captureSignalNK records the signal data for inspection.
+type captureSignalNK struct {
+	runtime.NakamaModule
+	matchLabel string
+	onSignal   func(data string)
+}
+
+func (n *captureSignalNK) MatchGet(_ context.Context, matchID string) (*api.Match, error) {
+	return &api.Match{
+		MatchId:       matchID,
+		Authoritative: true,
+		Label:         &wrapperspb.StringValue{Value: n.matchLabel},
+	}, nil
+}
+
+func (n *captureSignalNK) MatchSignal(_ context.Context, _ string, data string) (string, error) {
+	if n.onSignal != nil {
+		n.onSignal(data)
+	}
+	return SignalResponse{Success: true}.String(), nil
+}


### PR DESCRIPTION
## Summary

Fixes a regression in `match/terminate` where global operators were blocked from terminating unassigned (parked) game servers. The handler incorrectly rejected any match with `LobbyType == UnassignedLobby` with the error _"match %s is not in a lobby"_.

## Root Cause

`shutdownMatchRpc` in `evr_runtime_rpc_match.go` contained a hard guard:

```go
if label.LobbyType == UnassignedLobby {
    return "", fmt.Errorf("match %s is not in a lobby", request.MatchID)
}
```

This predates the authorization middleware. Now that the RPC is gated behind `WithRPCAuthorization(GroupGlobalOperators)`, any caller who reaches the handler is already a verified global operator and **must** be able to shut down any match — including parked/unassigned game servers.

## Changes

### `server/evr_runtime_rpc_match.go`
- **Remove** `UnassignedLobby` lobby type check — global operators may terminate any match
- **Add** `MatchID.IsValid()` guard before calling `MatchLabelByID`
- **Add** nil check on `NewSignalEnvelope` result
- **Improve** error responses to use `runtime.NewError` with proper status codes

### `server/evr_runtime_rpc_match_test.go` _(new)_
- 7 unit tests for `shutdownMatchRpc`:
  - `InvalidPayload` — bad JSON returns error
  - `MissingMatchID` — empty `{}` returns error mentioning "match_id"
  - `MatchNotFound` — non-existent match returns error
  - **`UnassignedLobby`** — primary regression: unassigned match succeeds ✅
  - `PublicLobby` — public match succeeds
  - `PrivateLobby` — private match succeeds
  - `DefaultGraceSeconds` — omitting grace_seconds defaults to 10

### `server/evr_match_loop_blocking_test.go` _(new)_
- Regression test proving `MatchLoop` blocks when `allocatePostMatchSocialLobby` calls `nk.MatchSignal` synchronously inside the loop (the original blocking bug investigation)

## Testing

```
go test -short -vet=off ./server -run "TestShutdownMatchRpc" 
ok  github.com/heroiclabs/nakama/v3/server  0.015s
```

## Context: Changes Since v3.27.2-evr.245

This PR is targeted against `main` which contains the following work since the `.245` baseline:

### Features
| Commit | Description |
|--------|-------------|
| `08a16af` | `feat(rpc)`: TOT test management RPCs (CRUD + bulk-upload) + `get_client_role` endpoint |
| `0b7b5b6` | `feat(auth)`: `IsGlobalTesterAdmin` permission flag with edge state tracking |
| `83d1142` | `feat(discord)`: comprehensive `/search` command with permission controls |
| `301eb97` | `feat(cosmetics)`: cosmetic hashing system and guild management RPC |
| `7882c1b` | `feat(runtime)`: VRML verification and migration support |
| `c72bbfd` | `feat(match)`: match label system and statistics tracking |
| `966748e` | `feat(match)`: match ping request support |
| `56d4f0c` | `feat(moderation)`: `/lockout` command and ghost spam auto-kick |
| `e513f24` | `feat(evr)`: mock EchoVR client for local testing |
| `6ec4670` | `feat(evr)`: spark link in reservation activation DMs |
| `c8dae38` | `feat(evr)`: 20-minute no-show auto-vacate for reservations |
| `81eb0d3` | `feat(evr)`: `CheckNoShowReservations` integrated into cleanup ticker |
| `79f16a1` | `feat(discord)`: `--class` parameter for `/reserve` command |
| `e0af709` | `feat(discord)`: `--class` parameter for `/allocate` command |
| `d7e627b` | `feat(discord)`: `/vacate` command with handler and UI |
| `eb98ab4` | `feat(evr)`: `/vacate` command with grace period modes |
| `109e01f` | `feat(evr)`: time block configuration to `GroupMetadata` |
| `db1a8b6` | `feat(evr)`: `Classification` and `Owner` fields on `MatchLabel` (backward-compat) |
| `7c725be` | `feat(account)`: `break_alternates` RPC endpoint |
| `c7cbfde` | `feat(evr)`: allocate social lobby on private match completion |
| `82dae2e` | `feat(matchmaker)`: protect green division for moderators, max 2 per match |
| `118100c` | `feat(discord)`: confirmation flow + permission fix for `/shutdown-match` |
| `419f12a` | `feat`: cache system group permissions (eliminate redundant DB queries) |
| `8a456c6` | `refactor(account)`: `GamePauseSettings` moved to dedicated storage object |

### Bug Fixes
| Commit | Description |
|--------|-------------|
| `e10fb3b` | `fix(match)`: revert parking match timeout — `UnassignedLobby` with server is intended |
| `0807be0` | `fix(match)`: prevent parking match accumulation + fix preemption shutdown signal |
| `07e98dd` | `fix`: RPC permissions |
| `2b52bc8` | `fix(enforcement)`: re-read journals at join time to catch mid-session suspensions |
| `86dc6b4` | `fix(enforcement)`: respect `AllowPrivateLobbies` flag for private match kicks |
| `12ac877` | `fix(evr)`: `cleanupExpiredReservations` with audit logging |
| `6fc9a57` | `fix(evr)`: `GetGuildAuditChannelID` and `GetGroupIDByGuildIDNK` |
| `bda14875` | `fix(evr)`: `GetGuildIDByGroupID` (replace placeholder) |
| `49e21c1` | `fix(evr)`: `Classification` enum zero-value bug |

### Refactors / Chores
| Commit | Description |
|--------|-------------|
| `bfeeb77` | `chore(docker)`: build Nakama from local Dockerfile, upgrade Redis to 8 |
| `8ff0bbc` | `refactor(rpc)`: enhance RPC registration and storable types |
| `044c989` | `refactor(runtime)`: improve event logging and remote log set handling |
| `43c8fa6` | `refactor(discord)`: consolidate appbot command handlers |
| `e6a6baa` | `refactor(lobby)`: improve lobby parameters and matchmaking logic |
| `f8ae5af` | `chore`: purge unnecessary markdown, docs, and AI tooling directories |