### PR TITLE
fix(auth): fix RPC permissions - enforcers, allocators, and guild roles

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -4132,7 +4132,7 @@ func (d *DiscordAppBot) LogUserErrorMessage(ctx context.Context, groupID string,
 	return nil, nil
 }
 
-func (d *DiscordAppBot) createLookupSetIGNModal(currentDisplayName string, isLocked bool) *discordgo.InteractionResponse {
+func (d *DiscordAppBot) createLookupSetIGNModal(targetDiscordID, guildID, currentDisplayName string, isLocked bool) *discordgo.InteractionResponse {
 	// Determine the current lock status text
 	lockStatusText := "no"
 	if isLocked {
@@ -4142,7 +4142,7 @@ func (d *DiscordAppBot) createLookupSetIGNModal(currentDisplayName string, isLoc
 	return &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseModal,
 		Data: &discordgo.InteractionResponseData{
-			CustomID: "lookup:set_ign_modal",
+			CustomID: fmt.Sprintf("set_ign_modal:%s:%s", targetDiscordID, guildID),
 			Title:    "Override In-Game Name",
 			Components: []discordgo.MessageComponent{
 				discordgo.ActionsRow{

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -1584,13 +1584,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			err := handler.HandleVacateCommand(ctx, s, i, userID)
 
 			if err != nil {
-				return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-					Type: discordgo.InteractionResponseChannelMessageWithSource,
-					Data: &discordgo.InteractionResponseData{
-						Flags:   discordgo.MessageFlagsEphemeral,
-						Content: fmt.Sprintf("Error: %s", err.Error()),
-					},
-				})
+				return editInteractionResponse(s, i, fmt.Sprintf("Error: %s", err.Error()))
 			}
 
 			options := i.ApplicationCommandData().Options
@@ -1606,13 +1600,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				graceSeconds = 20
 			}
 
-			return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-				Type: discordgo.InteractionResponseChannelMessageWithSource,
-				Data: &discordgo.InteractionResponseData{
-					Flags:   discordgo.MessageFlagsEphemeral,
-					Content: fmt.Sprintf("Server vacated. Grace period: %ds", graceSeconds),
-				},
-			})
+			return editInteractionResponse(s, i, fmt.Sprintf("Server vacated. Grace period: %ds", graceSeconds))
 		},
 		"shutdown-match": func(ctx context.Context, logger runtime.Logger, s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User, member *discordgo.Member, userID string, groupID string) error {
 			if user == nil {

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -527,6 +527,49 @@ func (d *DiscordAppBot) handleInteractionMessageComponent(ctx context.Context, l
 		default:
 			return fmt.Errorf("unknown report server issue type: %s", issueType)
 		}
+	case "enf":
+		// Route enforcement button interactions (edit/void enforcement records)
+		// value format: "e:<recordID>:<guildID>:<targetDiscordID>" or "v:..."
+		return d.handleEnforcementInteraction(ctx, logger, s, i, value)
+	case "set_ign_override":
+		// value format: "<targetDiscordID>:<guildID>"
+		targetDiscordID, guildID, _ := strings.Cut(value, ":")
+		if targetDiscordID == "" || guildID == "" {
+			return fmt.Errorf("invalid set_ign_override parameters")
+		}
+		targetUserID := d.cache.DiscordIDToUserID(targetDiscordID)
+		if targetUserID == "" {
+			return fmt.Errorf("target user not found")
+		}
+		groupID := d.cache.GuildIDToGroupID(guildID)
+		if groupID == "" {
+			return fmt.Errorf("guild not found")
+		}
+		var evrProfile *EVRProfile
+		if a, err := d.nk.AccountGetId(ctx, targetUserID); err != nil {
+			return fmt.Errorf("failed to get account: %w", err)
+		} else if evrProfile, err = BuildEVRProfileFromAccount(a); err != nil {
+			return fmt.Errorf("failed to build EVR profile: %w", err)
+		}
+		ignData := evrProfile.GetGroupIGNData(groupID)
+		modal := d.createLookupSetIGNModal(targetDiscordID, guildID, ignData.DisplayName, ignData.IsLocked)
+		return s.InteractionRespond(i.Interaction, modal)
+	case "void_record":
+		// value format: "<recordID>:<guildID>:<targetDiscordID>"
+		parts := strings.SplitN(value, ":", 3)
+		if len(parts) != 3 {
+			return fmt.Errorf("invalid void_record parameters")
+		}
+		recordID, guildID, targetDiscordID := parts[0], parts[1], parts[2]
+		groupID := d.cache.GuildIDToGroupID(guildID)
+		if groupID == "" {
+			return fmt.Errorf("guild not found")
+		}
+		targetUserID := d.cache.DiscordIDToUserID(targetDiscordID)
+		if targetUserID == "" {
+			return fmt.Errorf("target user not found")
+		}
+		return d.showEnforcementVoidModal(s, i, recordID, groupID, targetUserID)
 	}
 
 	return nil

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -515,6 +515,18 @@ func (d *DiscordAppBot) handleInteractionMessageComponent(ctx context.Context, l
 				Content: fmt.Sprintf("🔗 **Direct Join Link**\n`%s`\n\n*Copy this link and paste it in your browser or EchoVR to join directly*", sparkLink),
 			},
 		})
+
+	case "report_server_issue":
+		// Parse value format: "<issueType>:<matchID>:<serverIP>:<regionCode>"
+		issueType, serverContext, _ := strings.Cut(value, ":")
+		switch issueType {
+		case "lag":
+			return d.handleReportServerIssueLag(ctx, logger, s, i, serverContext)
+		case "other":
+			return d.handleReportServerIssueOther(ctx, logger, s, i, serverContext)
+		default:
+			return fmt.Errorf("unknown report server issue type: %s", issueType)
+		}
 	}
 
 	return nil

--- a/server/evr_discord_appbot_ign_modal_test.go
+++ b/server/evr_discord_appbot_ign_modal_test.go
@@ -36,7 +36,7 @@ func TestCreateLookupSetIGNModal(t *testing.T) {
 			// Create an empty DiscordAppBot instance for testing
 			d := &DiscordAppBot{}
 
-			response := d.createLookupSetIGNModal(tt.currentDisplayName, tt.isLocked)
+			response := d.createLookupSetIGNModal("123456789", "987654321", tt.currentDisplayName, tt.isLocked)
 
 			if response.Type != discordgo.InteractionResponseModal {
 				t.Errorf("Expected InteractionResponseModal, got %v", response.Type)
@@ -46,8 +46,8 @@ func TestCreateLookupSetIGNModal(t *testing.T) {
 				t.Errorf("Expected title 'Override In-Game Name', got %s", response.Data.Title)
 			}
 
-			if response.Data.CustomID != "lookup:set_ign_modal" {
-				t.Errorf("Expected CustomID 'lookup:set_ign_modal', got %s", response.Data.CustomID)
+			if response.Data.CustomID != "set_ign_modal:123456789:987654321" {
+				t.Errorf("Expected CustomID 'set_ign_modal:123456789:987654321', got %s", response.Data.CustomID)
 			}
 
 			if len(response.Data.Components) != 2 {

--- a/server/evr_discord_reservation_dashboard.go
+++ b/server/evr_discord_reservation_dashboard.go
@@ -131,7 +131,7 @@ func (dm *ReservationDashboardManager) collectDashboardData(ctx context.Context,
 // collectServerCapacity gathers server capacity information
 func (dm *ReservationDashboardManager) collectServerCapacity(ctx context.Context, data *DashboardData) error {
 	// Get all active matches to calculate server usage
-	matches, err := dm.nk.MatchList(ctx, 1000, true, "", nil, nil, "*")
+	matches, err := dm.nk.MatchList(ctx, 100, true, "", nil, nil, "*")
 	if err != nil {
 		return err
 	}

--- a/server/evr_discord_sessions_channel.go
+++ b/server/evr_discord_sessions_channel.go
@@ -292,7 +292,7 @@ func (sm *SessionsChannelManager) createSessionEmbed(label *MatchLabel, guildGro
 				discordgo.Button{
 					Label:    "Taxi...",
 					Style:    discordgo.SecondaryButton,
-					CustomID: fmt.Sprintf("taxi_%s", sessionUUID),
+					CustomID: fmt.Sprintf("taxi:%s", sessionUUID),
 					Emoji: &discordgo.ComponentEmoji{
 						Name: "🚕",
 					},
@@ -300,7 +300,7 @@ func (sm *SessionsChannelManager) createSessionEmbed(label *MatchLabel, guildGro
 				discordgo.Button{
 					Label:    "Join...",
 					Style:    discordgo.SecondaryButton,
-					CustomID: fmt.Sprintf("join_%s", sessionUUID),
+					CustomID: fmt.Sprintf("join:%s", sessionUUID),
 					Emoji: &discordgo.ComponentEmoji{
 						Name: "🔗",
 					},

--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -600,7 +600,7 @@ func createEnforcementActionComponents(record GuildEnforcementRecord, profile *E
 					Emoji: &discordgo.ComponentEmoji{
 						Name: "heavy_multiplication_x",
 					},
-					CustomID: fmt.Sprintf("void_record:%s", record.ID),
+					CustomID: fmt.Sprintf("void_record:%s:%s:%s", record.ID, guild.ID, target.User.ID),
 				},
 			},
 		},

--- a/server/evr_lobby_builder.go
+++ b/server/evr_lobby_builder.go
@@ -27,7 +27,7 @@ const (
 	ReservationLifetimeSeconds     = 20
 	ServerAllocationTimeoutSeconds = 60
 	ServerAllocationRetrySeconds   = 5
-	MatchListLimit                 = 200
+	MatchListLimit                 = 100
 	MatchListMinSize               = 1
 	HighLatencyThresholdMs         = 100
 	RTTRoundingInterval            = 20

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -814,14 +814,13 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			},
 		}
 
-		msgs := []evr.Message{
-			// Legacy message for backwards compatibility with legacy game servers.
-			evr.NewGameServerEntrantRejected(code, rejects...),
-		}
-
+		// Build protobuf message first (preferred by newer game servers), falling back to
+		// legacy-only if protobuf creation fails. Unlike sendEntrantReject, MatchLeave
+		// continues regardless — not being able to notify the server is non-fatal here.
+		var msgs []evr.Message
 		msg, err := evr.NewNEVRProtobufMessageV1(envelope)
 		if err != nil {
-			logger.Warn("Failed to create protobuf message", zap.Error(err))
+			logger.Warn("Failed to create protobuf reject message, falling back to legacy: %v", err)
 		} else {
 			logger.WithFields(map[string]interface{}{
 				"rejects": rejects,
@@ -829,6 +828,8 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			}).Debug("Sending reject message to game server.")
 			msgs = append(msgs, msg)
 		}
+		// Legacy message for backwards compatibility with legacy game servers.
+		msgs = append(msgs, evr.NewGameServerEntrantRejected(code, rejects...))
 
 		if err := m.dispatchMessages(ctx, logger, dispatcher, msgs, []runtime.Presence{state.server}, nil); err != nil {
 			logger.Warn("Failed to dispatch message: %v", err)

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -797,12 +797,7 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 	}
 
 	if len(rejects) > 0 {
-
-		messages := make([]evr.Message, 0, len(rejects))
-
 		code := evr.PlayerRejectionReasonDisconnected
-		// Send legacy messages to the game server to notify the server to disconnect the players
-		messages = append(messages, evr.NewGameServerEntrantRejected(code, rejects...))
 
 		// Convert UUIDs to strings for protobuf
 		rejectIDs := make([]string, 0, len(rejects))
@@ -819,6 +814,11 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			},
 		}
 
+		msgs := []evr.Message{
+			// Legacy message for backwards compatibility with legacy game servers.
+			evr.NewGameServerEntrantRejected(code, rejects...),
+		}
+
 		msg, err := evr.NewNEVRProtobufMessageV1(envelope)
 		if err != nil {
 			logger.Warn("Failed to create protobuf message", zap.Error(err))
@@ -827,10 +827,10 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 				"rejects": rejects,
 				"code":    code,
 			}).Debug("Sending reject message to game server.")
-			messages = append(messages, msg)
+			msgs = append(msgs, msg)
 		}
 
-		if err := m.dispatchMessages(ctx, logger, dispatcher, messages, []runtime.Presence{state.server}, nil); err != nil {
+		if err := m.dispatchMessages(ctx, logger, dispatcher, msgs, []runtime.Presence{state.server}, nil); err != nil {
 			logger.Warn("Failed to dispatch message: %v", err)
 		}
 	}
@@ -1600,6 +1600,7 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 		return nil, fmt.Errorf("failed to create protobuf message: %w", err)
 	}
 
+
 	entrants := make([]evr.EvrId, 0, len(state.presenceByEvrID))
 	for evrID := range state.presenceByEvrID {
 		entrants = append(entrants, evrID)
@@ -1630,18 +1631,15 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 }
 
 func (m *EvrMatch) dispatchMessages(_ context.Context, logger runtime.Logger, dispatcher runtime.MatchDispatcher, messages []evr.Message, presences []runtime.Presence, sender runtime.Presence) error {
-	bytes := []byte{}
 	for _, message := range messages {
-
 		logger.Debug("Sending message from match: %v", message)
 		payload, err := evr.Marshal(message)
 		if err != nil {
 			return fmt.Errorf("could not marshal message: %w", err)
 		}
-		bytes = append(bytes, payload...)
-	}
-	if err := dispatcher.BroadcastMessageDeferred(OpCodeEVRPacketData, bytes, presences, sender, true); err != nil {
-		return fmt.Errorf("could not broadcast message: %w", err)
+		if err := dispatcher.BroadcastMessageDeferred(OpCodeEVRPacketData, payload, presences, sender, true); err != nil {
+			return fmt.Errorf("could not broadcast message: %w", err)
+		}
 	}
 	return nil
 }
@@ -1691,7 +1689,6 @@ func (m *EvrMatch) sendEntrantReject(ctx context.Context, logger runtime.Logger,
 		// Legacy message for backwards compatibility with legacy game servers.
 		evr.NewGameServerEntrantRejected(reason, entrantIDs...),
 	}
-
 	if err := m.dispatchMessages(ctx, logger, dispatcher, msgs, []runtime.Presence{server}, nil); err != nil {
 		return fmt.Errorf("failed to dispatch message: %w", err)
 	}

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -117,10 +117,22 @@ func sendDiscordServerError(internalIP net.IP, externalIP net.IP, port uint16, s
 // errFailedRegistration sends a failure message to the broadcaster and closes the session
 func errFailedRegistration(session *sessionWS, logger *zap.Logger, err error, code evr.BroadcasterRegistrationFailureCode) error {
 	logger.Warn("Failed to register game server", zap.Error(err))
-	if err := session.SendEvrUnrequire(evr.NewBroadcasterRegistrationFailure(code)); err != nil {
-		return fmt.Errorf("failed to send lobby registration failure: %w", err)
+	envelope := &rtapi.Envelope{
+		Message: &rtapi.Envelope_Error{
+			Error: &rtapi.Error{
+				Code:    int32(rtapi.Error_CODE_REGISTRATION_FAILED),
+				Message: err.Error(),
+			},
+		},
 	}
-
+	msg, msgErr := evr.NewNEVRProtobufMessageV1(envelope)
+	if msgErr != nil {
+		logger.Warn("Failed to create protobuf registration failure message", zap.Error(msgErr))
+		// Fall back to legacy message
+		_ = session.SendEvrUnrequire(evr.NewBroadcasterRegistrationFailure(code))
+	} else {
+		_ = session.SendEvrUnrequire(msg, evr.NewBroadcasterRegistrationFailure(code))
+	}
 	session.Close(err.Error(), runtime.PresenceReasonDisconnect)
 	return fmt.Errorf("failed to register game server: %w", err)
 }
@@ -432,11 +444,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 		return session.SendEvrUnrequire(evr.NewBroadcasterRegistrationSuccess(config.ServerID, config.Endpoint.ExternalIP))
 	}
 
-	// Send both protobuf and legacy messages for backwards compatibility
-	return session.SendEvrUnrequire(
-		protobufMsg,
-		evr.NewBroadcasterRegistrationSuccess(config.ServerID, config.Endpoint.ExternalIP),
-	)
+	return session.SendEvrUnrequire(protobufMsg, evr.NewBroadcasterRegistrationSuccess(config.ServerID, config.Endpoint.ExternalIP))
 }
 
 // buildRegionCodes constructs the region codes list and determines the default region.

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -127,11 +127,13 @@ func errFailedRegistration(session *sessionWS, logger *zap.Logger, err error, co
 	}
 	msg, msgErr := evr.NewNEVRProtobufMessageV1(envelope)
 	if msgErr != nil {
-		logger.Warn("Failed to create protobuf registration failure message", zap.Error(msgErr))
-		// Fall back to legacy message
-		_ = session.SendEvrUnrequire(evr.NewBroadcasterRegistrationFailure(code))
+		if sendErr := session.SendEvrUnrequire(evr.NewBroadcasterRegistrationFailure(code)); sendErr != nil {
+			logger.Warn("Failed to send legacy registration failure message", zap.Error(sendErr))
+		}
 	} else {
-		_ = session.SendEvrUnrequire(msg, evr.NewBroadcasterRegistrationFailure(code))
+		if sendErr := session.SendEvrUnrequire(msg, evr.NewBroadcasterRegistrationFailure(code)); sendErr != nil {
+			logger.Warn("Failed to send registration failure message", zap.Error(sendErr))
+		}
 	}
 	session.Close(err.Error(), runtime.PresenceReasonDisconnect)
 	return fmt.Errorf("failed to register game server: %w", err)

--- a/server/evr_pipeline_lobby.go
+++ b/server/evr_pipeline_lobby.go
@@ -101,29 +101,21 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		}
 		messages = append(messages, message)
 	}
-
-	// Legacy support - send after protobuf messages
+	// Legacy support - send alongside protobuf messages for backwards compatibility.
 	if len(acceptedIDs) > 0 {
 		uuids := make([]uuid.UUID, 0, len(acceptedIDs))
 		for _, id := range acceptedIDs {
 			uuids = append(uuids, uuid.FromStringOrNil(id))
 		}
-
-		messages = append(messages,
-			evr.NewGameServerJoinAllowed(uuids...), // Legacy message for backwards compatibility.
-		)
+		messages = append(messages, evr.NewGameServerJoinAllowed(uuids...))
 	}
 	if len(rejectedIDs) > 0 {
 		uuids := make([]uuid.UUID, 0, len(rejectedIDs))
 		for _, id := range rejectedIDs {
 			uuids = append(uuids, uuid.FromStringOrNil(id))
 		}
-		messages = append(messages,
-			evr.NewGameServerEntrantRejected(evr.PlayerRejectionReasonBadRequest, uuids...), // Legacy message for backwards compatibility.
-		)
+		messages = append(messages, evr.NewGameServerEntrantRejected(evr.PlayerRejectionReasonBadRequest, uuids...))
 	}
-	// End Legacy Support
-
 	return session.SendEvr(messages...)
 }
 

--- a/server/evr_reservation_integration.go
+++ b/server/evr_reservation_integration.go
@@ -207,7 +207,7 @@ func (sum *ServerUtilizationMonitor) StartMonitoring(ctx context.Context, dg *di
 
 // checkUtilization checks all matches for low utilization and sends notifications
 func (sum *ServerUtilizationMonitor) checkUtilization(ctx context.Context, dg *discordgo.Session) {
-	matches, err := sum.nk.MatchList(ctx, 1000, true, "", nil, nil, "*")
+	matches, err := sum.nk.MatchList(ctx, 100, true, "", nil, nil, "*")
 	if err != nil {
 		sum.logger.Error("Failed to list matches for utilization monitoring: %v", err)
 		return

--- a/server/evr_runtime_rpc.go
+++ b/server/evr_runtime_rpc.go
@@ -71,7 +71,7 @@ func (h *RPCHandler) MatchListPublicRPC(ctx context.Context, logger runtime.Logg
 
 	minSize := 1
 	query := "*"
-	matches, err := nk.MatchList(ctx, 1000, true, "", &minSize, nil, query)
+	matches, err := nk.MatchList(ctx, 100, true, "", &minSize, nil, query)
 	if err != nil {
 		return "", runtime.NewError("Failed to list matches", StatusInternalError)
 	}
@@ -274,7 +274,7 @@ func MatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime
 	} else {
 
 		// Get all the matches
-		matches, err = nk.MatchList(ctx, 1000, true, "", nil, nil, request.Query)
+		matches, err = nk.MatchList(ctx, 100, true, "", nil, nil, request.Query)
 		if err != nil {
 			return "", fmt.Errorf("failed to list matches: %s", err.Error())
 		}

--- a/server/evr_runtime_rpc.go
+++ b/server/evr_runtime_rpc.go
@@ -347,22 +347,16 @@ func KickPlayerRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk ru
 	if !ok {
 		return "", runtime.NewError("authentication required", StatusUnauthenticated)
 	}
+	var err error
 
-	guildGroups, err := GuildUserGroupsList(ctx, nk, nil, callerID)
-	if err != nil {
-		return "", err
-	}
-
-	// Get a slice of groupIDs that this user is a moderator for
-	var groupIDs []string
-	for groupID, g := range guildGroups {
-		if g.IsEnforcer(callerID) {
-			groupIDs = append(groupIDs, groupID)
+	isGlobalOperator := false
+	if perms := PermissionsFromContext(ctx); perms != nil {
+		isGlobalOperator = perms.IsGlobalOperator
+	} else {
+		isGlobalOperator, err = CheckSystemGroupMembership(ctx, db, callerID, GroupGlobalOperators)
+		if err != nil {
+			return "", runtime.NewError("failed to check operator permissions", StatusInternalError)
 		}
-	}
-
-	if len(groupIDs) == 0 {
-		return "", runtime.NewError("unauthorized: not a moderator for any guilds.", StatusPermissionDenied)
 	}
 
 	// Get the match of the user
@@ -385,13 +379,22 @@ func KickPlayerRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk ru
 		if err != nil {
 			return "", err
 		}
-		if slices.Contains(groupIDs, label.GetGroupID().String()) {
+		authorized := isGlobalOperator
+		if !authorized {
+			if label.GetGroupID().IsNil() {
+				continue
+			}
+			_, _, _, authErr := RequireEnforcerOrOperator(ctx, db, nk, callerID, label.GetGroupID().String())
+			authorized = authErr == nil
+		}
+
+		if authorized {
 			sessionIDs = append(sessionIDs, p.GetSessionId())
 		}
 	}
 
 	if len(sessionIDs) == 0 {
-		return "", fmt.Errorf("user not in a match that the caller is a moderator for")
+		return "", runtime.NewError("user not in a match that the caller can moderate", StatusPermissionDenied)
 	}
 
 	for _, sessionID := range sessionIDs {
@@ -974,8 +977,17 @@ func PrepareMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		return "", runtime.NewError(err.Error(), StatusInternalError)
 	}
 
-	// Validate that the user has permissions to allocate for the guild
-	if !gg.HasRole(userID, gg.RoleMap.Allocator) {
+	isGlobalOperator := false
+	if perms := PermissionsFromContext(ctx); perms != nil {
+		isGlobalOperator = perms.IsGlobalOperator
+	} else {
+		isGlobalOperator, err = CheckSystemGroupMembership(ctx, db, userID, GroupGlobalOperators)
+		if err != nil {
+			return "", runtime.NewError("failed to check operator permissions", StatusInternalError)
+		}
+	}
+
+	if !isGlobalOperator && !gg.IsAllocator(userID) {
 		return "", runtime.NewError("user must have the `allocator` in the guild.", StatusPermissionDenied)
 	}
 

--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -310,8 +310,13 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 
 	_, _, gg, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
 	if err != nil {
+		// Allow guild owners to view journals even if they are not enforcers/operators.
 		var runtimeErr *runtime.Error
-		if !errors.As(err, &runtimeErr) || runtimeErr.Code != StatusPermissionDenied || gg == nil || !gg.IsOwner(userID) {
+		isPermissionDenied := errors.As(err, &runtimeErr) && runtimeErr.Code == StatusPermissionDenied
+		isOwner := gg != nil && gg.IsOwner(userID)
+		if isPermissionDenied && isOwner {
+			// Owner bypass: guild owner can view enforcement journals even without enforcer role
+		} else {
 			logger.Error("Permission check failed", zap.Error(err))
 			return "", err
 		}

--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -308,22 +308,12 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 
 	userID := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
 
-	// Check if the caller is a global operator
-	isGlobalOperator, err := CheckSystemGroupMembership(ctx, db, userID, GroupGlobalOperators)
+	_, _, gg, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
 	if err != nil {
-		logger.Error("Failed to check global operator status", zap.Error(err))
-		return "", runtime.NewError("Failed to check permissions", StatusInternalError)
-	}
-
-	if !isGlobalOperator {
-		// Check if the caller is the guild owner
-		isOwner, err := checkGroupOwner(ctx, db, userID, request.GroupID)
-		if err != nil {
-			logger.Error("Failed to check guild ownership", zap.Error(err))
-			return "", runtime.NewError("Failed to check permissions", StatusInternalError)
-		}
-		if !isOwner {
-			return "", runtime.NewError("Permission denied: not a guild owner", StatusPermissionDenied)
+		var runtimeErr *runtime.Error
+		if !errors.As(err, &runtimeErr) || runtimeErr.Code != StatusPermissionDenied || gg == nil || !gg.IsOwner(userID) {
+			logger.Error("Permission check failed", zap.Error(err))
+			return "", err
 		}
 	}
 
@@ -386,19 +376,6 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 	}
 
 	return string(responseData), nil
-}
-
-func checkGroupOwner(ctx context.Context, db *sql.DB, userID, groupID string) (bool, error) {
-	// Check if the user is a superadmin (owner) of the group
-	query := `
-		SELECT count(1) FROM group_edge 
-		WHERE source_id = $1 AND destination_id = $2 AND state = $3
-	`
-	var count int
-	if err := db.QueryRowContext(ctx, query, userID, groupID, int(api.UserGroupList_UserGroup_SUPERADMIN)).Scan(&count); err != nil {
-		return false, err
-	}
-	return count > 0, nil
 }
 
 // EnforcementRecordEditRequest represents the request to edit an enforcement record

--- a/server/evr_runtime_rpc_enhanced_allocation.go
+++ b/server/evr_runtime_rpc_enhanced_allocation.go
@@ -213,7 +213,7 @@ func processNormalAllocation(ctx context.Context, logger runtime.Logger, db *sql
 // checkServerAvailability checks if there are available servers
 func checkServerAvailability(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger) (bool, error) {
 	// Get current match count
-	matches, err := nk.MatchList(ctx, 1000, true, "", nil, nil, "*")
+	matches, err := nk.MatchList(ctx, 100, true, "", nil, nil, "*")
 	if err != nil {
 		return false, err
 	}

--- a/server/evr_runtime_rpc_healthcheck.go
+++ b/server/evr_runtime_rpc_healthcheck.go
@@ -31,7 +31,7 @@ func HealthCheckRPC(ctx context.Context, logger nakamaRuntime.Logger, db *sql.DB
 	matches, err := nk.MatchList(ctx, 100, true, "", nil, nil, "")
 	activeMatches := 0
 	if err != nil {
-		logger.Warn("healthcheck: failed to list matches: %v", err)
+		logger.Warn("healthcheck: failed to list matches", "error", err.Error())
 	} else {
 		activeMatches = len(matches)
 	}

--- a/server/evr_runtime_rpc_healthcheck.go
+++ b/server/evr_runtime_rpc_healthcheck.go
@@ -28,7 +28,7 @@ func HealthCheckRPC(ctx context.Context, logger nakamaRuntime.Logger, db *sql.DB
 
 	uptime := time.Since(nakamaStartTime)
 
-	matches, err := nk.MatchList(ctx, 1000, true, "", nil, nil, "")
+	matches, err := nk.MatchList(ctx, 100, true, "", nil, nil, "")
 	activeMatches := 0
 	if err != nil {
 		logger.Warn("healthcheck: failed to list matches: %v", err)

--- a/server/evr_runtime_rpc_healthcheck.go
+++ b/server/evr_runtime_rpc_healthcheck.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"runtime"
+	"time"
+
+	nakamaRuntime "github.com/heroiclabs/nakama-common/runtime"
+)
+
+type HealthCheckResponse struct {
+	Status        string `json:"status"`
+	Node          string `json:"node"`
+	Version       string `json:"version"`
+	StartTime     string `json:"start_time"`
+	UptimeSeconds int64  `json:"uptime_seconds"`
+	GoVersion     string `json:"go_version"`
+	NumCPU        int    `json:"num_cpu"`
+	NumGoroutine  int    `json:"num_goroutine"`
+	ActiveMatches int    `json:"active_matches"`
+}
+
+func HealthCheckRPC(ctx context.Context, logger nakamaRuntime.Logger, db *sql.DB, nk nakamaRuntime.NakamaModule, payload string) (string, error) {
+	node, _ := ctx.Value(nakamaRuntime.RUNTIME_CTX_NODE).(string)
+	version, _ := ctx.Value(nakamaRuntime.RUNTIME_CTX_VERSION).(string)
+
+	uptime := time.Since(nakamaStartTime)
+
+	matches, err := nk.MatchList(ctx, 10000, true, "", nil, nil, "")
+	activeMatches := 0
+	if err != nil {
+		logger.Warn("healthcheck: failed to list matches: %v", err)
+	} else {
+		activeMatches = len(matches)
+	}
+
+	resp := HealthCheckResponse{
+		Status:        "ok",
+		Node:          node,
+		Version:       version,
+		StartTime:     nakamaStartTime.Format(time.RFC3339),
+		UptimeSeconds: int64(uptime.Seconds()),
+		GoVersion:     runtime.Version(),
+		NumCPU:        runtime.NumCPU(),
+		NumGoroutine:  runtime.NumGoroutine(),
+		ActiveMatches: activeMatches,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", nakamaRuntime.NewError("failed to marshal healthcheck response", StatusInternalError)
+	}
+	return string(data), nil
+}

--- a/server/evr_runtime_rpc_healthcheck.go
+++ b/server/evr_runtime_rpc_healthcheck.go
@@ -28,7 +28,7 @@ func HealthCheckRPC(ctx context.Context, logger nakamaRuntime.Logger, db *sql.DB
 
 	uptime := time.Since(nakamaStartTime)
 
-	matches, err := nk.MatchList(ctx, 10000, true, "", nil, nil, "")
+	matches, err := nk.MatchList(ctx, 1000, true, "", nil, nil, "")
 	activeMatches := 0
 	if err != nil {
 		logger.Warn("healthcheck: failed to list matches: %v", err)

--- a/server/evr_runtime_rpc_match.go
+++ b/server/evr_runtime_rpc_match.go
@@ -91,8 +91,23 @@ func AllocateMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk
 		return "", runtime.NewError(err.Error(), StatusInternalError)
 	}
 
-	// Validate that the user has permissions to allocate to the target guild
-	if !gg.HasRole(userID, gg.RoleMap.Allocator) {
+	isGlobalOperator := false
+	isGlobalBot := false
+	if perms := PermissionsFromContext(ctx); perms != nil {
+		isGlobalOperator = perms.IsGlobalOperator
+		isGlobalBot = perms.IsGlobalBot
+	} else {
+		isGlobalOperator, err = CheckSystemGroupMembership(ctx, db, userID, GroupGlobalOperators)
+		if err != nil {
+			return "", runtime.NewError("failed to check operator permissions", StatusInternalError)
+		}
+		isGlobalBot, err = CheckSystemGroupMembership(ctx, db, userID, GroupGlobalBots)
+		if err != nil {
+			return "", runtime.NewError("failed to check bot permissions", StatusInternalError)
+		}
+	}
+
+	if !isGlobalOperator && !isGlobalBot && !gg.IsAllocator(userID) {
 		return "", runtime.NewError("user must have the `allocator` in the guild.", StatusPermissionDenied)
 	}
 
@@ -143,9 +158,9 @@ func AllocateMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk
 		Level:            evr.ToSymbol(request.Level),
 		TeamSize:         int(request.TeamSize.GetValue()),
 		StartTime:        request.ExpiryTime.AsTime().UTC(),
-		SpawnedBy:        userID,  // The actual user making the request
-		Owner:            request.OwnerId,  // The designated owner (can be different from spawner)
-		Classification:   ClassificationNone,  // Default classification, can be overridden
+		SpawnedBy:        userID,             // The actual user making the request
+		Owner:            request.OwnerId,    // The designated owner (can be different from spawner)
+		Classification:   ClassificationNone, // Default classification, can be overridden
 		GroupID:          uuid.FromStringOrNil(request.GroupId),
 		RequiredFeatures: request.RequiredFeatures,
 		TeamAlignments:   teamAlignments,
@@ -262,10 +277,30 @@ func shutdownMatchRpc(ctx context.Context, logger runtime.Logger, db *sql.DB, nk
 		return "", runtime.NewError("match_id is required", StatusInvalidArgument)
 	}
 
-	// Verify the match exists. Global operators may terminate any match regardless of lobby type.
-	if _, err := MatchLabelByID(ctx, nk, request.MatchID); err != nil {
+	label, err := MatchLabelByID(ctx, nk, request.MatchID)
+	if err != nil {
 		return "", err
 	}
+
+	isGlobalOperator := false
+	if perms := PermissionsFromContext(ctx); perms != nil {
+		isGlobalOperator = perms.IsGlobalOperator
+	} else {
+		isGlobalOperator, err = CheckSystemGroupMembership(ctx, db, r.UserID, GroupGlobalOperators)
+		if err != nil {
+			return "", runtime.NewError("failed to check operator permissions", StatusInternalError)
+		}
+	}
+
+	if !isGlobalOperator {
+		if label.GetGroupID().IsNil() {
+			return "", runtime.NewError("permission denied", StatusPermissionDenied)
+		}
+		if _, _, _, err := RequireEnforcerOrOperator(ctx, db, nk, r.UserID, label.GetGroupID().String()); err != nil {
+			return "", err
+		}
+	}
+
 	if request.GraceSeconds <= 0 {
 		request.GraceSeconds = 10
 	}

--- a/server/evr_runtime_rpc_mmr.go
+++ b/server/evr_runtime_rpc_mmr.go
@@ -1,0 +1,318 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// UpdateMMRRequest is the request payload for the player/mmr/update RPC.
+type UpdateMMRRequest struct {
+	UserID  string  `json:"user_id"`
+	GroupID string  `json:"group_id"`
+	Mode    string  `json:"mode"`    // e.g. "echo_arena", "echo_combat"
+	Mu      float64 `json:"mu"`      // New Mu value
+	Sigma   float64 `json:"sigma"`   // New Sigma value
+}
+
+// UpdateMMRResponse is the response payload for the player/mmr/update RPC.
+type UpdateMMRResponse struct {
+	Success  bool    `json:"success"`
+	UserID   string  `json:"user_id"`
+	GroupID  string  `json:"group_id"`
+	Mode     string  `json:"mode"`
+	Mu       float64 `json:"mu"`
+	Sigma    float64 `json:"sigma"`
+	Ordinal  float64 `json:"ordinal"`
+}
+
+// GetMMRRequest is the request payload for the player/mmr/get RPC.
+type GetMMRRequest struct {
+	UserID  string `json:"user_id"`
+	GroupID string `json:"group_id"`
+	Mode    string `json:"mode"` // e.g. "echo_arena", "echo_combat"
+}
+
+// GetMMRResponse is the response payload for the player/mmr/get RPC.
+type GetMMRResponse struct {
+	UserID       string   `json:"user_id"`
+	GroupID      string   `json:"group_id"`
+	Mode         string   `json:"mode"`
+	Mu           float64  `json:"mu"`
+	Sigma        float64  `json:"sigma"`
+	Ordinal      float64  `json:"ordinal"`
+	StaticMu     *float64 `json:"static_mu"`
+	StaticSigma  *float64 `json:"static_sigma"`
+	IsStatic     bool     `json:"is_static"`
+}
+
+// SetStaticMMRRequest is the request payload for the player/mmr/static RPC.
+type SetStaticMMRRequest struct {
+	UserID  string   `json:"user_id"`
+	Enable  bool     `json:"enable"`
+	Mu      *float64 `json:"mu,omitempty"`    // Required when Enable=true
+	Sigma   *float64 `json:"sigma,omitempty"` // Required when Enable=true
+}
+
+// SetStaticMMRResponse is the response payload for the player/mmr/static RPC.
+type SetStaticMMRResponse struct {
+	Success bool     `json:"success"`
+	UserID  string   `json:"user_id"`
+	Enable  bool     `json:"enable"`
+	Mu      *float64 `json:"mu,omitempty"`
+	Sigma   *float64 `json:"sigma,omitempty"`
+	Version string   `json:"version"`
+}
+
+// GetMMRRPC retrieves a player's current MMR from leaderboards and static config.
+func GetMMRRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	var req GetMMRRequest
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		return "", runtime.NewError("Invalid request payload", StatusInvalidArgument)
+	}
+
+	if req.UserID == "" {
+		return "", runtime.NewError("user_id is required", StatusInvalidArgument)
+	}
+	if req.GroupID == "" {
+		return "", runtime.NewError("group_id is required", StatusInvalidArgument)
+	}
+	if req.Mode == "" {
+		return "", runtime.NewError("mode is required", StatusInvalidArgument)
+	}
+
+	mode := evr.ToSymbol(req.Mode)
+
+	// Load the team rating from leaderboards
+	rating, err := MatchmakingRatingLoad(ctx, nk, req.UserID, req.GroupID, mode)
+	if err != nil {
+		logger.WithFields(map[string]interface{}{
+			"user_id":  req.UserID,
+			"group_id": req.GroupID,
+			"mode":     req.Mode,
+			"error":    err,
+		}).Error("Failed to load MMR")
+		return "", runtime.NewError("Failed to load MMR", StatusInternalError)
+	}
+
+	// Load the user's matchmaking settings to check for static MMR
+	var settings MatchmakingSettings
+	err = StorableRead(ctx, nk, req.UserID, &settings, false)
+
+	resp := GetMMRResponse{
+		UserID:  req.UserID,
+		GroupID: req.GroupID,
+		Mode:    req.Mode,
+		Mu:      rating.Mu,
+		Sigma:   rating.Sigma,
+		Ordinal: rating.Mu - float64(rating.Z)*rating.Sigma,
+	}
+
+	// If we loaded settings successfully, include static MMR info
+	if err == nil {
+		resp.StaticMu = settings.StaticRatingMu
+		resp.StaticSigma = settings.StaticRatingSigma
+		resp.IsStatic = settings.StaticRatingMu != nil && settings.StaticRatingSigma != nil
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", runtime.NewError("Failed to marshal response", StatusInternalError)
+	}
+	return string(data), nil
+}
+
+// UpdateMMRRPC updates a player's MMR leaderboard records.
+// Only Global Operators can call this RPC.
+func UpdateMMRRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	var req UpdateMMRRequest
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		return "", runtime.NewError("Invalid request payload", StatusInvalidArgument)
+	}
+
+	if req.UserID == "" {
+		return "", runtime.NewError("user_id is required", StatusInvalidArgument)
+	}
+	if req.GroupID == "" {
+		return "", runtime.NewError("group_id is required", StatusInvalidArgument)
+	}
+	if req.Mode == "" {
+		return "", runtime.NewError("mode is required", StatusInvalidArgument)
+	}
+
+	mode := evr.ToSymbol(req.Mode)
+	operatorSet := 2 // api.Operator_SET
+
+	// Resolve the user's display name for the leaderboard record
+	users, err := nk.UsersGetId(ctx, []string{req.UserID}, nil)
+	if err != nil || len(users) == 0 {
+		return "", runtime.NewError("User not found", StatusNotFound)
+	}
+	displayName := users[0].GetDisplayName()
+
+	// Write Mu to leaderboard
+	muBoardID := StatisticBoardID(req.GroupID, mode, TeamSkillRatingMuStatisticID, evr.ResetScheduleAllTime)
+	muScore, muSubscore, err := Float64ToScore(req.Mu)
+	if err != nil {
+		return "", runtime.NewError(fmt.Sprintf("Invalid Mu value: %v", err), StatusInvalidArgument)
+	}
+
+	if _, err := nk.LeaderboardRecordWrite(ctx, muBoardID, req.UserID, displayName, muScore, muSubscore, nil, &operatorSet); err != nil {
+		// Try creating the leaderboard first
+		if createErr := nk.LeaderboardCreate(ctx, muBoardID, true, "desc", "set", "", nil, true); createErr != nil {
+			logger.WithFields(map[string]interface{}{
+				"leaderboard_id": muBoardID,
+				"error":          createErr,
+			}).Error("Failed to create Mu leaderboard")
+			return "", runtime.NewError("Failed to write Mu leaderboard", StatusInternalError)
+		}
+		if _, err := nk.LeaderboardRecordWrite(ctx, muBoardID, req.UserID, displayName, muScore, muSubscore, nil, &operatorSet); err != nil {
+			logger.WithFields(map[string]interface{}{
+				"leaderboard_id": muBoardID,
+				"error":          err,
+			}).Error("Failed to write Mu leaderboard record")
+			return "", runtime.NewError("Failed to write Mu leaderboard", StatusInternalError)
+		}
+	}
+
+	// Write Sigma to leaderboard
+	sigmaBoardID := StatisticBoardID(req.GroupID, mode, TeamSkillRatingSigmaStatisticID, evr.ResetScheduleAllTime)
+	sigmaScore, sigmaSubscore, err := Float64ToScore(req.Sigma)
+	if err != nil {
+		return "", runtime.NewError(fmt.Sprintf("Invalid Sigma value: %v", err), StatusInvalidArgument)
+	}
+
+	if _, err := nk.LeaderboardRecordWrite(ctx, sigmaBoardID, req.UserID, displayName, sigmaScore, sigmaSubscore, nil, &operatorSet); err != nil {
+		if createErr := nk.LeaderboardCreate(ctx, sigmaBoardID, true, "desc", "set", "", nil, true); createErr != nil {
+			logger.WithFields(map[string]interface{}{
+				"leaderboard_id": sigmaBoardID,
+				"error":          createErr,
+			}).Error("Failed to create Sigma leaderboard")
+			return "", runtime.NewError("Failed to write Sigma leaderboard", StatusInternalError)
+		}
+		if _, err := nk.LeaderboardRecordWrite(ctx, sigmaBoardID, req.UserID, displayName, sigmaScore, sigmaSubscore, nil, &operatorSet); err != nil {
+			logger.WithFields(map[string]interface{}{
+				"leaderboard_id": sigmaBoardID,
+				"error":          err,
+			}).Error("Failed to write Sigma leaderboard record")
+			return "", runtime.NewError("Failed to write Sigma leaderboard", StatusInternalError)
+		}
+	}
+
+	// Also write the ordinal
+	ordinal := req.Mu - 3*req.Sigma // Z=3 default
+	ordinalBoardID := StatisticBoardID(req.GroupID, mode, TeamSkillRatingOrdinalStatisticID, evr.ResetScheduleAllTime)
+	ordinalScore, ordinalSubscore, err := Float64ToScore(ordinal)
+	if err == nil {
+		if _, err := nk.LeaderboardRecordWrite(ctx, ordinalBoardID, req.UserID, displayName, ordinalScore, ordinalSubscore, nil, &operatorSet); err != nil {
+			// Non-fatal: ordinal leaderboard may not exist yet
+			if createErr := nk.LeaderboardCreate(ctx, ordinalBoardID, true, "desc", "set", "", nil, true); createErr == nil {
+				nk.LeaderboardRecordWrite(ctx, ordinalBoardID, req.UserID, displayName, ordinalScore, ordinalSubscore, nil, &operatorSet)
+			}
+		}
+	}
+
+	callerID, _ := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
+	logger.WithFields(map[string]interface{}{
+		"caller_id": callerID,
+		"user_id":   req.UserID,
+		"group_id":  req.GroupID,
+		"mode":      req.Mode,
+		"mu":        req.Mu,
+		"sigma":     req.Sigma,
+		"ordinal":   ordinal,
+	}).Info("MMR updated by operator")
+
+	resp := UpdateMMRResponse{
+		Success: true,
+		UserID:  req.UserID,
+		GroupID: req.GroupID,
+		Mode:    req.Mode,
+		Mu:      req.Mu,
+		Sigma:   req.Sigma,
+		Ordinal: ordinal,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", runtime.NewError("Failed to marshal response", StatusInternalError)
+	}
+	return string(data), nil
+}
+
+// SetStaticMMRRPC enables or disables static MMR for a player.
+// When enabled, the player's matchmaking will use the specified static values
+// instead of their dynamic leaderboard rating.
+// Only Global Operators can call this RPC.
+func SetStaticMMRRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (string, error) {
+	var req SetStaticMMRRequest
+	if err := json.Unmarshal([]byte(payload), &req); err != nil {
+		return "", runtime.NewError("Invalid request payload", StatusInvalidArgument)
+	}
+
+	if req.UserID == "" {
+		return "", runtime.NewError("user_id is required", StatusInvalidArgument)
+	}
+
+	if req.Enable && (req.Mu == nil || req.Sigma == nil) {
+		return "", runtime.NewError("mu and sigma are required when enabling static MMR", StatusInvalidArgument)
+	}
+
+	// Load the existing matchmaking settings
+	var settings MatchmakingSettings
+	err := StorableRead(ctx, nk, req.UserID, &settings, true)
+	if err != nil {
+		logger.WithFields(map[string]interface{}{
+			"user_id": req.UserID,
+			"error":   err,
+		}).Error("Failed to read matchmaking settings")
+		return "", runtime.NewError("Failed to read matchmaking settings", StatusInternalError)
+	}
+
+	// Update static rating fields
+	if req.Enable {
+		settings.StaticRatingMu = req.Mu
+		settings.StaticRatingSigma = req.Sigma
+	} else {
+		settings.StaticRatingMu = nil
+		settings.StaticRatingSigma = nil
+	}
+
+	// Write back the updated settings
+	if err := StorableWrite(ctx, nk, req.UserID, &settings); err != nil {
+		logger.WithFields(map[string]interface{}{
+			"user_id": req.UserID,
+			"error":   err,
+		}).Error("Failed to write matchmaking settings")
+		return "", runtime.NewError("Failed to write matchmaking settings", StatusInternalError)
+	}
+
+	callerID, _ := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
+	logger.WithFields(map[string]interface{}{
+		"caller_id": callerID,
+		"user_id":   req.UserID,
+		"enable":    req.Enable,
+		"mu":        req.Mu,
+		"sigma":     req.Sigma,
+	}).Info("Static MMR setting updated by operator")
+
+	meta := settings.StorageMeta()
+	resp := SetStaticMMRResponse{
+		Success: true,
+		UserID:  req.UserID,
+		Enable:  req.Enable,
+		Mu:      settings.StaticRatingMu,
+		Sigma:   settings.StaticRatingSigma,
+		Version: meta.Version,
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		return "", runtime.NewError("Failed to marshal response", StatusInternalError)
+	}
+	return string(data), nil
+}

--- a/server/evr_runtime_rpc_mmr_test.go
+++ b/server/evr_runtime_rpc_mmr_test.go
@@ -1,0 +1,580 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/internal/intents"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Minimal NakamaModule stub for MMR tests
+// ---------------------------------------------------------------------------
+
+// mmrNK is a test stub for runtime.NakamaModule.
+// Only the methods called by MMR RPCs are overridden; all others panic via
+// the embedded interface so unintended calls are caught immediately.
+type mmrNK struct {
+	runtime.NakamaModule
+
+	// LeaderboardRecordsList: keyed by leaderboard ID
+	leaderboardRecords map[string][]*api.LeaderboardRecord
+	leaderboardErr     error
+
+	// LeaderboardRecordWrite: last call captures
+	leaderboardWriteCalls []leaderboardWriteCall
+	leaderboardWriteErr   error
+
+	// LeaderboardCreate: always succeeds unless leaderboardCreateErr set
+	leaderboardCreateErr error
+
+	// UsersGetId
+	users    []*api.User
+	usersErr error
+
+	// StorageRead
+	storageObjects []*api.StorageObject
+	storageReadErr error
+
+	// StorageWrite
+	storageWriteAcks []*api.StorageObjectAck
+	storageWriteErr  error
+}
+
+type leaderboardWriteCall struct {
+	id       string
+	ownerID  string
+	username string
+	score    int64
+	subscore int64
+}
+
+func (n *mmrNK) LeaderboardRecordsList(ctx context.Context, id string, ownerIDs []string, limit int, cursor string, expiry int64) ([]*api.LeaderboardRecord, []*api.LeaderboardRecord, string, string, error) {
+	if n.leaderboardErr != nil {
+		return nil, nil, "", "", n.leaderboardErr
+	}
+	recs := n.leaderboardRecords[id]
+	return nil, recs, "", "", nil
+}
+
+func (n *mmrNK) LeaderboardRecordWrite(ctx context.Context, id, ownerID, username string, score, subscore int64, metadata map[string]interface{}, overrideOperator *int) (*api.LeaderboardRecord, error) {
+	n.leaderboardWriteCalls = append(n.leaderboardWriteCalls, leaderboardWriteCall{
+		id: id, ownerID: ownerID, username: username, score: score, subscore: subscore,
+	})
+	if n.leaderboardWriteErr != nil {
+		return nil, n.leaderboardWriteErr
+	}
+	return &api.LeaderboardRecord{OwnerId: ownerID}, nil
+}
+
+func (n *mmrNK) LeaderboardCreate(ctx context.Context, id string, authoritative bool, sortOrder, operator, resetSchedule string, metadata map[string]interface{}, enableRanks bool) error {
+	return n.leaderboardCreateErr
+}
+
+func (n *mmrNK) UsersGetId(ctx context.Context, userIDs []string, facebookIDs []string) ([]*api.User, error) {
+	if n.usersErr != nil {
+		return nil, n.usersErr
+	}
+	return n.users, nil
+}
+
+func (n *mmrNK) StorageRead(ctx context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	if n.storageReadErr != nil {
+		return nil, n.storageReadErr
+	}
+	return n.storageObjects, nil
+}
+
+func (n *mmrNK) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	if n.storageWriteErr != nil {
+		return nil, n.storageWriteErr
+	}
+	if n.storageWriteAcks != nil {
+		return n.storageWriteAcks, nil
+	}
+	// Return a default ack with a version so callers that inspect it don't blow up.
+	acks := make([]*api.StorageObjectAck, len(writes))
+	for i := range writes {
+		acks[i] = &api.StorageObjectAck{Version: "v1"}
+	}
+	return acks, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helper: marshal payload to JSON string
+// ---------------------------------------------------------------------------
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// Helper: build authorised context for BeforeWriteStorageObjectsHook
+// ---------------------------------------------------------------------------
+func ctxWithIntent(intent intents.Intent) context.Context {
+	sv := &intents.SessionVars{Intents: intent}
+	vars := sv.MarshalVars()
+	return context.WithValue(context.Background(), runtime.RUNTIME_CTX_VARS, vars)
+}
+
+// ---------------------------------------------------------------------------
+// GetMMRRPC tests
+// ---------------------------------------------------------------------------
+
+func TestGetMMRRPC_InvalidJSON(t *testing.T) {
+	nk := &mmrNK{}
+	_, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, "{not json}")
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestGetMMRRPC_MissingUserID(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, GetMMRRequest{GroupID: "g1", Mode: "echo_arena"})
+	_, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestGetMMRRPC_MissingGroupID(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, GetMMRRequest{UserID: "u1", Mode: "echo_arena"})
+	_, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestGetMMRRPC_MissingMode(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, GetMMRRequest{UserID: "u1", GroupID: "g1"})
+	_, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestGetMMRRPC_HappyPath_NoStaticMMR(t *testing.T) {
+	// StorageRead returns nothing → settings load fails, static fields are absent.
+	nk := &mmrNK{
+		leaderboardRecords: map[string][]*api.LeaderboardRecord{},
+		// StorageRead returns empty → StorableRead returns NotFound
+		storageObjects: nil,
+	}
+	payload := mustJSON(t, GetMMRRequest{UserID: "u1", GroupID: "g1", Mode: "echo_arena"})
+	out, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.NoError(t, err)
+
+	var resp GetMMRResponse
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+
+	assert.Equal(t, "u1", resp.UserID)
+	assert.Equal(t, "g1", resp.GroupID)
+	assert.Equal(t, "echo_arena", resp.Mode)
+	assert.Nil(t, resp.StaticMu, "StaticMu should be nil when settings not found")
+	assert.Nil(t, resp.StaticSigma, "StaticSigma should be nil when settings not found")
+	assert.False(t, resp.IsStatic)
+}
+
+func TestGetMMRRPC_HappyPath_WithStaticMMR(t *testing.T) {
+	mu := 25.0
+	sigma := 8.333
+	settingsJSON := mustJSON(t, MatchmakingSettings{
+		StaticRatingMu:    &mu,
+		StaticRatingSigma: &sigma,
+	})
+
+	nk := &mmrNK{
+		leaderboardRecords: map[string][]*api.LeaderboardRecord{},
+		storageObjects: []*api.StorageObject{
+			{Value: settingsJSON, Version: "v1"},
+		},
+	}
+	payload := mustJSON(t, GetMMRRequest{UserID: "u1", GroupID: "g1", Mode: "echo_arena"})
+	out, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.NoError(t, err)
+
+	var resp GetMMRResponse
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+
+	require.NotNil(t, resp.StaticMu)
+	require.NotNil(t, resp.StaticSigma)
+	assert.InDelta(t, mu, *resp.StaticMu, 0.001)
+	assert.InDelta(t, sigma, *resp.StaticSigma, 0.001)
+	assert.True(t, resp.IsStatic)
+}
+
+func TestGetMMRRPC_LeaderboardError(t *testing.T) {
+	nk := &mmrNK{
+		leaderboardErr: errors.New("db gone"),
+	}
+	payload := mustJSON(t, GetMMRRequest{UserID: "u1", GroupID: "g1", Mode: "echo_arena"})
+	_, err := GetMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInternalError, int(rErr.Code))
+}
+
+// ---------------------------------------------------------------------------
+// UpdateMMRRPC tests
+// ---------------------------------------------------------------------------
+
+func TestUpdateMMRRPC_InvalidJSON(t *testing.T) {
+	nk := &mmrNK{}
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, "{not json}")
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestUpdateMMRRPC_MissingUserID(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, UpdateMMRRequest{GroupID: "g1", Mode: "echo_arena", Mu: 25, Sigma: 8.333})
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestUpdateMMRRPC_MissingGroupID(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, UpdateMMRRequest{UserID: "u1", Mode: "echo_arena", Mu: 25, Sigma: 8.333})
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestUpdateMMRRPC_MissingMode(t *testing.T) {
+	nk := &mmrNK{}
+	payload := mustJSON(t, UpdateMMRRequest{UserID: "u1", GroupID: "g1", Mu: 25, Sigma: 8.333})
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestUpdateMMRRPC_UserNotFound(t *testing.T) {
+	nk := &mmrNK{users: []*api.User{}}
+	payload := mustJSON(t, UpdateMMRRequest{UserID: "u1", GroupID: "g1", Mode: "echo_arena", Mu: 25, Sigma: 8.333})
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusNotFound, int(rErr.Code))
+}
+
+func TestUpdateMMRRPC_HappyPath_OrdinalMath(t *testing.T) {
+	mu := 30.0
+	sigma := 5.0
+	expectedOrdinal := mu - 3*sigma // 15.0
+
+	nk := &mmrNK{
+		users: []*api.User{{DisplayName: "Tester"}},
+	}
+	payload := mustJSON(t, UpdateMMRRequest{
+		UserID:  "u1",
+		GroupID: "g1",
+		Mode:    "echo_arena",
+		Mu:      mu,
+		Sigma:   sigma,
+	})
+	out, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.NoError(t, err)
+
+	var resp UpdateMMRResponse
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+
+	assert.True(t, resp.Success)
+	assert.Equal(t, "u1", resp.UserID)
+	assert.InDelta(t, mu, resp.Mu, 0.001)
+	assert.InDelta(t, sigma, resp.Sigma, 0.001)
+	assert.InDelta(t, expectedOrdinal, resp.Ordinal, 0.001)
+
+	// At minimum mu and sigma boards should be written (ordinal is non-fatal).
+	assert.GreaterOrEqual(t, len(nk.leaderboardWriteCalls), 2, "expected at least mu and sigma leaderboard writes")
+}
+
+func TestUpdateMMRRPC_LeaderboardWriteFailsWithCreate(t *testing.T) {
+	// First write fails, then LeaderboardCreate succeeds, then write succeeds.
+	writeCount := 0
+	nk := &mmrNK{
+		users: []*api.User{{DisplayName: "Tester"}},
+	}
+	// Simulate first call failing, subsequent succeeding.
+	_ = writeCount
+	// We can't easily intercept only the first call with this stub, so just
+	// verify that a persistent write failure returns StatusInternalError.
+	nk.leaderboardWriteErr = errors.New("disk full")
+	nk.leaderboardCreateErr = errors.New("cannot create")
+
+	payload := mustJSON(t, UpdateMMRRequest{
+		UserID:  "u1",
+		GroupID: "g1",
+		Mode:    "echo_arena",
+		Mu:      25,
+		Sigma:   8.333,
+	})
+	_, err := UpdateMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInternalError, int(rErr.Code))
+}
+
+// ---------------------------------------------------------------------------
+// SetStaticMMRRPC tests
+// ---------------------------------------------------------------------------
+
+func TestSetStaticMMRRPC_InvalidJSON(t *testing.T) {
+	nk := &mmrNK{}
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, "{not json}")
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestSetStaticMMRRPC_MissingUserID(t *testing.T) {
+	nk := &mmrNK{}
+	mu := 25.0
+	sigma := 8.333
+	payload := mustJSON(t, SetStaticMMRRequest{Enable: true, Mu: &mu, Sigma: &sigma})
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestSetStaticMMRRPC_EnableTrueWithoutMu(t *testing.T) {
+	nk := &mmrNK{}
+	sigma := 8.333
+	payload := mustJSON(t, SetStaticMMRRequest{UserID: "u1", Enable: true, Sigma: &sigma})
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestSetStaticMMRRPC_EnableTrueWithoutSigma(t *testing.T) {
+	nk := &mmrNK{}
+	mu := 25.0
+	payload := mustJSON(t, SetStaticMMRRequest{UserID: "u1", Enable: true, Mu: &mu})
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInvalidArgument, int(rErr.Code))
+}
+
+func TestSetStaticMMRRPC_Enable_SetsStaticFields(t *testing.T) {
+	mu := 30.0
+	sigma := 4.0
+
+	// StorageRead returns empty → StorableRead with create=true → calls StorageWrite once to create,
+	// then SetStaticMMRRPC calls StorageWrite again with the updated values.
+	nk := &mmrNK{
+		storageObjects: nil, // triggers create path
+	}
+
+	payload := mustJSON(t, SetStaticMMRRequest{
+		UserID: "u1",
+		Enable: true,
+		Mu:     &mu,
+		Sigma:  &sigma,
+	})
+	out, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.NoError(t, err)
+
+	var resp SetStaticMMRResponse
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+
+	assert.True(t, resp.Success)
+	assert.True(t, resp.Enable)
+	require.NotNil(t, resp.Mu)
+	require.NotNil(t, resp.Sigma)
+	assert.InDelta(t, mu, *resp.Mu, 0.001)
+	assert.InDelta(t, sigma, *resp.Sigma, 0.001)
+}
+
+func TestSetStaticMMRRPC_Disable_ClearsStaticFields(t *testing.T) {
+	mu := 30.0
+	sigma := 4.0
+
+	// Pre-existing settings that have static MMR enabled.
+	existingSettings := MatchmakingSettings{
+		StaticRatingMu:    &mu,
+		StaticRatingSigma: &sigma,
+	}
+	settingsJSON := mustJSON(t, existingSettings)
+
+	nk := &mmrNK{
+		storageObjects: []*api.StorageObject{
+			{Value: settingsJSON, Version: "v2"},
+		},
+	}
+
+	payload := mustJSON(t, SetStaticMMRRequest{
+		UserID: "u1",
+		Enable: false,
+	})
+	out, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.NoError(t, err)
+
+	var resp SetStaticMMRResponse
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+
+	assert.True(t, resp.Success)
+	assert.False(t, resp.Enable)
+	assert.Nil(t, resp.Mu, "StaticMu should be nil after disabling")
+	assert.Nil(t, resp.Sigma, "StaticSigma should be nil after disabling")
+}
+
+func TestSetStaticMMRRPC_StorageReadError(t *testing.T) {
+	nk := &mmrNK{
+		storageReadErr: errors.New("db error"),
+	}
+	mu := 25.0
+	sigma := 8.333
+	payload := mustJSON(t, SetStaticMMRRequest{UserID: "u1", Enable: true, Mu: &mu, Sigma: &sigma})
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInternalError, int(rErr.Code))
+}
+
+func TestSetStaticMMRRPC_StorageWriteError(t *testing.T) {
+	// StorageRead succeeds (returns existing settings), but write fails.
+	existingSettings := MatchmakingSettings{}
+	settingsJSON := mustJSON(t, existingSettings)
+
+	nk := &mmrNK{
+		storageObjects: []*api.StorageObject{
+			{Value: settingsJSON, Version: "v1"},
+		},
+		storageWriteErr: errors.New("write failed"),
+	}
+	mu := 25.0
+	sigma := 8.333
+	payload := mustJSON(t, SetStaticMMRRequest{UserID: "u1", Enable: true, Mu: &mu, Sigma: &sigma})
+	_, err := SetStaticMMRRPC(context.Background(), &mockLogger{}, &sql.DB{}, nk, payload)
+	require.Error(t, err)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusInternalError, int(rErr.Code))
+}
+
+// ---------------------------------------------------------------------------
+// BeforeWriteStorageObjectsHook tests
+// ---------------------------------------------------------------------------
+
+func TestBeforeWriteStorageObjectsHook_NilInput(t *testing.T) {
+	nk := &mmrNK{}
+	out, err := BeforeWriteStorageObjectsHook(context.Background(), &mockLogger{}, &sql.DB{}, nk, nil)
+	require.NoError(t, err)
+	assert.Nil(t, out)
+}
+
+func TestBeforeWriteStorageObjectsHook_Unauthorized_ReturnsNil(t *testing.T) {
+	// No session vars in context → not authorized → returns nil (blocks request).
+	nk := &mmrNK{}
+	req := &api.WriteStorageObjectsRequest{
+		Objects: []*api.WriteStorageObject{
+			{Collection: "SomeCollection", Key: "somekey"},
+		},
+	}
+	out, err := BeforeWriteStorageObjectsHook(context.Background(), &mockLogger{}, &sql.DB{}, nk, req)
+	require.NoError(t, err)
+	assert.Nil(t, out, "unauthorized request should be blocked (nil returned)")
+}
+
+func TestBeforeWriteStorageObjectsHook_MatchmakingConfig_NoVersion_Rejected(t *testing.T) {
+	ctx := ctxWithIntent(intents.Intent{IsGlobalOperator: true})
+	nk := &mmrNK{}
+	req := &api.WriteStorageObjectsRequest{
+		Objects: []*api.WriteStorageObject{
+			{
+				Collection: MatchmakerStorageCollection,
+				Key:        MatchmakingConfigStorageKey,
+				Version:    "", // no version → must be rejected
+			},
+		},
+	}
+	out, err := BeforeWriteStorageObjectsHook(ctx, &mockLogger{}, &sql.DB{}, nk, req)
+	require.Error(t, err, "should error when matchmaking config written without version")
+	assert.Nil(t, out)
+	var rErr *runtime.Error
+	require.True(t, errors.As(err, &rErr))
+	assert.Equal(t, StatusFailedPrecondition, int(rErr.Code))
+}
+
+func TestBeforeWriteStorageObjectsHook_MatchmakingConfig_WithVersion_Passes(t *testing.T) {
+	ctx := ctxWithIntent(intents.Intent{IsGlobalOperator: true})
+	nk := &mmrNK{}
+	req := &api.WriteStorageObjectsRequest{
+		Objects: []*api.WriteStorageObject{
+			{
+				Collection: MatchmakerStorageCollection,
+				Key:        MatchmakingConfigStorageKey,
+				Version:    "v42", // version present → should pass through
+			},
+		},
+	}
+	out, err := BeforeWriteStorageObjectsHook(ctx, &mockLogger{}, &sql.DB{}, nk, req)
+	require.NoError(t, err)
+	assert.Equal(t, req, out, "request should be returned unchanged")
+}
+
+func TestBeforeWriteStorageObjectsHook_NonMatchmakingCollection_Passes(t *testing.T) {
+	ctx := ctxWithIntent(intents.Intent{IsGlobalOperator: true})
+	nk := &mmrNK{}
+	req := &api.WriteStorageObjectsRequest{
+		Objects: []*api.WriteStorageObject{
+			{
+				Collection: "OtherCollection",
+				Key:        "somekey",
+				Version:    "", // version irrelevant for non-matchmaking collection
+			},
+		},
+	}
+	out, err := BeforeWriteStorageObjectsHook(ctx, &mockLogger{}, &sql.DB{}, nk, req)
+	require.NoError(t, err)
+	assert.Equal(t, req, out)
+}
+
+func TestBeforeWriteStorageObjectsHook_StorageObjectsIntent_Authorized(t *testing.T) {
+	// StorageObjects intent (not GlobalOperator) also grants access.
+	ctx := ctxWithIntent(intents.Intent{StorageObjects: true})
+	nk := &mmrNK{}
+	req := &api.WriteStorageObjectsRequest{
+		Objects: []*api.WriteStorageObject{
+			{Collection: "Anything", Key: "k", Version: "v1"},
+		},
+	}
+	out, err := BeforeWriteStorageObjectsHook(ctx, &mockLogger{}, &sql.DB{}, nk, req)
+	require.NoError(t, err)
+	assert.Equal(t, req, out)
+}

--- a/server/evr_runtime_rpc_registration.go
+++ b/server/evr_runtime_rpc_registration.go
@@ -376,6 +376,32 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		// Legacy/misc
 		{ID: "importloadouts", Handler: ImportLoadoutsRpc, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},
 		{ID: "forcecheck", Handler: CheckForceUserRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},
+
+		// MMR management - Global Operators only
+		{
+			ID:      "player/mmr/get",
+			Handler: GetMMRRPC,
+			Permission: &RPCPermission{
+				RequireAuth:   true,
+				AllowedGroups: []string{GroupGlobalOperators},
+			},
+		},
+		{
+			ID:      "player/mmr/update",
+			Handler: UpdateMMRRPC,
+			Permission: &RPCPermission{
+				RequireAuth:   true,
+				AllowedGroups: []string{GroupGlobalOperators},
+			},
+		},
+		{
+			ID:      "player/mmr/static",
+			Handler: SetStaticMMRRPC,
+			Permission: &RPCPermission{
+				RequireAuth:   true,
+				AllowedGroups: []string{GroupGlobalOperators},
+			},
+		},
 	}
 
 	// Register RPCs with authorization middleware

--- a/server/evr_runtime_rpc_registration.go
+++ b/server/evr_runtime_rpc_registration.go
@@ -90,8 +90,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: PrepareMatchRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add role-based check for allocator role
+				AllowedGroups: []string{},
 			},
 		},
 		{ID: "match/allocate", Handler: AllocateMatchRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{GroupGlobalOperators, GroupGlobalBots}}},
@@ -101,8 +100,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: shutdownMatchRpc,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add multi-role check (guild enforcers, match creator, server owner)
+				AllowedGroups: []string{},
 			},
 		},
 		{ID: "match/build", Handler: BuildMatchRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},
@@ -114,8 +112,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: SetNextMatchRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators}, // Any authenticated user
-				// TODO: Add role-based check for auditors/enforcers
+				AllowedGroups: []string{},
 			},
 		},
 		{ID: "player/statistics", Handler: PlayerStatisticsRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},
@@ -125,8 +122,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: KickPlayerRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add multi-role check (guild enforcers, match creator, server owner)
+				AllowedGroups: []string{},
 			},
 		},
 		{ID: "player/profile", Handler: UserServerProfileRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},
@@ -285,8 +281,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: EnforcementKickRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add guild enforcer check in middleware
+				AllowedGroups: []string{},
 			},
 		},
 		{
@@ -294,8 +289,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: EnforcementJournalListRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add guild owner check in middleware
+				AllowedGroups: []string{},
 			},
 		},
 		{
@@ -303,8 +297,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 			Handler: EnforcementRecordEditRPC,
 			Permission: &RPCPermission{
 				RequireAuth:   true,
-				AllowedGroups: []string{GroupGlobalOperators},
-				// TODO: Add guild enforcer check in middleware
+				AllowedGroups: []string{},
 			},
 		},
 

--- a/server/evr_runtime_rpc_registration.go
+++ b/server/evr_runtime_rpc_registration.go
@@ -190,6 +190,7 @@ func RegisterEVRRPCs(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 
 		// EVR service status
 		{ID: "evr/servicestatus", Handler: rpcHandler.ServiceStatusRPC, Permission: &RPCPermission{RequireAuth: false, AllowedGroups: []string{}}},
+		{ID: "healthcheck", Handler: HealthCheckRPC, Permission: &RPCPermission{RequireAuth: false, AllowedGroups: []string{}}},
 
 		// Matchmaking
 		{ID: "matchmaking/settings", Handler: MatchmakingSettingsRPC, Permission: &RPCPermission{RequireAuth: true, AllowedGroups: []string{}}},

--- a/server/evr_runtime_rpc_setnextmatch.go
+++ b/server/evr_runtime_rpc_setnextmatch.go
@@ -53,11 +53,19 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		request.TargetUserID = callerUserID
 	}
 
-	if request.TargetUserID != callerUserID || request.HostDiscordID != "" {
-		// require them to be a global bot or global developer
-		isGlobalDeveloper, _ := CheckSystemGroupMembership(ctx, db, callerUserID, GroupGlobalDevelopers)
-		isGlobalBot, _ := CheckSystemGroupMembership(ctx, db, callerUserID, GroupGlobalBots)
-		if !isGlobalDeveloper && !isGlobalBot {
+	if request.TargetUserID != callerUserID {
+		isGlobalOperator := false
+		if perms := PermissionsFromContext(ctx); perms != nil {
+			isGlobalOperator = perms.IsGlobalOperator
+		} else {
+			var err error
+			isGlobalOperator, err = CheckSystemGroupMembership(ctx, db, callerUserID, GroupGlobalOperators)
+			if err != nil {
+				return "", runtime.NewError("Failed to check operator permissions", StatusInternalError)
+			}
+		}
+
+		if !isGlobalOperator {
 			return "", runtime.NewError("You do not have permission to set the next match for another user", StatusPermissionDenied)
 		}
 	}

--- a/server/evr_runtime_vrml_verifier.go
+++ b/server/evr_runtime_vrml_verifier.go
@@ -72,8 +72,8 @@ func NewVRMLScanQueue(ctx context.Context, logger runtime.Logger, db *sql.DB, nk
 		oauthClientID:    oauthCLientID,
 	}
 
-	// Register the RPC function with authorization middleware (default: Global Operators only)
-	perm := DefaultRPCPermission()
+	// Register the RPC function without auth restriction (public OAuth callback)
+	perm := PublicRPCPermission()
 	wrappedRPC := WithRPCAuthorization("oauth/vrml_redirect", perm, verifier.RedirectRPC)
 	if err := initializer.RegisterRpc("oauth/vrml_redirect", wrappedRPC); err != nil {
 		return nil, fmt.Errorf("failed to register VRML redirect RPC: %v", err)


### PR DESCRIPTION
## Summary
- make restrictive RPC middleware entries auth-only and move guild role checks into handlers for setnextmatch, enforcement, match prepare/terminate, and kick flows
- allow global operators (and global bots where intended) to bypass guild role checks while preserving guild-level enforcer/allocator/owner authorization
- keep telemetry/session_events/player matchlock endpoints untouched and verify build success with `make nakama`