### PR TITLE
Fix party splitting in matchmaking and harden timeout bounds

### DIFF
--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -277,6 +277,13 @@ func FixDefaultServiceSettings(logger runtime.Logger, data *ServiceSettingsData)
 		data.Matchmaking.MatchmakingTimeoutSecs = 360
 	}
 
+	// Hard upper bound: never allow matchmaking to run longer than 10 minutes.
+	// Prevents indefinite hangs when clients silently re-queue expired tickets.
+	const maxMatchmakingTimeoutSecs = 600
+	if data.Matchmaking.MatchmakingTimeoutSecs > maxMatchmakingTimeoutSecs {
+		data.Matchmaking.MatchmakingTimeoutSecs = maxMatchmakingTimeoutSecs
+	}
+
 	if data.Matchmaking.FailsafeTimeoutSecs == 0 {
 		data.Matchmaking.FailsafeTimeoutSecs = data.Matchmaking.MatchmakingTimeoutSecs - 60
 	}

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -604,6 +604,8 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 		"failsafe_timeout": p.FailsafeTimeout.Seconds(),
 		"min_team_size":    minTeamSize,
 		"max_team_size":    maxTeamSize,
+		"count_multiple":   float64(ticketParams.CountMultiple),
+		"max_count":        float64(ticketParams.MaxCount),
 	}
 
 	qparts := []string{

--- a/server/evr_matchmaker.go
+++ b/server/evr_matchmaker.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/base32"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -197,6 +198,33 @@ func (m *SkillBasedMatchmaker) EvrMatchmakerFn(ctx context.Context, logger runti
 		nk.MetricsCounterAdd("matchmaker_ticket_count", nil, int64(len(ticketSet)))
 		nk.MetricsCounterAdd("matchmaker_unmatched_player_count", nil, int64(len(unmatchedPlayers)))
 		nk.MetricsCounterAdd("matchmaker_matched_player_count", nil, int64(len(matchedPlayers)))
+	}
+
+	// Track unmatched party tickets (tickets with >1 player that failed to match).
+	// This helps diagnose party splitting issues and slot constraint failures.
+	unmatchedPartyTickets := make(map[string]int) // ticket -> party size
+	for _, entry := range entries {
+		ticket := entry.GetTicket()
+		unmatchedPartyTickets[ticket]++
+	}
+	// Remove matched tickets
+	for _, c := range matches {
+		for _, e := range c {
+			delete(unmatchedPartyTickets, e.GetTicket())
+		}
+	}
+	// Filter to only party tickets (size > 1) and log them
+	for ticket, size := range unmatchedPartyTickets {
+		if size <= 1 {
+			delete(unmatchedPartyTickets, ticket)
+		}
+	}
+	if nk != nil && len(unmatchedPartyTickets) > 0 {
+		for _, size := range unmatchedPartyTickets {
+			nk.MetricsCounterAdd("matchmaker_unmatched_party_tickets", map[string]string{
+				"party_size": fmt.Sprintf("%d", size),
+			}, 1)
+		}
 	}
 
 	// Calculate wait time statistics for logging

--- a/server/evr_matchmaker_flat_test.go
+++ b/server/evr_matchmaker_flat_test.go
@@ -84,6 +84,124 @@ func TestEvrMatchmakerFn(t *testing.T) {
 	})
 }
 
+func TestGroupEntriesPartyAtomicity(t *testing.T) {
+	t.Run("party members stay in same candidate", func(t *testing.T) {
+		// Create 10 entries: 6 solo players + 1 party of 4 (same ticket).
+		// With maxCount=8, the party must not be split across candidates.
+		entries := make([]runtime.MatchmakerEntry, 0, 10)
+		now := float64(time.Now().UTC().Unix())
+		baseProps := map[string]any{
+			"group_id":        "group-1",
+			"game_mode":       "echo_arena",
+			"max_count":       8.0,
+			"count_multiple":  2.0,
+			"max_rtt":         250.0,
+			"rtt_test":        40.0,
+			"rating_mu":       25.0,
+			"rating_sigma":    8.33,
+			"submission_time": now,
+		}
+
+		// 6 solo players (each with a unique ticket)
+		for i := 0; i < 6; i++ {
+			props := make(map[string]any)
+			for k, v := range baseProps {
+				props[k] = v
+			}
+			entries = append(entries, &MatchmakerEntry{
+				Ticket: fmt.Sprintf("solo-%d", i),
+				Presence: &MatchmakerPresence{
+					UserId:    fmt.Sprintf("user-solo-%d", i),
+					SessionId: fmt.Sprintf("session-solo-%d", i),
+					Username:  fmt.Sprintf("solo-%d", i),
+				},
+				Properties: props,
+			})
+		}
+		// 4-player party (all share "party-ticket")
+		for i := 0; i < 4; i++ {
+			props := make(map[string]any)
+			for k, v := range baseProps {
+				props[k] = v
+			}
+			entries = append(entries, &MatchmakerEntry{
+				Ticket: "party-ticket",
+				Presence: &MatchmakerPresence{
+					UserId:    fmt.Sprintf("user-party-%d", i),
+					SessionId: fmt.Sprintf("session-party-%d", i),
+					Username:  fmt.Sprintf("party-%d", i),
+				},
+				Properties: props,
+			})
+		}
+
+		candidates := groupEntriesSequentially(entries)
+
+		// Verify no candidate splits the party ticket across boundaries
+		for _, candidate := range candidates {
+			partyCount := 0
+			for _, e := range candidate {
+				if e.GetTicket() == "party-ticket" {
+					partyCount++
+				}
+			}
+			if partyCount > 0 && partyCount != 4 {
+				t.Fatalf("party was split: found %d of 4 party members in a single candidate", partyCount)
+			}
+		}
+
+		// Verify all entries accounted for (10 total, in groups divisible by 2)
+		total := 0
+		for _, c := range candidates {
+			if len(c)%2 != 0 {
+				t.Fatalf("candidate size %d not divisible by count_multiple 2", len(c))
+			}
+			total += len(c)
+		}
+		if total != 10 {
+			t.Fatalf("expected 10 total entries across candidates, got %d", total)
+		}
+	})
+
+	t.Run("party larger than maxCount is skipped", func(t *testing.T) {
+		now := float64(time.Now().UTC().Unix())
+		baseProps := map[string]any{
+			"group_id":        "group-1",
+			"game_mode":       "echo_arena",
+			"max_count":       4.0,
+			"count_multiple":  2.0,
+			"max_rtt":         250.0,
+			"rtt_test":        40.0,
+			"rating_mu":       25.0,
+			"rating_sigma":    8.33,
+			"submission_time": now,
+		}
+		entries := make([]runtime.MatchmakerEntry, 0, 6)
+		// 5-player party that exceeds maxCount of 4
+		for i := 0; i < 5; i++ {
+			props := make(map[string]any)
+			for k, v := range baseProps {
+				props[k] = v
+			}
+			entries = append(entries, &MatchmakerEntry{
+				Ticket: "big-party",
+				Presence: &MatchmakerPresence{
+					UserId:    fmt.Sprintf("user-%d", i),
+					SessionId: fmt.Sprintf("session-%d", i),
+					Username:  fmt.Sprintf("player-%d", i),
+				},
+				Properties: props,
+			})
+		}
+
+		candidates := groupEntriesSequentially(entries)
+		// The oversized party should be skipped, no candidates produced
+		if len(candidates) != 0 {
+			t.Fatalf("expected 0 candidates for oversized party, got %d", len(candidates))
+		}
+	})
+}
+
 func TestProcessPotentialMatches(t *testing.T) {
 	t.Run("groups flat entries sequentially respecting max_count and count_multiple", func(t *testing.T) {
 		m := NewSkillBasedMatchmaker()

--- a/server/evr_matchmaker_process.go
+++ b/server/evr_matchmaker_process.go
@@ -126,24 +126,62 @@ func groupEntriesSequentially(entries []runtime.MatchmakerEntry) [][]runtime.Mat
 		countMultiple = 2
 	}
 
+	// Group entries by ticket to keep parties atomic. Each ticket represents
+	// a party (or solo player) and must never be split across candidates.
+	type ticketGroup struct {
+		ticket  string
+		entries []runtime.MatchmakerEntry
+	}
+
+	ticketOrder := make([]string, 0)
+	ticketMap := make(map[string]*ticketGroup)
+	for _, entry := range entries {
+		ticket := entry.GetTicket()
+		if tg, ok := ticketMap[ticket]; ok {
+			tg.entries = append(tg.entries, entry)
+		} else {
+			ticketOrder = append(ticketOrder, ticket)
+			ticketMap[ticket] = &ticketGroup{ticket: ticket, entries: []runtime.MatchmakerEntry{entry}}
+		}
+	}
+
+	// Pack ticket groups into candidates, never splitting a ticket across candidates.
 	candidates := make([][]runtime.MatchmakerEntry, 0, (len(entries)+maxCount-1)/maxCount)
-	for i := 0; i < len(entries); {
-		remaining := len(entries) - i
-		groupSize := maxCount
-		if remaining < groupSize {
-			groupSize = remaining
+	current := make([]runtime.MatchmakerEntry, 0, maxCount)
+
+	for _, ticket := range ticketOrder {
+		tg := ticketMap[ticket]
+
+		// If this ticket alone exceeds maxCount, it can't fit in any candidate — skip it.
+		if len(tg.entries) > maxCount {
+			continue
 		}
 
-		if rem := groupSize % countMultiple; rem != 0 {
-			groupSize -= rem
+		// If adding this ticket would exceed maxCount, flush the current candidate.
+		if len(current)+len(tg.entries) > maxCount {
+			// Trim to count_multiple boundary before flushing.
+			if rem := len(current) % countMultiple; rem != 0 {
+				current = current[:len(current)-rem]
+			}
+			if len(current) > 0 {
+				candidate := make([]runtime.MatchmakerEntry, len(current))
+				copy(candidate, current)
+				candidates = append(candidates, candidate)
+			}
+			current = current[:0]
 		}
 
-		if groupSize <= 0 {
-			break
-		}
+		current = append(current, tg.entries...)
+	}
 
-		candidates = append(candidates, entries[i:i+groupSize])
-		i += groupSize
+	// Flush remaining entries.
+	if rem := len(current) % countMultiple; rem != 0 {
+		current = current[:len(current)-rem]
+	}
+	if len(current) > 0 {
+		candidate := make([]runtime.MatchmakerEntry, len(current))
+		copy(candidate, current)
+		candidates = append(candidates, candidate)
 	}
 
 	return candidates


### PR DESCRIPTION
## Summary
- Rewrite `groupEntriesSequentially()` to keep party/ticket members in the same match candidate (fixes party splitting bug)
- Expose `count_multiple` and `max_count` as numeric properties for the custom matchmaker
- Enforce hard 10-minute upper bound on `MatchmakingTimeoutSecs` to prevent indefinite hangs
- Add `matchmaker_unmatched_party_tickets` metric with `party_size` dimension for observability

## Context
Addresses Aaliyah Report #000046:
- **Item #1** — Party split in matchmaking (Critical bug): `groupEntriesSequentially()` was blindly chunking entries without respecting ticket boundaries, so a 4-player party could be split across two match candidates
- **Item #3** — Matchmaking timeout >10 min (Critical bug): Added hard upper bound to prevent runaway timeouts from misconfiguration

## Test plan
- [x] `TestGroupEntriesPartyAtomicity/party_members_stay_in_same_candidate` — verifies party entries with the same ticket are never split across candidates
- [x] `TestGroupEntriesPartyAtomicity/party_larger_than_maxCount_is_skipped` — verifies oversized parties are gracefully skipped
- [x] `TestProcessPotentialMatches` — existing tests pass with no regression
- [ ] Manual: verify in staging that 4-player parties consistently land on the same team

🤖 Generated with [Claude Code](https://claude.com/claude-code)