### PR TITLE
feat(discord): add guild group toggle for kick-player allow_privates default

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2747,6 +2747,13 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 
 					allowPrivateLobbies = gg.KickPlayerAllowPrivates
 
+				} else {
+
+					logger.Warn("Failed to load guild group for kick-player allow_private_lobbies default",
+						"group_id", groupID,
+						"error", err.Error(),
+					)
+
 				}
 
 			}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1139,8 +1139,6 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				} else {
 					state.matchSummarySent = true
 				}
-			} else {
-				state.matchSummarySent = true
 			}
 		}
 	}

--- a/tools/purge-docker-ips/go.mod
+++ b/tools/purge-docker-ips/go.mod
@@ -1,6 +1,6 @@
 module purge-docker-ips
 
-go 1.25.5
+go 1.25.0
 
 replace github.com/heroiclabs/nakama/v3 => ../..
 


### PR DESCRIPTION
## Summary
- Add guild kick-player allow_private_lobbies toggle wiring and defaults.
- Update shutdown-match authorization semantics across Discord helper and runtime RPC, with tests.
- Add purge-docker-ips admin tool for clearing stale Docker IP data.