### PR TITLE
fix: party followers can join leader's lobby after reconnecting

### DIFF
--- a/.claude/commands/release-notes.md
+++ b/.claude/commands/release-notes.md
@@ -1,0 +1,158 @@
+---
+description: "Generate audience-targeted release notes and post to Discord. Use when tagging a release, preparing changelog, or user says /release-notes."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent, WebFetch
+---
+
+# Release Notes Generator
+
+Generate release notes for an EchoVR game server called EchoRelay. The audience is the EchoVR community on Discord. The server is a custom backend that replaces the defunct official servers.
+
+**Input:** A release tag (e.g. `v3.27.2-evr.263`) and optionally a base tag. If no base tag is given, use the immediately preceding tag.
+
+If no tag is provided, determine the latest tag from `git tag --sort=-v:refname | head -5` and use it.
+
+## Step 1: Gather commits
+
+```bash
+git log <base_tag>..<release_tag> --oneline --no-merges
+```
+
+Filter out merge commits (lines starting with "Merge worktree-agent-" or similar). These are infrastructure noise.
+
+For any commit that isn't self-explanatory from its one-line message, read the full commit message and/or the diff to understand the user-facing impact.
+
+## Step 2: Categorize each change
+
+Assign each meaningful commit to one or more audience categories:
+
+| Category        | Who sees it                                 | Description                                                                                                                                                                                                                                                                                           |
+| --------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `player`        | All players                                 | Gameplay fixes, matchmaking improvements, party system changes, crash fixes, connection improvements                                                                                                                                                                                                  |
+| `enforcer`      | In-game moderators/enforcers                | In-game moderation tools, kick/smite/ban actions, enforcement UI, in-match moderation features                                                                                                                                                                                                        |
+| `operator`      | Guild owners, global operators, moderators  | Server management, guild management, Discord bot admin features, enforcement configuration, operator dashboards                                                                                                                                                                                       |
+| `app-developer` | App/integration developers                  | API changes, RPC endpoints, webhook changes, integration points, SDK-facing changes                                                                                                                                                                                                                   |
+| `competitive`   | Comp server hosts, allocators, coordinators | Changes to echo_arena_private and echo_combat_private modes ONLY. Private match hosting, private match configuration, server allocation for private matches, team settings in private matches. Do NOT include public matchmaking (echo_arena, echo_combat) changes here — those are `player` category |
+| `echotools`     | EchoTools core developers                   | Internal refactors, binary protocol changes, migration changes, code cleanup, architecture, infrastructure                                                                                                                                                                                            |
+
+A single commit can belong to multiple categories.
+
+## Step 3: Write the descriptions
+
+For each change, write a SHORT (one line) player-friendly description. Do NOT use commit-message language. Translate technical changes into what the player experiences.
+
+Examples:
+
+- `fix: matchmaker reservation system broken by wrong property key` -> "Fixed a bug where matchmaking could fail to find matches"
+- `fix: party members don't follow leader into social lobbies` -> "Fixed party members not following the party leader into lobbies"
+- `feat: add suspension enforcement system` -> "Added suspension enforcement system"
+- `fix: KickPlayerAllowPrivates defaults to false instead of true` -> "Players can no longer join private matches while kicked (previously the default allowed it)"
+
+Do NOT include:
+
+- Commit hashes
+- File names or function names
+- Technical jargon about binary formats, protocol rewrites, etc. (except in echotools/app-developer notes)
+
+## Step 4: Game Service Updated Notification
+
+Generate a short notification message for the general announcements channel:
+
+```
+# :EchoVR: Deployed Game Service Update :EchoVR:
+
+- <short one-line player-facing change>
+- <short one-line player-facing change>
+
+### :warning: if you get an error, then reopen your game. If you still get an error, then go pet your dog for 10 minutes. :doggoblob:
+```
+
+Only include `player` category items. Keep it to 3-8 short bullet points. No bold titles, no descriptions — just the facts.
+
+## Step 5: Generate seven release notes
+
+All release notes use this structure. Group changes by TOPIC (e.g. "Matchmaking", "Party System", "Moderation"), not by commit type. Each item gets a **bold title** followed by a colon and a description.
+
+All release notes EXCEPT #7 (full changelog) must include this footer:
+
+```
+-# [Full Changelog](https://discord.com/channels/1179666360863817749/1485036740820472080)
+```
+
+### 1: Players (#release-notes)
+
+`player` category only. No emoji in title.
+
+```
+## Release Notes <release_tag>
+
+<1-2 sentence summary of the release theme>
+
+### <Topic Area>
+* **<Title>:** <What changed and why it matters>
+
+-# [Full Changelog](https://discord.com/channels/1179666360863817749/1485036740820472080)
+```
+
+### 2: EchoTools Core Developers
+
+ALL categories. Full technical detail. Include refactors, protocol changes, migration changes, binary format changes in a "Technical / Internal" section.
+
+### 3: App Developers
+
+`app-developer` category ONLY. Focus on API surface changes, RPC endpoints, behavioral changes that affect integrations. If none, say "No app-developer-facing changes in this release."
+
+### 4: Guild Owners / Operators / Moderators
+
+`player`, `operator`, and `enforcer` categories. Focus on management tools, enforcement features, guild administration.
+
+### 5: Competitive Server Hosts / Allocators / Coordinators
+
+`player`, `enforcer`, and `competitive` categories. ONLY echo_arena_private and echo_combat_private changes. Do NOT include public matchmaking. If none, say "No competitive hosting changes in this release."
+
+### 6: In-Game Mod / Enforcer Quick Notes
+
+`enforcer` category ONLY. Brief bullet list, no topic grouping. If none, say "No enforcer-specific changes in this release."
+
+### 7: Full Changelog (#full-changelog)
+
+ALL categories. Concise but comprehensive. Grouped by topic. No footer needed.
+
+```
+## Changelog <release_tag>
+
+### <Topic Area>
+* **<Title>:** <Concise description>
+
+### Protocol & Internal
+* **<Title>:** <Technical description>
+```
+
+## Step 6: Output
+
+Present all seven release notes + the notification message clearly separated. Wrap each in a markdown code block for easy copy-paste into Discord. Format using Discord markdown.
+
+## Step 7: Post to Discord
+
+Present this table and ask which to post:
+
+| #   | Channel               | Audience                            | Env Var                        |
+| --- | --------------------- | ----------------------------------- | ------------------------------ |
+| 1   | #release-notes        | Players                             | `WEBHOOK_RELEASE_NOTES`        |
+| 2   | #echotools-releases   | EchoTools devs                      | `WEBHOOK_ECHOTOOLS_RELEASES`   |
+| 3   | #app-dev-releases     | App developers                      | `WEBHOOK_APP_DEV_RELEASES`     |
+| 4   | #operator-releases    | Guild owners/operators/mods         | `WEBHOOK_OPERATOR_RELEASES`    |
+| 5   | #competitive-releases | Comp hosts/allocators/coordinators  | `WEBHOOK_COMPETITIVE_RELEASES` |
+| 6   | #enforcer-updates     | In-game mods/enforcers              | `WEBHOOK_ENFORCER_UPDATES`     |
+| 7   | #full-changelog       | Detailed changelog (all categories) | `WEBHOOK_FULL_CHANGELOG`       |
+
+Webhook URLs are stored in `.env` at the project root (gitignored).
+
+Post using the script:
+
+```bash
+./docs/post-release-notes.sh <channel_number> <file_with_message_content>
+```
+
+Write each message to a temp file first, then post. Discord content field has a 2000 character limit — the script handles splitting automatically.
+
+**Only post after explicit user confirmation. Never post automatically.**

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -395,6 +395,25 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 		}
 	}
 
+	// Look up slot reservation BEFORE the capacity check.
+	// Reservations are counted in Size (via rebuildCache), so consuming one
+	// frees a slot. Without this ordering, a full lobby rejects the join
+	// at the OpenSlots gate before the reservation lookup is reached.
+	// First try by session ID (fast path). If that misses — e.g. the follower
+	// disconnected and reconnected with a new session — fall back to user ID.
+	var slotReservationPresence *EvrMatchPresence
+	if e, found := state.LoadAndDeleteReservation(meta.Presence.GetSessionId()); found {
+		slotReservationPresence = e
+	} else if e, found := state.LoadAndDeleteReservationByUserID(meta.Presence.GetUserId()); found {
+		slotReservationPresence = e
+	}
+	if slotReservationPresence != nil {
+		meta.Presence.PartyID = slotReservationPresence.PartyID
+		meta.Presence.RoleAlignment = slotReservationPresence.RoleAlignment
+		state.rebuildCache()
+		logger = logger.WithField("has_reservation", true)
+	}
+
 	// Ensure the match has enough slots available.
 	// Reconnecting users can reclaim their own reconnect reservation slot.
 	availableSlots := state.OpenSlots()
@@ -410,15 +429,6 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 		delete(state.reconnectReservations, meta.Presence.GetUserId())
 		state.rebuildCache()
 		consumeReconnectReservation = true
-	}
-
-	// If this is a reservation, load the reservation
-	if e, found := state.LoadAndDeleteReservation(meta.Presence.GetSessionId()); found {
-		meta.Presence.PartyID = e.PartyID
-		meta.Presence.RoleAlignment = e.RoleAlignment
-
-		state.rebuildCache()
-		logger = logger.WithField("has_reservation", true)
 	}
 
 	// If this player has a team alignment, load it

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -92,6 +92,26 @@ func (s *MatchLabel) LoadAndDeleteReservation(sessionID string) (*EvrMatchPresen
 	return r.Presence, true
 }
 
+// LoadAndDeleteReservationByUserID searches the reservation map for a reservation
+// matching the given user ID. This is a fallback for when the session ID has changed
+// (e.g., party follower disconnected and reconnected with a new session).
+// Expired reservations are cleaned up during the scan.
+func (s *MatchLabel) LoadAndDeleteReservationByUserID(userID string) (*EvrMatchPresence, bool) {
+	for sessionID, r := range s.reservationMap {
+		if r.Presence.GetUserId() != userID {
+			continue
+		}
+		if r.Expiry.Before(time.Now()) {
+			delete(s.reservationMap, sessionID)
+			continue
+		}
+		delete(s.reservationMap, sessionID)
+		s.rebuildCache()
+		return r.Presence, true
+	}
+	return nil, false
+}
+
 func (s *MatchLabel) IsPublic() bool {
 	return s.LobbyType == PublicLobby
 }

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -2244,3 +2244,125 @@ func TestSlotReservation_ExpiredReservationNotReturnedByUserID(t *testing.T) {
 		t.Error("Expired reservation should have been cleaned up")
 	}
 }
+
+// TestMatchJoinAttempt_PartyFollowerReconnectFindsReservation exercises the full
+// MatchJoinAttempt flow: leader joins creating a reservation for a follower,
+// lobby fills to capacity, then the follower reconnects with a new session ID.
+// The join must succeed via user-ID reservation fallback.
+func TestMatchJoinAttempt_PartyFollowerReconnectFindsReservation(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.LobbyType = PublicLobby
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+
+	leaderUserID := uuid.Must(uuid.NewV4())
+	leaderSessionID := uuid.Must(uuid.NewV4())
+	followerUserID := uuid.Must(uuid.NewV4())
+	followerOriginalSID := uuid.Must(uuid.NewV4())
+	followerNewSID := uuid.Must(uuid.NewV4())
+	partyID := uuid.Must(uuid.NewV4())
+
+	leader := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     leaderSessionID,
+		UserID:        leaderUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 1},
+		Username:      "leader",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+		ClientIP:      "127.0.0.1",
+		ClientPort:    "1001",
+	}
+	followerReservation := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerOriginalSID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 2},
+		Username:      "follower",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+		ClientIP:      "127.0.0.2",
+		ClientPort:    "1002",
+	}
+
+	leaderMeta := &EntrantMetadata{
+		Presence:     leader,
+		Reservations: []*EvrMatchPresence{followerReservation},
+	}
+
+	m := &EvrMatch{}
+	ctx := context.Background()
+	logger := NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
+	nk := &reconnectTestNakamaModule{}
+	disp := &reconnectTestDispatcher{}
+
+	// Leader joins — creates reservation for follower
+	resultState, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, leader, leaderMeta.ToMatchMetadata())
+	if !allowed {
+		t.Fatalf("Leader join should be allowed, got: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	if _, exists := state.reservationMap[followerOriginalSID.String()]; !exists {
+		t.Fatal("Reservation should exist for follower's original session ID")
+	}
+
+	// Fill the lobby to capacity: leader=1, reservation=1, add 10 fillers = 12
+	for i := 0; i < 10; i++ {
+		filler := &EvrMatchPresence{
+			Node:          "testnode",
+			SessionID:     uuid.Must(uuid.NewV4()),
+			UserID:        uuid.Must(uuid.NewV4()),
+			EvrID:         evr.EvrId{PlatformCode: 4, AccountId: uint64(100 + i)},
+			Username:      fmt.Sprintf("filler%d", i),
+			RoleAlignment: evr.TeamSocial,
+			SessionExpiry: 9999999999,
+			ClientIP:      fmt.Sprintf("127.0.1.%d", i),
+			ClientPort:    fmt.Sprintf("200%d", i),
+		}
+		fillerMeta := NewJoinMetadata(filler)
+		resultState, allowed, reason = m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, filler, fillerMeta.ToMatchMetadata())
+		if !allowed {
+			t.Fatalf("Filler %d join rejected: %s", i, reason)
+		}
+		state = resultState.(*MatchLabel)
+	}
+
+	// Lobby is at capacity (12/12)
+	if state.OpenSlots() != 0 {
+		t.Fatalf("Expected 0 open slots, got %d", state.OpenSlots())
+	}
+
+	// Follower reconnects with a NEW session ID
+	followerReconnected := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerNewSID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 2},
+		Username:      "follower",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+		ClientIP:      "127.0.0.2",
+		ClientPort:    "1002",
+	}
+	followerMeta := NewJoinMetadata(followerReconnected)
+
+	// Without the fix: rejected with "lobby full" because OpenSlots()=0
+	// blocks the join before reservation lookup runs.
+	// With the fix: reservation is looked up BEFORE the slot check,
+	// consumed (freeing a slot), and the join succeeds.
+	resultState, allowed, reason = m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, followerReconnected, followerMeta.ToMatchMetadata())
+	if !allowed {
+		t.Fatalf("Follower reconnect should succeed via reservation fallback, but rejected: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	// Verify reservation was consumed
+	if _, exists := state.reservationMap[followerOriginalSID.String()]; exists {
+		t.Error("Original reservation should have been consumed")
+	}
+}

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -2146,3 +2146,101 @@ func TestArenaLocking_DoesNotLockOnPlaying(t *testing.T) {
 		t.Fatal("expected LockedAt to remain nil after playing update")
 	}
 }
+
+func newSocialTestMatchLabel() *MatchLabel {
+	state := &MatchLabel{
+		CreatedAt:             time.Now(),
+		GameServer:            &GameServerPresence{SessionID: uuid.Must(uuid.NewV4())},
+		Open:                  true,
+		RequiredFeatures:      make([]string, 0),
+		Players:               make([]PlayerInfo, 0, SocialLobbyMaxSize),
+		presenceMap:           make(map[string]*EvrMatchPresence, SocialLobbyMaxSize),
+		reservationMap:        make(map[string]*slotReservation, 2),
+		reconnectReservations: make(map[string]*reconnectReservation),
+		presenceByEvrID:       make(map[evr.EvrId]*EvrMatchPresence, SocialLobbyMaxSize),
+		goals:                 make([]*evr.MatchGoal, 0),
+		TeamAlignments:        make(map[string]int, SocialLobbyMaxSize),
+		joinTimestamps:        make(map[string]time.Time, SocialLobbyMaxSize),
+		joinTimeMilliseconds:  make(map[string]int64, SocialLobbyMaxSize),
+		participations:        make(map[string]*PlayerParticipation),
+		emptyTicks:            0,
+		tickRate:              10,
+	}
+	state.rebuildCache()
+	return state
+}
+
+// TestSlotReservation_FollowerReconnectNewSessionID verifies that a party
+// follower who reconnects (getting a new session ID) can still claim the
+// slot reservation that was created under their original session ID.
+func TestSlotReservation_FollowerReconnectNewSessionID(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	originalSessionID := uuid.Must(uuid.NewV4())
+	newSessionID := uuid.Must(uuid.NewV4())
+
+	state.reservationMap[originalSessionID.String()] = &slotReservation{
+		Presence: &EvrMatchPresence{
+			UserID:        followerUserID,
+			SessionID:     originalSessionID,
+			RoleAlignment: evr.TeamSocial,
+			PartyID:       uuid.Must(uuid.NewV4()),
+		},
+		Expiry: time.Now().Add(5 * time.Minute),
+	}
+	state.rebuildCache()
+
+	// Session-ID lookup should miss (different session).
+	_, found := state.LoadAndDeleteReservation(newSessionID.String())
+	if found {
+		t.Fatal("LoadAndDeleteReservation should miss for new session ID")
+	}
+
+	// User-ID fallback should find it.
+	presence, found := state.LoadAndDeleteReservationByUserID(followerUserID.String())
+	if !found {
+		t.Fatal("LoadAndDeleteReservationByUserID should find the reservation by user ID")
+	}
+	if presence.UserID != followerUserID {
+		t.Errorf("Expected user ID %s, got %s", followerUserID, presence.UserID)
+	}
+
+	// Verify consumed.
+	if _, stillThere := state.reservationMap[originalSessionID.String()]; stillThere {
+		t.Error("Reservation should have been deleted")
+	}
+}
+
+// TestSlotReservation_ExpiredReservationNotReturnedByUserID verifies that
+// LoadAndDeleteReservationByUserID does not return expired reservations.
+func TestSlotReservation_ExpiredReservationNotReturnedByUserID(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	originalSessionID := uuid.Must(uuid.NewV4())
+
+	state.reservationMap[originalSessionID.String()] = &slotReservation{
+		Presence: &EvrMatchPresence{
+			UserID:        followerUserID,
+			SessionID:     originalSessionID,
+			RoleAlignment: evr.TeamSocial,
+		},
+		Expiry: time.Now().Add(-1 * time.Minute),
+	}
+	state.rebuildCache()
+
+	_, found := state.LoadAndDeleteReservationByUserID(followerUserID.String())
+	if found {
+		t.Fatal("Expired reservation should not be returned")
+	}
+	if _, stillThere := state.reservationMap[originalSessionID.String()]; stillThere {
+		t.Error("Expired reservation should have been cleaned up")
+	}
+}


### PR DESCRIPTION
## Summary

- Party followers could not join their leader's social lobby after disconnecting and reconnecting. The slot reservation (created when the leader joined) was keyed by session ID, which changes on every reconnect, making the reservation unreachable.
- Players experienced this as repeated "server full" errors when trying to join pubs with friends — the client would disconnect and reconnect in a loop, each time hitting the same full lobby and failing.
- Fix: add a user-ID fallback for reservation lookup, and move the reservation lookup before the capacity check in `MatchJoinAttempt` (reservations are counted in `Size`, so consuming one must happen before `OpenSlots()` is checked).

## Test plan

- [x] Unit test: `TestSlotReservation_FollowerReconnectNewSessionID` — verifies user-ID fallback finds reservation after session change
- [x] Unit test: `TestSlotReservation_ExpiredReservationNotReturnedByUserID` — verifies expired reservations are cleaned up
- [x] Integration test: `TestMatchJoinAttempt_PartyFollowerReconnectFindsReservation` — full MatchJoinAttempt flow: leader joins with reservation, lobby fills to capacity, follower reconnects with new session, join succeeds via fallback
- [x] All 12 existing `TestReconnectReservation_*` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)