### PR TITLE
Add PartyRegistry.GetOrCreate and PartyData handler

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -70,6 +70,11 @@ const (
 	OpCodeGameServerLobbyStatus
 )
 
+// Party data opcodes for inter-member communication.
+const (
+	OpPartyMatchJoined int64 = 1
+)
+
 type MatchStatGroup string
 type MatchLevelSelection string
 

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -599,6 +599,25 @@ func ProcessOutgoing(logger *zap.Logger, session *sessionWS, in *nkrtapi.Envelop
 		if in.GetMatchData().GetOpCode() == OpCodeEVRPacketData {
 			return nil, session.SendBytes(in.GetMatchData().GetData(), true)
 		}
+
+	case *nkrtapi.Envelope_PartyData:
+		partyData := in.GetPartyData()
+		switch partyData.GetOpCode() {
+		case OpPartyMatchJoined:
+			matchID, err := MatchIDFromString(string(partyData.GetData()))
+			if err != nil || matchID.IsNil() {
+				logger.Warn("Received invalid match ID in party data")
+				return nil, nil
+			}
+			logger.Info("Party member received match join notification",
+				zap.String("match_id", matchID.String()),
+				zap.String("from", partyData.GetPresence().GetUsername()),
+			)
+			// The actual match join will be handled by the party follow system.
+			// This is a notification that the leader has joined a match.
+		}
+		// Suppress PartyData from reaching EVR client.
+		return nil, nil
 	}
 
 	params, ok := LoadParams(session.Context())

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -606,7 +606,12 @@ func ProcessOutgoing(logger *zap.Logger, session *sessionWS, in *nkrtapi.Envelop
 		case OpPartyMatchJoined:
 			matchID, err := MatchIDFromString(string(partyData.GetData()))
 			if err != nil || matchID.IsNil() {
-				logger.Warn("Received invalid match ID in party data")
+				logger.Warn("Received invalid match ID in party data",
+					zap.Error(err),
+					zap.Int64("op_code", partyData.GetOpCode()),
+					zap.String("from_user", partyData.GetPresence().GetUsername()),
+					zap.Int("data_len", len(partyData.GetData())),
+				)
 				return nil, nil
 			}
 			logger.Info("Party member received match join notification",
@@ -615,6 +620,11 @@ func ProcessOutgoing(logger *zap.Logger, session *sessionWS, in *nkrtapi.Envelop
 			)
 			// The actual match join will be handled by the party follow system.
 			// This is a notification that the leader has joined a match.
+		default:
+			logger.Debug("Suppressing unhandled PartyData opcode for EVR client",
+				zap.Int64("op_code", partyData.GetOpCode()),
+				zap.String("from_user", partyData.GetPresence().GetUsername()),
+			)
 		}
 		// Suppress PartyData from reaching EVR client.
 		return nil, nil

--- a/server/evr_pipeline_test.go
+++ b/server/evr_pipeline_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"reflect"
@@ -13,6 +14,8 @@ import (
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -104,5 +107,158 @@ func TestProcessOutgoingNotificationConnectionInfo(t *testing.T) {
 				t.Errorf("ProcessOutgoing() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProcessOutgoing_PartyData_MatchJoined(t *testing.T) {
+	testLogger := NewConsoleLogger(os.Stdout, true)
+	matchID := MatchID{uuid.Must(uuid.NewV4()), "testnode"}
+
+	in := &rtapi.Envelope{
+		Message: &rtapi.Envelope_PartyData{
+			PartyData: &rtapi.PartyData{
+				PartyId: "test-party",
+				Presence: &rtapi.UserPresence{
+					UserId:   uuid.Must(uuid.NewV4()).String(),
+					Username: "leader",
+				},
+				OpCode: OpPartyMatchJoined,
+				Data:   []byte(matchID.String()),
+			},
+		},
+	}
+
+	got, err := ProcessOutgoing(testLogger, &sessionWS{}, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil messages (suppressed), got %v", got)
+	}
+}
+
+func TestProcessOutgoing_PartyData_InvalidMatchID(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+	testLogger := zap.New(core)
+
+	in := &rtapi.Envelope{
+		Message: &rtapi.Envelope_PartyData{
+			PartyData: &rtapi.PartyData{
+				PartyId: "test-party",
+				Presence: &rtapi.UserPresence{
+					UserId:   uuid.Must(uuid.NewV4()).String(),
+					Username: "leader",
+				},
+				OpCode: OpPartyMatchJoined,
+				Data:   []byte("not-a-valid-match-id"),
+			},
+		},
+	}
+
+	got, err := ProcessOutgoing(testLogger, &sessionWS{}, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil messages (suppressed), got %v", got)
+	}
+
+	// Verify warning was logged with diagnostic fields.
+	if logs.Len() == 0 {
+		t.Fatal("expected a warning log entry for invalid match ID")
+	}
+	entry := logs.All()[0]
+	if entry.Message != "Received invalid match ID in party data" {
+		t.Fatalf("unexpected log message: %s", entry.Message)
+	}
+	// Check that diagnostic fields are present.
+	fieldNames := make(map[string]bool)
+	for _, f := range entry.Context {
+		fieldNames[f.Key] = true
+	}
+	for _, expected := range []string{"op_code", "from_user", "data_len"} {
+		if !fieldNames[expected] {
+			t.Errorf("expected log field %q not found in warning", expected)
+		}
+	}
+}
+
+func TestProcessOutgoing_PartyData_UnknownOpcode(t *testing.T) {
+	core, logs := observer.New(zapcore.DebugLevel)
+	testLogger := zap.New(core)
+
+	unknownOpCode := int64(999)
+	in := &rtapi.Envelope{
+		Message: &rtapi.Envelope_PartyData{
+			PartyData: &rtapi.PartyData{
+				PartyId: "test-party",
+				Presence: &rtapi.UserPresence{
+					UserId:   uuid.Must(uuid.NewV4()).String(),
+					Username: "someone",
+				},
+				OpCode: unknownOpCode,
+				Data:   []byte("whatever"),
+			},
+		},
+	}
+
+	got, err := ProcessOutgoing(testLogger, &sessionWS{}, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil messages (suppressed), got %v", got)
+	}
+
+	// Verify debug log for unhandled opcode.
+	found := false
+	for _, entry := range logs.All() {
+		if entry.Message == "Suppressing unhandled PartyData opcode for EVR client" {
+			found = true
+			fieldMap := make(map[string]interface{})
+			for _, f := range entry.Context {
+				fieldMap[f.Key] = f.Integer
+			}
+			if fieldMap["op_code"] != unknownOpCode {
+				t.Errorf("expected op_code=%d, got %v", unknownOpCode, fieldMap["op_code"])
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected debug log for unhandled opcode")
+	}
+}
+
+func TestProcessOutgoing_PartyData_NilMatchID(t *testing.T) {
+	// A match ID string that parses but has a nil UUID should also be rejected.
+	core, logs := observer.New(zapcore.WarnLevel)
+	testLogger := zap.New(core)
+
+	nilMatchID := fmt.Sprintf("%s.testnode", uuid.Nil.String())
+	in := &rtapi.Envelope{
+		Message: &rtapi.Envelope_PartyData{
+			PartyData: &rtapi.PartyData{
+				PartyId: "test-party",
+				Presence: &rtapi.UserPresence{
+					UserId:   uuid.Must(uuid.NewV4()).String(),
+					Username: "leader",
+				},
+				OpCode: OpPartyMatchJoined,
+				Data:   []byte(nilMatchID),
+			},
+		},
+	}
+
+	got, err := ProcessOutgoing(testLogger, &sessionWS{}, in)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil messages (suppressed), got %v", got)
+	}
+
+	if logs.Len() == 0 {
+		t.Fatal("expected a warning log for nil match ID")
 	}
 }

--- a/server/party_registry.go
+++ b/server/party_registry.go
@@ -28,6 +28,7 @@ var ErrPartyNotFound = errors.New("party not found")
 
 type PartyRegistry interface {
 	Create(open bool, maxSize int, leader *rtapi.UserPresence) *PartyHandler
+	GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool)
 	Delete(id uuid.UUID)
 
 	Join(id uuid.UUID, presences []*Presence)
@@ -78,6 +79,21 @@ func (p *LocalPartyRegistry) Create(open bool, maxSize int, presence *rtapi.User
 	p.parties.Store(id, partyHandler)
 
 	return partyHandler
+}
+
+func (p *LocalPartyRegistry) GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool) {
+	ph, found := p.parties.Load(id)
+	if found {
+		return ph, false
+	}
+	ph = NewPartyHandler(p.logger, p, p.matchmaker, p.tracker, p.streamManager, p.router, id, p.node, open, maxSize, leader)
+	actual, loaded := p.parties.LoadOrStore(id, ph)
+	if loaded {
+		// Another goroutine created it first, clean up ours.
+		ph.ctxCancelFn()
+		return actual, false
+	}
+	return ph, true
 }
 
 func (p *LocalPartyRegistry) Delete(id uuid.UUID) {

--- a/server/party_registry.go
+++ b/server/party_registry.go
@@ -28,7 +28,7 @@ var ErrPartyNotFound = errors.New("party not found")
 
 type PartyRegistry interface {
 	Create(open bool, maxSize int, leader *rtapi.UserPresence) *PartyHandler
-	GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool)
+	GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool, error)
 	Delete(id uuid.UUID)
 
 	Join(id uuid.UUID, presences []*Presence)
@@ -81,19 +81,26 @@ func (p *LocalPartyRegistry) Create(open bool, maxSize int, presence *rtapi.User
 	return partyHandler
 }
 
-func (p *LocalPartyRegistry) GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool) {
+func (p *LocalPartyRegistry) GetOrCreate(id uuid.UUID, open bool, maxSize int, leader *rtapi.UserPresence) (*PartyHandler, bool, error) {
+	if id == uuid.Nil {
+		return nil, false, errors.New("party ID must not be nil")
+	}
+	if maxSize <= 0 {
+		return nil, false, errors.New("party maxSize must be greater than zero")
+	}
+
 	ph, found := p.parties.Load(id)
 	if found {
-		return ph, false
+		return ph, false, nil
 	}
 	ph = NewPartyHandler(p.logger, p, p.matchmaker, p.tracker, p.streamManager, p.router, id, p.node, open, maxSize, leader)
 	actual, loaded := p.parties.LoadOrStore(id, ph)
 	if loaded {
 		// Another goroutine created it first, clean up ours.
 		ph.ctxCancelFn()
-		return actual, false
+		return actual, false, nil
 	}
-	return ph, true
+	return ph, true, nil
 }
 
 func (p *LocalPartyRegistry) Delete(id uuid.UUID) {

--- a/server/party_registry_test.go
+++ b/server/party_registry_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/rtapi"
+)
+
+func createTestPartyRegistry(t *testing.T) *LocalPartyRegistry {
+	t.Helper()
+	logger := loggerForTest(t)
+	node := "testnode"
+	tt := testTracker{}
+	tsm := testStreamManager{}
+	dmr := DummyMessageRouter{}
+	return &LocalPartyRegistry{
+		logger:        logger,
+		config:        cfg,
+		matchmaker:    nil,
+		tracker:       &tt,
+		streamManager: &tsm,
+		router:        &dmr,
+		node:          node,
+		parties:       &MapOf[uuid.UUID, *PartyHandler]{},
+	}
+}
+
+func testLeader() *rtapi.UserPresence {
+	return &rtapi.UserPresence{UserId: uuid.Must(uuid.NewV4()).String(), Username: "leader"}
+}
+
+func TestGetOrCreate_NilID(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	ph, created, err := pr.GetOrCreate(uuid.Nil, true, 4, testLeader())
+	if err == nil {
+		t.Fatal("expected error for nil UUID, got nil")
+	}
+	if ph != nil {
+		t.Fatal("expected nil handler for nil UUID")
+	}
+	if created {
+		t.Fatal("expected created=false for nil UUID")
+	}
+}
+
+func TestGetOrCreate_InvalidMaxSize(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	id := uuid.Must(uuid.NewV4())
+	leader := testLeader()
+
+	for _, maxSize := range []int{0, -1, -100} {
+		ph, created, err := pr.GetOrCreate(id, true, maxSize, leader)
+		if err == nil {
+			t.Fatalf("expected error for maxSize=%d, got nil", maxSize)
+		}
+		if ph != nil {
+			t.Fatalf("expected nil handler for maxSize=%d", maxSize)
+		}
+		if created {
+			t.Fatalf("expected created=false for maxSize=%d", maxSize)
+		}
+	}
+}
+
+func TestGetOrCreate_CreatesNewParty(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	id := uuid.Must(uuid.NewV4())
+	leader := testLeader()
+
+	ph, created, err := pr.GetOrCreate(id, true, 4, leader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created {
+		t.Fatal("expected created=true for new party")
+	}
+	if ph == nil {
+		t.Fatal("expected non-nil handler")
+	}
+	if ph.ID != id {
+		t.Fatalf("expected party ID %v, got %v", id, ph.ID)
+	}
+}
+
+func TestGetOrCreate_ReturnsExisting(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	id := uuid.Must(uuid.NewV4())
+	leader := testLeader()
+
+	ph1, created1, err := pr.GetOrCreate(id, true, 4, leader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created1 {
+		t.Fatal("expected created=true on first call")
+	}
+
+	ph2, created2, err := pr.GetOrCreate(id, true, 4, leader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if created2 {
+		t.Fatal("expected created=false on second call")
+	}
+	if ph1 != ph2 {
+		t.Fatal("expected same handler returned on second call")
+	}
+}
+
+func TestGetOrCreate_ConcurrentSameID(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	id := uuid.Must(uuid.NewV4())
+	leader := testLeader()
+
+	const goroutines = 50
+	var (
+		wg         sync.WaitGroup
+		createdCnt atomic.Int32
+		handlers   [goroutines]*PartyHandler
+		errs       [goroutines]error
+	)
+
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			ph, created, err := pr.GetOrCreate(id, true, 4, leader)
+			handlers[idx] = ph
+			errs[idx] = err
+			if created {
+				createdCnt.Add(1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < goroutines; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d got error: %v", i, errs[i])
+		}
+	}
+
+	if createdCnt.Load() != 1 {
+		t.Fatalf("expected exactly 1 goroutine to report created=true, got %d", createdCnt.Load())
+	}
+
+	// All handlers must be the same instance.
+	first := handlers[0]
+	for i := 1; i < goroutines; i++ {
+		if handlers[i] != first {
+			t.Fatalf("goroutine %d returned different handler than goroutine 0", i)
+		}
+	}
+}
+
+func TestGetOrCreate_DifferentIDs(t *testing.T) {
+	pr := createTestPartyRegistry(t)
+
+	leader := testLeader()
+	id1 := uuid.Must(uuid.NewV4())
+	id2 := uuid.Must(uuid.NewV4())
+
+	ph1, created1, err := pr.GetOrCreate(id1, true, 4, leader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created1 {
+		t.Fatal("expected created=true for first ID")
+	}
+
+	ph2, created2, err := pr.GetOrCreate(id2, true, 8, leader)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !created2 {
+		t.Fatal("expected created=true for second ID")
+	}
+
+	if ph1 == ph2 {
+		t.Fatal("expected different handlers for different IDs")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `GetOrCreate(id, open, maxSize, leader)` to `PartyRegistry` interface and `LocalPartyRegistry`, using `LoadOrStore` for race-safe party creation with a known ID
- Add `Envelope_PartyData` case in `ProcessOutgoing` to intercept party data server-side (EVR clients can't process it), with `OpPartyMatchJoined` opcode handling
- Add `OpPartyMatchJoined` constant for party-to-member match notifications

Prep work for the party group simplification refactor. These upstream changes unblock:
1. Replacing the `LocalPartyRegistry` type assertion in `JoinPartyGroup` with the interface method
2. Replacing the `PartyFollow` polling loop with event-driven notifications via `PartyDataSend`

## Test plan
- [ ] `go build ./...` passes (verified)
- [ ] `go vet ./...` passes — no new warnings (verified)
- [ ] Existing `TestPartyMatchmakerAddAndRemove` still passes
- [ ] Existing `TestMatchmakerMaxPartyTracking` still passes
- [ ] No behavioral change — `GetOrCreate` is not called yet, `PartyData` handler only logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)