### PR TITLE
fix: demote backfill join failure log from Warn to Info

### DIFF
--- a/server/evr_lobby_backfill.go
+++ b/server/evr_lobby_backfill.go
@@ -997,7 +997,7 @@ func (b *PostMatchmakerBackfill) executeBackfillResult(ctx context.Context, logg
 		go func(idx int, ent *EvrMatchPresence) {
 			defer wg.Done()
 			if err := LobbyJoinEntrants(logger, b.matchRegistry, b.tracker, sessions[idx], serverSession, result.Match.Label, ent); err != nil {
-				logger.Warn("Failed to join entrant to backfill match", zap.Error(err), zap.String("match_id", result.Match.Label.ID.String()), zap.String("user_id", ent.GetUserId()))
+				logger.Info("Failed to join entrant to backfill match", zap.Error(err), zap.String("match_id", result.Match.Label.ID.String()), zap.String("user_id", ent.GetUserId()))
 			} else {
 				mu.Lock()
 				successCount++


### PR DESCRIPTION
## Summary

- Last remaining fix from the `investigation/log-triage-20260314` branch (all other fixes were already merged)
- Backfill join failures are expected during normal operation and shouldn't be Warn-level

## Test plan

- [x] `go build ./server/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)