### PR TITLE
Add crash vs disconnect classification with differential penalties

### DIFF
--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"sync"
 	"time"
 
@@ -335,6 +336,95 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 					"discord_id": discordID,
 					"error":      err,
 				}).Warn("Failed to send tier change notification after logout")
+			}
+		}
+	}
+}
+
+// CheckAndApplyEarlyQuitIfStillOnline is the inverse of CheckAndStrikeEarlyQuitIfLoggedOut.
+// For disconnects where penalty was deferred: if the player is still online after the grace
+// period, they likely force-closed intentionally, so apply the penalty. If they're offline,
+// they genuinely crashed/had a network issue, so forgive it.
+func CheckAndApplyEarlyQuitIfStillOnline(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, db *sql.DB, sessionRegistry SessionRegistry, userID, sessionID string, matchID MatchID, checkInterval time.Duration) {
+	select {
+	case <-time.After(checkInterval):
+	case <-ctx.Done():
+		return
+	}
+
+	sessionUUID, err := uuid.FromString(sessionID)
+	if err != nil {
+		logger.WithField("error", err).Warn("Invalid session ID for disconnect penalty check")
+		return
+	}
+
+	// If session is gone, player logged out — genuine crash/disconnect, no penalty.
+	if sessionRegistry.Get(sessionUUID) == nil {
+		logger.WithFields(map[string]any{
+			"uid":        userID,
+			"session_id": sessionID,
+		}).Info("Disconnect forgiven: player logged out (likely crash/network issue)")
+		return
+	}
+
+	// Player is still online — this was likely an intentional force-close. Apply penalty.
+	logger.WithFields(map[string]any{
+		"uid":        userID,
+		"session_id": sessionID,
+	}).Info("Applying deferred penalty: player still online after disconnect")
+
+	eqconfig := NewEarlyQuitConfig()
+	if err := StorableRead(ctx, nk, userID, eqconfig, true); err != nil {
+		logger.WithField("error", err).Warn("Failed to load early quit config for deferred penalty")
+		return
+	}
+
+	eqconfig.IncrementEarlyQuit()
+	eqconfig.LastEarlyQuitMatchID = matchID
+
+	serviceSettings := ServiceSettings()
+	oldTier, newTier, tierChanged := eqconfig.UpdateTier(serviceSettings.Matchmaking.EarlyQuitTier1Threshold)
+
+	if err := StorableWrite(ctx, nk, userID, eqconfig); err != nil {
+		logger.WithField("error", err).Warn("Failed to write deferred early quit penalty")
+		return
+	}
+
+	// Update session cache
+	if s := sessionRegistry.Get(sessionUUID); s != nil {
+		if params, ok := LoadParams(s.Context()); ok {
+			params.earlyQuitConfig.Store(eqconfig)
+		}
+	}
+
+	// Send penalty notification
+	if messageTrigger := globalEarlyQuitMessageTrigger.Load(); messageTrigger != nil {
+		penaltyLevel := int32(eqconfig.EarlyQuitPenaltyLevel)
+		if penaltyLevel > MaxEarlyQuitPenaltyLevel {
+			penaltyLevel = int32(MaxEarlyQuitPenaltyLevel)
+		}
+		lockoutDuration := GetLockoutDurationSeconds(int(penaltyLevel))
+		reason := fmt.Sprintf("Deferred penalty: disconnect from match %s (still online)", matchID.String())
+		messageTrigger.SendPenaltyAppliedNotification(ctx, userID, penaltyLevel, lockoutDuration, reason)
+	}
+
+	// Send tier change notifications
+	if tierChanged {
+		if messageTrigger := globalEarlyQuitMessageTrigger.Load(); messageTrigger != nil {
+			messageTrigger.SendTierChangeNotification(ctx, userID, oldTier, newTier, newTier > oldTier)
+		}
+		discordID, err := GetDiscordIDByUserID(ctx, db, userID)
+		if err == nil {
+			if appBot := globalAppBot.Load(); appBot != nil && appBot.dg != nil {
+				var message string
+				if newTier > oldTier {
+					message = TierDegradedMessage
+				} else {
+					message = TierRestoredMessage
+				}
+				if _, err := SendUserMessage(ctx, appBot.dg, discordID, message); err != nil {
+					logger.WithField("error", err).Warn("Failed to send tier change DM for deferred penalty")
+				}
 			}
 		}
 	}

--- a/server/evr_earlyquit_detailed.go
+++ b/server/evr_earlyquit_detailed.go
@@ -22,6 +22,20 @@ const (
 	QuitTypePregame QuitType = "pregame" // Left before game started
 )
 
+// LeaveReason classifies why a player left a match.
+// Used for differential penalty logic: voluntary leaves get full penalties,
+// while disconnects/crashes get reduced or deferred penalties.
+type LeaveReason string
+
+const (
+	LeaveReasonVoluntary      LeaveReason = "voluntary"       // Clean leave packet received
+	LeaveReasonDisconnect     LeaveReason = "disconnect"      // TCP/WebSocket closed without leave packet
+	LeaveReasonTimeout        LeaveReason = "timeout"         // No heartbeat / connection timeout
+	LeaveReasonCrashRecovery  LeaveReason = "crash_recovery"  // Disconnect with reconnect reservation created
+	LeaveReasonReservationExp LeaveReason = "reservation_exp" // Reconnect reservation expired (deferred penalty)
+	LeaveReasonUnknown        LeaveReason = "unknown"
+)
+
 // CompletionRecord represents a completed match (no early quit)
 type CompletionRecord struct {
 	MatchID        MatchID   `json:"match_id"`
@@ -31,11 +45,12 @@ type CompletionRecord struct {
 // QuitRecord represents a single early quit event with full context
 type QuitRecord struct {
 	// Event info
-	MatchID    MatchID   `json:"match_id"`
-	QuitTime   time.Time `json:"quit_time"`
-	QuitType   QuitType  `json:"quit_type"`
-	Forgiven   bool      `json:"forgiven,omitempty"`    // True if quit was forgiven due to full logout
-	ForgivenAt time.Time `json:"forgiven_at,omitempty"` // When the quit was forgiven
+	MatchID     MatchID     `json:"match_id"`
+	QuitTime    time.Time   `json:"quit_time"`
+	QuitType    QuitType    `json:"quit_type"`
+	LeaveReason LeaveReason `json:"leave_reason,omitempty"` // Why the player left (voluntary, disconnect, crash, etc.)
+	Forgiven    bool        `json:"forgiven,omitempty"`     // True if quit was forgiven due to full logout
+	ForgivenAt  time.Time   `json:"forgiven_at,omitempty"`  // When the quit was forgiven
 
 	// Player info at time of quit
 	Username    string    `json:"username,omitempty"`
@@ -258,10 +273,11 @@ func CreateQuitRecordFromParticipation(state *MatchLabel, participation *PlayerP
 	}
 
 	return QuitRecord{
-		MatchID:  state.ID,
-		QuitTime: participation.LeaveTime,
-		QuitType: quitType,
-		Forgiven: false,
+		MatchID:     state.ID,
+		QuitTime:    participation.LeaveTime,
+		QuitType:    quitType,
+		LeaveReason: participation.LeaveReason,
+		Forgiven:    false,
 
 		Username:    participation.Username,
 		DisplayName: participation.DisplayName,

--- a/server/evr_earlyquit_leave_reason_test.go
+++ b/server/evr_earlyquit_leave_reason_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+func TestLeaveReasonClassification(t *testing.T) {
+	tests := []struct {
+		name           string
+		leaveReason    LeaveReason
+		shouldPenalize bool // Whether immediate penalty should be applied
+	}{
+		{"voluntary leave gets immediate penalty", LeaveReasonVoluntary, true},
+		{"unknown leave gets immediate penalty", LeaveReasonUnknown, true},
+		{"empty leave reason gets immediate penalty", "", true},
+		{"disconnect defers penalty", LeaveReasonDisconnect, false},
+		{"timeout defers penalty", LeaveReasonTimeout, false},
+		{"crash recovery defers penalty", LeaveReasonCrashRecovery, false},
+		{"reservation expiry defers penalty", LeaveReasonReservationExp, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// This mirrors the logic in MatchLeave
+			shouldPenalizeImmediately := tt.leaveReason == LeaveReasonVoluntary ||
+				tt.leaveReason == LeaveReasonUnknown ||
+				tt.leaveReason == ""
+
+			if shouldPenalizeImmediately != tt.shouldPenalize {
+				t.Errorf("leaveReason=%q: expected shouldPenalize=%v, got %v",
+					tt.leaveReason, tt.shouldPenalize, shouldPenalizeImmediately)
+			}
+		})
+	}
+}
+
+func TestCreateQuitRecordFromParticipation_IncludesLeaveReason(t *testing.T) {
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	tests := []struct {
+		name        string
+		leaveReason LeaveReason
+	}{
+		{"voluntary", LeaveReasonVoluntary},
+		{"disconnect", LeaveReasonDisconnect},
+		{"crash_recovery", LeaveReasonCrashRecovery},
+		{"reservation_exp", LeaveReasonReservationExp},
+		{"unknown", LeaveReasonUnknown},
+		{"empty", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &MatchLabel{
+				ID:        matchID,
+				Mode:      evr.ModeArenaPublic,
+				StartTime: time.Now().Add(-5 * time.Minute),
+				GameState: &GameState{
+					BlueScore:   2,
+					OrangeScore: 3,
+					MatchOver:   false,
+				},
+			}
+
+			participation := &PlayerParticipation{
+				UserID:               uuid.Must(uuid.NewV4()).String(),
+				Username:             "testplayer",
+				DisplayName:          "TestPlayer",
+				Team:                 BlueTeam,
+				JoinTime:             time.Now().Add(-4 * time.Minute),
+				LeaveTime:            time.Now(),
+				LeaveReason:          tt.leaveReason,
+				GameDurationAtLeave:  4 * time.Minute,
+				ScoresAtLeave:        [2]int{2, 3},
+				ClockRemainingAtJoin: 300.0,
+			}
+
+			record := CreateQuitRecordFromParticipation(state, participation)
+
+			if record.LeaveReason != tt.leaveReason {
+				t.Errorf("expected LeaveReason=%q, got %q", tt.leaveReason, record.LeaveReason)
+			}
+			if record.MatchID != matchID {
+				t.Errorf("expected MatchID=%v, got %v", matchID, record.MatchID)
+			}
+		})
+	}
+}
+
+func TestDifferentialPenalty_VoluntaryVsDisconnect(t *testing.T) {
+	t.Run("voluntary leave increments penalty immediately", func(t *testing.T) {
+		config := NewEarlyQuitConfig()
+		leaveReason := LeaveReasonVoluntary
+
+		// Mirrors the MatchLeave logic
+		if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+			config.IncrementEarlyQuit()
+		}
+
+		if config.TotalEarlyQuits != 1 {
+			t.Errorf("expected 1 early quit, got %d", config.TotalEarlyQuits)
+		}
+		if config.EarlyQuitPenaltyLevel != 1 {
+			t.Errorf("expected penalty level 1, got %d", config.EarlyQuitPenaltyLevel)
+		}
+	})
+
+	t.Run("disconnect does not increment penalty immediately", func(t *testing.T) {
+		config := NewEarlyQuitConfig()
+		leaveReason := LeaveReasonDisconnect
+
+		// Mirrors the MatchLeave logic
+		if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+			config.IncrementEarlyQuit()
+		}
+
+		if config.TotalEarlyQuits != 0 {
+			t.Errorf("expected 0 early quits for disconnect, got %d", config.TotalEarlyQuits)
+		}
+		if config.EarlyQuitPenaltyLevel != 0 {
+			t.Errorf("expected penalty level 0 for disconnect, got %d", config.EarlyQuitPenaltyLevel)
+		}
+	})
+
+	t.Run("crash recovery does not increment penalty immediately", func(t *testing.T) {
+		config := NewEarlyQuitConfig()
+		leaveReason := LeaveReasonCrashRecovery
+
+		if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+			config.IncrementEarlyQuit()
+		}
+
+		if config.TotalEarlyQuits != 0 {
+			t.Errorf("expected 0 early quits for crash recovery, got %d", config.TotalEarlyQuits)
+		}
+	})
+}
+
+func TestPlayerParticipation_LeaveReason(t *testing.T) {
+	p := &PlayerParticipation{}
+
+	// Default should be zero value (empty string)
+	if p.LeaveReason != "" {
+		t.Errorf("expected empty default LeaveReason, got %q", p.LeaveReason)
+	}
+
+	// Should be settable
+	p.LeaveReason = LeaveReasonDisconnect
+	if p.LeaveReason != LeaveReasonDisconnect {
+		t.Errorf("expected LeaveReason=%q, got %q", LeaveReasonDisconnect, p.LeaveReason)
+	}
+}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -736,6 +736,15 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			if participation, ok := state.participations[p.GetUserId()]; ok {
 				// Record the leave event for the participation
 				participation.RecordLeaveEvent(state)
+
+				// Classify leave reason based on presence reason
+				if p.GetReason() == runtime.PresenceReasonLeave {
+					participation.LeaveReason = LeaveReasonVoluntary
+				} else if disconnectedFromGameServer {
+					participation.LeaveReason = LeaveReasonDisconnect
+				} else {
+					participation.LeaveReason = LeaveReasonUnknown
+				}
 			}
 
 			serviceSettings := ServiceSettings()
@@ -763,12 +772,23 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 					"expiry": expiry,
 				}).Info("Created reconnect reservation for crashed player")
 				hasReconnectReservation = true
+				// Update leave reason to reflect crash recovery
+				if participation, ok := state.participations[mp.GetUserId()]; ok {
+					participation.LeaveReason = LeaveReasonCrashRecovery
+				}
 			}
 			// If the round is not over, then add an early quit count to the player.
 			// Count all quits before match completion (both pre-game and early quits)
 			if !hasReconnectReservation && state.Mode == evr.ModeArenaPublic && !state.GameState.IsMatchOver() {
 				// Only players
 				if mp.IsPlayer() {
+					// Determine leave reason for penalty differentiation
+					var leaveReason LeaveReason
+					if participation, ok := state.participations[mp.GetUserId()]; ok {
+						leaveReason = participation.LeaveReason
+					}
+
+					tags["leave_reason"] = string(leaveReason)
 					nk.MetricsCounterAdd("match_entrant_early_quit", tags, 1)
 
 					logger.WithFields(map[string]interface{}{
@@ -776,6 +796,7 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 						"username":     mp.Username,
 						"evrid":        mp.EvrID,
 						"display_name": mp.DisplayName,
+						"leave_reason": leaveReason,
 					}).Debug("Incrementing early quit for player.")
 
 					if err := AccumulateLeaderboardStat(ctx, nk, mp.GetUserId(), mp.DisplayName, state.GetGroupID().String(), state.Mode, EarlyQuitStatisticID, 1); err != nil {
@@ -809,7 +830,19 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 						logger.WithField("error", err).Warn("Failed to load early quitter config")
 					} else {
 
-						eqconfig.IncrementEarlyQuit()
+						// Differential penalty: only apply immediate penalty for voluntary leaves.
+						// Disconnects get deferred — the logout forgiveness goroutine will
+						// auto-forgive if the player fully logged out (crash/network issue).
+						if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+							eqconfig.IncrementEarlyQuit()
+						} else {
+							// For disconnects: still record the quit but don't increment penalty.
+							// The logout forgiveness goroutine handles cleanup.
+							logger.WithFields(map[string]interface{}{
+								"uid":          mp.GetUserId(),
+								"leave_reason": leaveReason,
+							}).Info("Disconnect detected — deferring penalty to logout check")
+						}
 						eqconfig.LastEarlyQuitMatchID = state.ID
 
 						// Check for tier change after early quit
@@ -880,13 +913,23 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 								}
 							}
 
-							// Launch goroutine to check if player logs out and remove early quit if they do
-							// Use a 5-minute grace period before checking logout status
-							// Use background context to ensure goroutine isn't cancelled when match ends
-							go func(userID, sessionID string) {
-								bgCtx := context.Background()
-								CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, 5*time.Minute)
-							}(mp.GetUserId(), mp.GetSessionId())
+							// Launch goroutine for deferred penalty resolution.
+							// Use background context to ensure goroutine isn't cancelled when match ends.
+							if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+								// Voluntary leave: penalty applied immediately. If player logs out
+								// within 5 minutes, forgive the penalty (crash during quit flow).
+								go func(userID, sessionID string) {
+									bgCtx := context.Background()
+									CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, 5*time.Minute)
+								}(mp.GetUserId(), mp.GetSessionId())
+							} else {
+								// Disconnect: penalty deferred. If player is still online after
+								// 5 minutes, they force-closed intentionally — apply the penalty.
+								go func(userID, sessionID string, matchID MatchID) {
+									bgCtx := context.Background()
+									CheckAndApplyEarlyQuitIfStillOnline(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, matchID, 5*time.Minute)
+								}(mp.GetUserId(), mp.GetSessionId(), state.ID)
+							}
 						}
 					}
 				}
@@ -1131,6 +1174,11 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 			}
 
 			if rr.DeferPenalty {
+				// Update participation leave reason to reflect reservation expiry
+				if participation, ok := state.participations[rr.UserID]; ok {
+					participation.LeaveReason = LeaveReasonReservationExp
+				}
+
 				eqconfig := NewEarlyQuitConfig()
 				if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
 					logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")

--- a/server/evr_runtime_event_match_summary.go
+++ b/server/evr_runtime_event_match_summary.go
@@ -63,8 +63,9 @@ type PlayerParticipation struct {
 	IsTeamWipeMember       bool `json:"is_team_wipe_member,omitempty" bson:"is_team_wipe_member,omitempty"`
 
 	// Final status
-	WasPresentAtEnd bool `json:"was_present_at_end" bson:"was_present_at_end"`
-	IsAbandoner     bool `json:"is_abandoner,omitempty" bson:"is_abandoner,omitempty"`
+	WasPresentAtEnd bool        `json:"was_present_at_end" bson:"was_present_at_end"`
+	IsAbandoner     bool        `json:"is_abandoner,omitempty" bson:"is_abandoner,omitempty"`
+	LeaveReason     LeaveReason `json:"leave_reason,omitempty" bson:"leave_reason,omitempty"`
 }
 
 // MatchSummaryState captures the full final match state.


### PR DESCRIPTION
## Summary
- Add `LeaveReason` enum to classify match leaves: voluntary, disconnect, crash recovery, reservation expiry
- Implement differential penalty logic: voluntary leaves get immediate penalty, disconnects are deferred
- After 5-minute grace period: penalty applied only if player is still online (intentional force-close); forgiven if offline (genuine crash/network issue)
- Store `LeaveReason` in `PlayerParticipation`, `QuitRecord`, and as a metric dimension

## Context
Addresses Aaliyah Report #000046 item #4 — Crash vs. Disconnect vs. Leave Detection.

Previously, all match leaves were penalized identically regardless of whether the player voluntarily left, crashed, or had a network issue. This caused crashes to unfairly penalize players with the same early quit escalation (0s → 2m → 5m → 15m lockouts).

## Design

```
Player leaves match
├─ PresenceReasonLeave → LeaveReasonVoluntary → immediate penalty
│  └─ 5 min later: if logged out → forgive (existing behavior)
├─ PresenceReasonDisconnect + crash recovery enabled → LeaveReasonCrashRecovery
│  └─ Reconnect reservation created (existing behavior)
│     └─ Expires → LeaveReasonReservationExp → penalty applied
└─ PresenceReasonDisconnect + no crash recovery → LeaveReasonDisconnect
   └─ No immediate penalty
      └─ 5 min later: if still online → penalty (intentional force-close)
                       if offline → forgiven (genuine crash/network)
```

## Test plan
- [x] All existing early quit tests pass (TestEarlyQuit*, TestTier*)
- [x] Build passes
- [ ] Manual: verify crash recovery flow preserves LeaveReason through reservation lifecycle
- [ ] Manual: verify disconnect forgiveness works when player logs out after network issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)