### PR TITLE
feat(audit): add RPC audit notices for moderation actions

### DIFF
--- a/server/evr_runtime_rpc.go
+++ b/server/evr_runtime_rpc.go
@@ -409,6 +409,16 @@ func KickPlayerRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk ru
 		SessionIDs: sessionIDs,
 	}
 
+	sendRPCAuditMessage(
+		ctx,
+		logger,
+		nk,
+		"player/kick",
+		"",
+		callerID,
+		fmt.Sprintf("target_user_id=%s disconnected_sessions=%d", request.UserID, len(sessionIDs)),
+	)
+
 	data, err := json.Marshal(response)
 	if err != nil {
 		return "", err

--- a/server/evr_runtime_rpc_audit.go
+++ b/server/evr_runtime_rpc_audit.go
@@ -61,7 +61,12 @@ func sendRPCAuditMessage(ctx context.Context, logger runtime.Logger, nk runtime.
 		}
 	}
 
-	if err := AuditLogSend(appBot.dg, ServiceSettings().ServiceAuditChannelID, content); err != nil {
+	svcSettings := ServiceSettings()
+	if svcSettings == nil || svcSettings.ServiceAuditChannelID == "" {
+		return
+	}
+
+	if err := AuditLogSend(appBot.dg, svcSettings.ServiceAuditChannelID, content); err != nil {
 		logger.Warn("Failed to send service RPC audit log for %s: %v", rpcID, err)
 	}
 }

--- a/server/evr_runtime_rpc_audit.go
+++ b/server/evr_runtime_rpc_audit.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+func rpcAuditActor(ctx context.Context, nk runtime.NakamaModule, callerUserID string) string {
+	if callerUserID == "" {
+		return "unknown"
+	}
+
+	if account, err := nk.AccountGetId(ctx, callerUserID); err == nil && account != nil && account.GetCustomId() != "" {
+		discordID := account.GetCustomId()
+		if isNumericID(discordID) {
+			return fmt.Sprintf("<@%s>", discordID)
+		}
+		return discordID
+	}
+
+	return fmt.Sprintf("`%s`", callerUserID)
+}
+
+func isNumericID(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func sendRPCAuditMessage(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, rpcID, groupID, callerUserID, details string) {
+	if rpcID == "" {
+		return
+	}
+
+	appBot := globalAppBot.Load()
+	if appBot == nil || appBot.dg == nil {
+		return
+	}
+
+	actor := rpcAuditActor(ctx, nk, callerUserID)
+	content := fmt.Sprintf("%s invoked `%s`", actor, rpcID)
+	if strings.TrimSpace(details) != "" {
+		content += ": " + details
+	}
+
+	if groupID != "" {
+		if gg, err := GuildGroupLoad(ctx, nk, groupID); err == nil && gg != nil {
+			if _, err := AuditLogSendGuild(appBot.dg, gg, content); err != nil {
+				logger.Warn("Failed to send guild RPC audit log for %s: %v", rpcID, err)
+			}
+			return
+		}
+	}
+
+	if err := AuditLogSend(appBot.dg, ServiceSettings().ServiceAuditChannelID, content); err != nil {
+		logger.Warn("Failed to send service RPC audit log for %s: %v", rpcID, err)
+	}
+}

--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -285,6 +286,16 @@ func EnforcementKickRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		return "", runtime.NewError("Failed to create response", StatusInternalError)
 	}
 
+	sendRPCAuditMessage(
+		ctx,
+		logger,
+		nk,
+		"enforcement/kick",
+		groupID,
+		userID,
+		fmt.Sprintf("target_user_id=%s sessions_kicked=%d user_notice=%q actions=%s", targetUserID, cnt, request.UserNotice, strings.Join(actions, "; ")),
+	)
+
 	return string(responseData), nil
 }
 
@@ -504,6 +515,16 @@ func EnforcementRecordEditRPC(ctx context.Context, logger runtime.Logger, db *sq
 		zap.String("new_notice", newUserNotice),
 		zap.Time("previous_expiry", record.Expiry),
 		zap.Time("new_expiry", newExpiry),
+	)
+
+	sendRPCAuditMessage(
+		ctx,
+		logger,
+		nk,
+		"enforcement/record/edit",
+		request.GroupID,
+		userID,
+		fmt.Sprintf("target_user_id=%s record_id=%s new_expiry=%d new_notice=%q", request.TargetUserID, request.RecordID, newExpiry.Unix(), newUserNotice),
 	)
 
 	response := EnforcementRecordEditResponse{

--- a/server/evr_runtime_rpc_match.go
+++ b/server/evr_runtime_rpc_match.go
@@ -323,6 +323,21 @@ func shutdownMatchRpc(ctx context.Context, logger runtime.Logger, db *sql.DB, nk
 	if err != nil {
 		return "", err
 	}
+
+	groupID := ""
+	if gid := label.GetGroupID(); !gid.IsNil() {
+		groupID = gid.String()
+	}
+	sendRPCAuditMessage(
+		ctx,
+		logger,
+		nk,
+		"match/terminate",
+		groupID,
+		r.UserID,
+		fmt.Sprintf("match_id=%s mode=%s grace_seconds=%d", request.MatchID.String(), label.Mode.String(), request.GraceSeconds),
+	)
+
 	response := &shutdownMatchResponse{
 		Success:  true,
 		Response: signalResponse,

--- a/server/evr_runtime_rpc_matchlock.go
+++ b/server/evr_runtime_rpc_matchlock.go
@@ -150,6 +150,14 @@ func MatchLockRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk run
 		return "", runtime.NewError(fmt.Sprintf("Failed to save matchmaking settings: %s", err.Error()), StatusInternalError)
 	}
 
+	auditDetails := fmt.Sprintf("target_user_id=%s target_discord_id=%s", targetUserID, targetDiscordID)
+	if response.Locked {
+		auditDetails = fmt.Sprintf("%s lock=true leader_discord_id=%s reason=%q", auditDetails, request.LeaderDiscordID, request.Reason)
+	} else {
+		auditDetails = fmt.Sprintf("%s lock=false previous_leader_id=%s", auditDetails, previousLeaderID)
+	}
+	sendRPCAuditMessage(ctx, logger, nk, "player/matchlock", "", callerUserID, auditDetails)
+
 	return response.String(), nil
 }
 

--- a/server/evr_runtime_rpc_setnextmatch.go
+++ b/server/evr_runtime_rpc_setnextmatch.go
@@ -70,6 +70,8 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		}
 	}
 
+	auditGroupID := ""
+
 	if !request.MatchID.IsNil() {
 		// Check if the match exists
 		label, err := MatchLabelByID(ctx, nk, request.MatchID)
@@ -98,6 +100,9 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 				return "", runtime.NewError(fmt.Sprintf("Role may not be set for %s matches", label.Mode.String()), StatusInvalidArgument)
 			}
 		}
+		if gid := label.GetGroupID(); !gid.IsNil() {
+			auditGroupID = gid.String()
+		}
 	}
 
 	directive := &JoinDirective{
@@ -114,6 +119,16 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		"target_user_id": request.TargetUserID,
 		"match_id":       request.MatchID.String(),
 	}).Info("Set next match")
+
+	sendRPCAuditMessage(
+		ctx,
+		logger,
+		nk,
+		"player/setnextmatch",
+		auditGroupID,
+		callerUserID,
+		fmt.Sprintf("target_user_id=%s match_id=%s role=%s host_discord_id=%s", request.TargetUserID, request.MatchID.String(), request.Role, request.HostDiscordID),
+	)
 
 	response := SetNextMatchRPCResponse{
 		UserID:  request.TargetUserID,


### PR DESCRIPTION
## Summary

Adds Discord audit notices for moderation RPCs by introducing a shared helper (`sendRPCAuditMessage`) that routes messages to a guild audit channel when a group context exists, otherwise to the service audit channel.

Also introduces the "vibinator's gravity" novelty matchmaking redirect behind the `enable_vibinators_gravity` global settings toggle (originally introduced in this PR alongside the audit work, now sharing its implementation with PR #344).

## Changes

- **`server/evr_runtime_rpc_audit.go`** — New `sendRPCAuditMessage` helper; formats RPC actor mentions and dispatches to guild or service audit channel. Guards against nil `ServiceSettings` before accessing channel ID.
- **`server/evr_runtime_rpc_match.go`** — Emit audit notice when terminating a match via RPC.
- **`server/evr_runtime_rpc_enforcement.go`** — Emit audit notices for enforcement kick and enforcement record edit.
- **`server/evr_runtime_rpc_matchlock.go`** — Emit audit notice when enabling/disabling matchlock.
- **`server/evr_runtime_rpc_setnextmatch.go`** — Emit audit notice for set-next-match directives; capture group context from match label.
- **`server/evr_runtime_rpc.go`** — Emit audit notice for the kick-player moderation RPC.

## Testing

- Audit notices are gated on a live Discord bot (`globalAppBot`) and `ServiceSettings`, making them no-ops in unit tests without additional mocking.
- The vibinator novelty feature and its integration tests were merged via PR #344.