### PR TITLE
feat: restrict enforcer visibility of moderator notes

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2337,6 +2337,9 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				IncludeMatchmakingTier:         access.IsAuditor,
 				ShowLoginsSince:                loginsSince,
 				SendFileOnError:                access.IsGlobalOperator,
+
+				CallerUserID:    callerUserID,
+				CallerIsAuditor: access.IsAuditor,
 			}
 
 			return d.handleProfileRequest(ctx, logger, nk, s, i, target, opts)

--- a/server/evr_discord_appbot_enforcement.go
+++ b/server/evr_discord_appbot_enforcement.go
@@ -56,14 +56,14 @@ func (d *DiscordAppBot) handleEnforcementInteraction(ctx context.Context, _ runt
 	}
 
 	// Check permissions - global operator or guild enforcer
-	_, _, _, err := RequireEnforcerOrOperator(ctx, d.db, d.nk, callerID, groupID)
+	isOperator, _, gg, err := RequireEnforcerOrOperator(ctx, d.db, d.nk, callerID, groupID)
 	if err != nil {
 		return simpleInteractionResponse(s, i, "You must be a guild enforcer or global operator to modify enforcement records.")
 	}
 
 	switch action {
 	case "edit":
-		return d.showEnforcementEditModal(s, i, recordID, groupID, targetUserID)
+		return d.showEnforcementEditModal(s, i, recordID, groupID, targetUserID, callerID, isOperator, gg)
 	case "void":
 		return d.showEnforcementVoidModal(s, i, recordID, groupID, targetUserID)
 	default:
@@ -71,8 +71,10 @@ func (d *DiscordAppBot) handleEnforcementInteraction(ctx context.Context, _ runt
 	}
 }
 
-// showEnforcementEditModal displays the edit modal with pre-filled current values
-func (d *DiscordAppBot) showEnforcementEditModal(s *discordgo.Session, i *discordgo.InteractionCreate, recordID, groupID, targetUserID string) error {
+// showEnforcementEditModal displays the edit modal with pre-filled current values.
+// When RestrictEnforcerNoteVisibility is active and the caller is not the record creator
+// (and not an auditor/operator), the moderator notes field is omitted from the modal.
+func (d *DiscordAppBot) showEnforcementEditModal(s *discordgo.Session, i *discordgo.InteractionCreate, recordID, groupID, targetUserID, callerID string, isOperator bool, gg *GuildGroup) error {
 	ctx := d.ctx
 
 	// Load the enforcement journal for the target user
@@ -106,8 +108,14 @@ func (d *DiscordAppBot) showEnforcementEditModal(s *discordgo.Session, i *discor
 		targetMention = fmt.Sprintf("<@%s>", targetDiscordID)
 	}
 
-	// Check if moderator notes exceed Discord modal limit
-	if len(record.AuditorNotes) > 200 {
+	// Determine if the caller can see/edit moderator notes on this record
+	canSeeNotes := true
+	if gg.RestrictEnforcerNoteVisibility && !isOperator && !gg.IsAuditor(callerID) {
+		canSeeNotes = record.EnforcerUserID == callerID
+	}
+
+	// Check if moderator notes exceed Discord modal limit (only relevant if caller can see them)
+	if canSeeNotes && len(record.AuditorNotes) > 200 {
 		portalBaseURL := os.Getenv("NEVR_PORTAL_BASE_URL")
 		if portalBaseURL == "" {
 			portalBaseURL = "https://echovrce.com/"
@@ -117,69 +125,77 @@ func (d *DiscordAppBot) showEnforcementEditModal(s *discordgo.Session, i *discor
 		return simpleInteractionResponse(s, i, fmt.Sprintf("Moderator notes for this record exceed 200 characters and cannot be edited through Discord.\n\nEdit this record on the portal: %s", portalLink))
 	}
 
+	// Build modal components
+	components := []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.TextInput{
+					CustomID:    "duration_input",
+					Label:       "Duration (e.g., 1d2h, 30m, 1w)",
+					Style:       discordgo.TextInputShort,
+					Placeholder: "Enter duration (e.g., 15m, 1h, 2d, 1w)",
+					Value:       durationStr,
+					Required:    true,
+					MinLength:   1,
+					MaxLength:   20,
+				},
+			},
+		},
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.TextInput{
+					CustomID:    "user_notice_input",
+					Label:       "User Notice (visible to user)",
+					Style:       discordgo.TextInputShort,
+					Placeholder: "Reason shown to the user",
+					Value:       record.UserNoticeText,
+					Required:    true,
+					MinLength:   1,
+					MaxLength:   45,
+				},
+			},
+		},
+	}
+
+	// Only include moderator notes field if the caller can see them
+	if canSeeNotes {
+		components = append(components, discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.TextInput{
+					CustomID:    "mod_notes_input",
+					Label:       "Moderator Notes (internal only)",
+					Style:       discordgo.TextInputParagraph,
+					Placeholder: "Internal notes for moderators",
+					Value:       record.AuditorNotes,
+					Required:    false,
+					MaxLength:   200,
+				},
+			},
+		})
+	}
+
+	components = append(components, discordgo.ActionsRow{
+		Components: []discordgo.MessageComponent{
+			discordgo.TextInput{
+				CustomID:    "allow_privates_input",
+				Label:       "Allow Private Lobbies (yes/no)",
+				Style:       discordgo.TextInputShort,
+				Placeholder: "yes or no",
+				Value:       formatYesNo(record.AllowPrivateLobbies),
+				Required:    true,
+				MinLength:   2,
+				MaxLength:   5,
+			},
+		},
+	})
+
 	// Create the modal with pre-filled values
 	modal := &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseModal,
 		Data: &discordgo.InteractionResponseData{
-			CustomID: fmt.Sprintf("enf_edit:%s:%s", targetDiscordID, recordID),
-			Title:    fmt.Sprintf("Edit Record for %s", targetMention),
-			Components: []discordgo.MessageComponent{
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.TextInput{
-							CustomID:    "duration_input",
-							Label:       "Duration (e.g., 1d2h, 30m, 1w)",
-							Style:       discordgo.TextInputShort,
-							Placeholder: "Enter duration (e.g., 15m, 1h, 2d, 1w)",
-							Value:       durationStr,
-							Required:    true,
-							MinLength:   1,
-							MaxLength:   20,
-						},
-					},
-				},
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.TextInput{
-							CustomID:    "user_notice_input",
-							Label:       "User Notice (visible to user)",
-							Style:       discordgo.TextInputShort,
-							Placeholder: "Reason shown to the user",
-							Value:       record.UserNoticeText,
-							Required:    true,
-							MinLength:   1,
-							MaxLength:   45,
-						},
-					},
-				},
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.TextInput{
-							CustomID:    "mod_notes_input",
-							Label:       "Moderator Notes (internal only)",
-							Style:       discordgo.TextInputParagraph,
-							Placeholder: "Internal notes for moderators",
-							Value:       record.AuditorNotes,
-							Required:    false,
-							MaxLength:   200,
-						},
-					},
-				},
-				discordgo.ActionsRow{
-					Components: []discordgo.MessageComponent{
-						discordgo.TextInput{
-							CustomID:    "allow_privates_input",
-							Label:       "Allow Private Lobbies (yes/no)",
-							Style:       discordgo.TextInputShort,
-							Placeholder: "yes or no",
-							Value:       formatYesNo(record.AllowPrivateLobbies),
-							Required:    true,
-							MinLength:   2,
-							MaxLength:   5,
-						},
-					},
-				},
-			},
+			CustomID:   fmt.Sprintf("enf_edit:%s:%s", targetDiscordID, recordID),
+			Title:      fmt.Sprintf("Edit Record for %s", targetMention),
+			Components: components,
 		},
 	}
 
@@ -271,17 +287,27 @@ func (d *DiscordAppBot) handleEnforcementEditModalSubmit(logger runtime.Logger, 
 	}
 
 	// Verify permissions - global operator or guild enforcer
-	_, _, gg, err := RequireEnforcerOrOperator(ctx, d.db, d.nk, callerID, groupID)
+	isOperator, _, gg, err := RequireEnforcerOrOperator(ctx, d.db, d.nk, callerID, groupID)
 	if err != nil {
 		return simpleInteractionResponse(d.dg, i, "You must be a guild enforcer or global operator to edit enforcement records.")
 	}
 
-	// Get form data
+	// Extract form data by custom ID (modal may have variable components when notes field is omitted)
 	data := i.Interaction.ModalSubmitData()
-	durationStr := data.Components[0].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value
-	userNotice := data.Components[1].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value
-	modNotes := data.Components[2].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value
-	allowPrivatesStr := data.Components[3].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value
+	formValues := make(map[string]string, len(data.Components))
+	for _, row := range data.Components {
+		actionRow, ok := row.(*discordgo.ActionsRow)
+		if !ok || len(actionRow.Components) == 0 {
+			continue
+		}
+		if input, ok := actionRow.Components[0].(*discordgo.TextInput); ok {
+			formValues[input.CustomID] = input.Value
+		}
+	}
+	durationStr := formValues["duration_input"]
+	userNotice := formValues["user_notice_input"]
+	modNotes := formValues["mod_notes_input"] // Empty when notes field was omitted from modal
+	allowPrivatesStr := formValues["allow_privates_input"]
 
 	allowPrivates, err := parseYesNo(allowPrivatesStr)
 	if err != nil {
@@ -309,6 +335,11 @@ func (d *DiscordAppBot) handleEnforcementEditModalSubmit(logger runtime.Logger, 
 	// Check if already voided
 	if journal.IsVoid(groupID, recordID) {
 		return simpleInteractionResponse(d.dg, i, "This record has already been voided and cannot be edited.")
+	}
+
+	// Preserve existing notes when toggle restricts visibility and caller is not the record creator
+	if gg.RestrictEnforcerNoteVisibility && !isOperator && !gg.IsAuditor(callerID) && record.EnforcerUserID != callerID {
+		modNotes = record.AuditorNotes
 	}
 
 	// Save old record values before editing
@@ -604,8 +635,9 @@ func (d *DiscordAppBot) updateEnforcementMessage(i *discordgo.InteractionCreate,
 		}
 	}
 
-	// Regenerate the suspension details field using the same function as kickPlayer
-	suspensionField := createSuspensionDetailsEmbedField(gg.Name(), []GuildEnforcementRecord{newRecord}, voids, true, true, true, gg.Group.Id)
+	// Regenerate the suspension details field; hide notes in channel message when toggle is active
+	showNotes := !gg.RestrictEnforcerNoteVisibility
+	suspensionField := createSuspensionDetailsEmbedField(gg.Name(), []GuildEnforcementRecord{newRecord}, voids, true, showNotes, true, gg.Group.Id, "")
 	if suspensionField != nil {
 		updatedEmbed.Fields = append(updatedEmbed.Fields, suspensionField)
 	}

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -1104,7 +1104,7 @@ func (d *DiscordAppBot) kickPlayer(logger runtime.Logger, i *discordgo.Interacti
 					fmt.Sprintf("<t:%d:R> by <@!%s>:", time.Now().UTC().Unix(), caller.User.ID),
 					fmt.Sprintf("- `%s`", userNotice),
 				}
-				if notes != "" {
+				if notes != "" && !gg.RestrictEnforcerNoteVisibility {
 					parts = append(parts,
 						fmt.Sprintf("- *%s*", notes),
 					)
@@ -1127,8 +1127,9 @@ func (d *DiscordAppBot) kickPlayer(logger runtime.Logger, i *discordgo.Interacti
 				}
 
 				// Create a field for each group
-				// Always show enforcer ID in enforcement notice channel (it's for moderators only)
-				field := createSuspensionDetailsEmbedField(gn, records, voids, true, true, true, gID)
+				// Show enforcer ID in enforcement notice channel; hide notes when toggle restricts visibility
+				showNotes := !gg.RestrictEnforcerNoteVisibility
+				field := createSuspensionDetailsEmbedField(gn, records, voids, true, showNotes, true, gID, "")
 				embed.Fields = append(embed.Fields, field)
 			}
 

--- a/server/evr_discord_appbot_whoami.go
+++ b/server/evr_discord_appbot_whoami.go
@@ -41,6 +41,9 @@ type UserProfileRequestOptions struct {
 	IncludeMatchmakingTier         bool
 	ShowLoginsSince                time.Time
 	SendFileOnError                bool // If true, send a file with the error message instead of an ephemeral message
+
+	CallerUserID    string // Nakama user ID of the caller (for per-record note filtering)
+	CallerIsAuditor bool   // Auditors bypass per-record note restriction
 }
 
 const (
@@ -482,7 +485,16 @@ func (w *WhoAmI) createSuspensionsEmbed() *discordgo.MessageEmbed {
 			if gg, ok := w.guildGroups[groupID]; ok {
 				gName = EscapeDiscordMarkdown(gg.Name())
 			}
-			if field := createSuspensionDetailsEmbedField(gName, records, voids, w.opts.IncludeInactiveSuspensions, w.opts.IncludeSuspensionAuditorNotes, w.opts.IncludeSuspensionAuditorNotes, w.GroupID); field != nil {
+
+			// Per-record note filtering: restrict enforcers to their own records' notes when toggle is active
+			callerForFilter := ""
+			if w.opts.IncludeSuspensionAuditorNotes {
+				if gg, ok := w.guildGroups[groupID]; ok && gg.RestrictEnforcerNoteVisibility && !w.opts.CallerIsAuditor {
+					callerForFilter = w.opts.CallerUserID
+				}
+			}
+
+			if field := createSuspensionDetailsEmbedField(gName, records, voids, w.opts.IncludeInactiveSuspensions, w.opts.IncludeSuspensionAuditorNotes, w.opts.IncludeSuspensionAuditorNotes, w.GroupID, callerForFilter); field != nil {
 				if field.Value != "" {
 					fields = append(fields, field)
 				}

--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -466,7 +466,10 @@ func FormatDuration(d time.Duration) string {
 	return "0s"
 }
 
-func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcementRecord, voids map[string]GuildEnforcementRecordVoid, includeInactive, includeAuditorNotes, showEnforcerID bool, currentGuildID string) *discordgo.MessageEmbedField {
+// createSuspensionDetailsEmbedField builds a Discord embed field summarizing enforcement records.
+// callerUserID restricts note visibility per-record: empty string means show all notes (auditor/operator),
+// non-empty means only show notes on records where EnforcerUserID matches the caller.
+func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcementRecord, voids map[string]GuildEnforcementRecordVoid, includeInactive, includeAuditorNotes, showEnforcerID bool, currentGuildID string, callerUserID string) *discordgo.MessageEmbedField {
 	if len(records) == 0 {
 		return nil
 	}
@@ -498,12 +501,14 @@ func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcem
 		)
 
 		if includeAuditorNotes {
-			if r.AuditorNotes != "" {
+			// When callerUserID is set, only show notes on records the caller created
+			canSeeNotes := callerUserID == "" || r.EnforcerUserID == callerUserID
+			if canSeeNotes && r.AuditorNotes != "" {
 				parts = append(parts,
 					fmt.Sprintf("- *%s*", r.AuditorNotes),
 				)
 			}
-			if voids != nil {
+			if canSeeNotes && voids != nil {
 				if v, ok := voids[r.ID]; ok {
 					parts = append(parts,
 						fmt.Sprintf("- voided by <@!%s> <t:%d:R> *%s*", v.AuthorDiscordID, v.VoidedAt.UTC().Unix(), v.Notes),

--- a/server/evr_enforcement_journal_test.go
+++ b/server/evr_enforcement_journal_test.go
@@ -307,6 +307,7 @@ func TestCreateSuspensionDetailsEmbedField(t *testing.T) {
 				tc.includeAuditorNotes,
 				tc.showEnforcerID,
 				tc.currentGuildID,
+				"", // callerUserID: empty = no per-record restriction
 			)
 
 			if field == nil {
@@ -326,6 +327,125 @@ func TestCreateSuspensionDetailsEmbedField(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
+	groupA := "group-a"
+	enforcerA := "enforcer-a"
+	enforcerB := "enforcer-b"
+
+	records := []GuildEnforcementRecord{
+		{
+			ID:                "record-by-a",
+			UserID:            "target-user",
+			GroupID:           groupA,
+			EnforcerUserID:    enforcerA,
+			EnforcerDiscordID: "discord-a",
+			CreatedAt:         time.Now().Add(-1 * time.Hour),
+			UpdatedAt:         time.Now().Add(-1 * time.Hour),
+			UserNoticeText:    "Notice from A",
+			Expiry:            time.Now().Add(1 * time.Hour),
+			AuditorNotes:      "Secret notes by A",
+		},
+		{
+			ID:                "record-by-b",
+			UserID:            "target-user",
+			GroupID:           groupA,
+			EnforcerUserID:    enforcerB,
+			EnforcerDiscordID: "discord-b",
+			CreatedAt:         time.Now().Add(-30 * time.Minute),
+			UpdatedAt:         time.Now().Add(-30 * time.Minute),
+			UserNoticeText:    "Notice from B",
+			Expiry:            time.Now().Add(2 * time.Hour),
+			AuditorNotes:      "Secret notes by B",
+		},
+	}
+
+	t.Run("Empty callerUserID shows all notes (auditor/operator path)", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "")
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if !strings.Contains(field.Value, "Secret notes by A") {
+			t.Error("expected A's notes to be visible")
+		}
+		if !strings.Contains(field.Value, "Secret notes by B") {
+			t.Error("expected B's notes to be visible")
+		}
+	})
+
+	t.Run("CallerUserID=enforcerA sees only own notes", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerA)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if !strings.Contains(field.Value, "Secret notes by A") {
+			t.Error("expected A's notes to be visible to A")
+		}
+		if strings.Contains(field.Value, "Secret notes by B") {
+			t.Error("expected B's notes to be hidden from A")
+		}
+	})
+
+	t.Run("CallerUserID=enforcerB sees only own notes", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerB)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if strings.Contains(field.Value, "Secret notes by A") {
+			t.Error("expected A's notes to be hidden from B")
+		}
+		if !strings.Contains(field.Value, "Secret notes by B") {
+			t.Error("expected B's notes to be visible to B")
+		}
+	})
+
+	t.Run("CallerUserID=unrelated sees no notes", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "unrelated-enforcer")
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if strings.Contains(field.Value, "Secret notes by A") {
+			t.Error("expected A's notes to be hidden from unrelated enforcer")
+		}
+		if strings.Contains(field.Value, "Secret notes by B") {
+			t.Error("expected B's notes to be hidden from unrelated enforcer")
+		}
+		// User notices should still be visible
+		if !strings.Contains(field.Value, "Notice from A") {
+			t.Error("expected A's user notice to still be visible")
+		}
+	})
+
+	t.Run("Void notes filtered for non-creator", func(t *testing.T) {
+		voids := map[string]GuildEnforcementRecordVoid{
+			"record-by-a": {
+				GroupID:         groupA,
+				RecordID:        "record-by-a",
+				AuthorID:        "voider",
+				AuthorDiscordID: "voider-discord",
+				VoidedAt:        time.Now(),
+				Notes:           "Void reason for A",
+			},
+		}
+		// enforcerB should not see void notes on A's record
+		field := createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerB)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if strings.Contains(field.Value, "Void reason for A") {
+			t.Error("expected void notes on A's record to be hidden from B")
+		}
+
+		// enforcerA should see void notes on their own record
+		field = createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerA)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if !strings.Contains(field.Value, "Void reason for A") {
+			t.Error("expected void notes on A's record to be visible to A")
+		}
+	})
 }
 
 // TestMidSessionSuspension_StaleEnforcementsMissPostLoginKick proves the bug:

--- a/server/evr_group_metadata.go
+++ b/server/evr_group_metadata.go
@@ -47,6 +47,8 @@ type GroupMetadata struct {
 
 	MaintenanceMinutes int `json:"maintenance_minutes,omitempty"` // Maintenance window duration in minutes (default: 10)
 
+	RestrictEnforcerNoteVisibility bool `json:"restrict_enforcer_note_visibility"` // Enforcers only see notes on their own records; auditors see all
+
 	KickPlayerAllowPrivates *bool    `json:"kick_player_allow_privates"` // Default allow_privates for /kick-player suspensions (default: true)
 	LoadoutCommandUsernames []string `json:"loadout_command_usernames"`  // Discord usernames allowed to use /loadout (legacy, prefer IDs)
 	LoadoutCommandUserIDs   []string `json:"loadout_command_user_ids"`   // Discord user IDs allowed to use /loadout

--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -268,7 +268,7 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 
 	userID := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
 
-	_, _, gg, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
+	isOperator, _, gg, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
 	if err != nil {
 		// Allow guild owners to view journals even if they are not enforcers/operators.
 		var runtimeErr *runtime.Error
@@ -280,6 +280,12 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 			logger.Error("Permission check failed", zap.Error(err))
 			return "", err
 		}
+	}
+
+	// Determine if the caller's note visibility should be restricted
+	redactOtherNotes := gg != nil && gg.RestrictEnforcerNoteVisibility && !isOperator && !gg.IsAuditor(userID)
+	if isOwner := gg != nil && gg.IsOwner(userID); isOwner {
+		redactOtherNotes = false // owners get auditor-level access
 	}
 
 	// List all journals containing this group_id
@@ -311,7 +317,20 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 
 			hasRecords := false
 			if records, ok := journal.RecordsByGroupID[request.GroupID]; ok && len(records) > 0 {
-				filteredJournal.RecordsByGroupID[request.GroupID] = records
+				if redactOtherNotes {
+					// Copy records and redact notes on records the caller didn't create
+					redacted := make([]GuildEnforcementRecord, len(records))
+					copy(redacted, records)
+					for i := range redacted {
+						if redacted[i].EnforcerUserID != userID {
+							redacted[i].AuditorNotes = ""
+							redacted[i].EditLog = nil
+						}
+					}
+					filteredJournal.RecordsByGroupID[request.GroupID] = redacted
+				} else {
+					filteredJournal.RecordsByGroupID[request.GroupID] = records
+				}
 				hasRecords = true
 			}
 			if voids, ok := journal.VoidsByRecordIDByGroupID[request.GroupID]; ok && len(voids) > 0 {
@@ -384,7 +403,7 @@ func EnforcementRecordEditRPC(ctx context.Context, logger runtime.Logger, db *sq
 	userID := ctx.Value(runtime.RUNTIME_CTX_USER_ID).(string)
 
 	// Check permissions (global operator or guild enforcer)
-	_, _, _, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
+	isOperator, _, gg, err := RequireEnforcerOrOperator(ctx, db, nk, userID, request.GroupID)
 	if err != nil {
 		logger.Error("Permission check failed", zap.Error(err))
 		return "", err
@@ -426,6 +445,11 @@ func EnforcementRecordEditRPC(ctx context.Context, logger runtime.Logger, db *sq
 	newAuditorNotes := record.AuditorNotes
 	if request.AuditorNotes != "" {
 		newAuditorNotes = request.AuditorNotes
+	}
+
+	// Preserve existing notes when toggle restricts visibility and caller is not the record creator
+	if gg.RestrictEnforcerNoteVisibility && !isOperator && !gg.IsAuditor(userID) && record.EnforcerUserID != userID {
+		newAuditorNotes = record.AuditorNotes
 	}
 
 	newAllowPrivates := record.AllowPrivateLobbies

--- a/server/evr_runtime_rpc_enforcement.go
+++ b/server/evr_runtime_rpc_enforcement.go
@@ -334,7 +334,28 @@ func EnforcementJournalListRPC(ctx context.Context, logger runtime.Logger, db *s
 				hasRecords = true
 			}
 			if voids, ok := journal.VoidsByRecordIDByGroupID[request.GroupID]; ok && len(voids) > 0 {
-				filteredJournal.VoidsByRecordIDByGroupID[request.GroupID] = voids
+				if redactOtherNotes {
+					// Redact void notes for records the caller didn't create
+					redactedVoids := make(map[string]GuildEnforcementRecordVoid, len(voids))
+					records := journal.RecordsByGroupID[request.GroupID]
+					for recordID, v := range voids {
+						// Find the original record to check ownership
+						isOwned := false
+						for _, r := range records {
+							if r.ID == recordID && r.EnforcerUserID == userID {
+								isOwned = true
+								break
+							}
+						}
+						if !isOwned {
+							v.Notes = ""
+						}
+						redactedVoids[recordID] = v
+					}
+					filteredJournal.VoidsByRecordIDByGroupID[request.GroupID] = redactedVoids
+				} else {
+					filteredJournal.VoidsByRecordIDByGroupID[request.GroupID] = voids
+				}
 				hasRecords = true
 			}
 
@@ -507,10 +528,19 @@ func EnforcementRecordEditRPC(ctx context.Context, logger runtime.Logger, db *sq
 		fmt.Sprintf("target_user_id=%s record_id=%s new_expiry=%d new_notice=%q", request.TargetUserID, request.RecordID, newExpiry.Unix(), newUserNotice),
 	)
 
+	// Redact sensitive fields in response when caller shouldn't see notes
+	responseRecord := updatedRecord
+	if gg.RestrictEnforcerNoteVisibility && !isOperator && !gg.IsAuditor(userID) && responseRecord.EnforcerUserID != userID {
+		redacted := *responseRecord
+		redacted.AuditorNotes = ""
+		redacted.EditLog = nil
+		responseRecord = &redacted
+	}
+
 	response := EnforcementRecordEditResponse{
 		Success: true,
 		Message: "Enforcement record updated successfully",
-		Record:  updatedRecord,
+		Record:  responseRecord,
 	}
 
 	responseData, err := json.Marshal(response)


### PR DESCRIPTION
## Summary

- Adds `restrict_enforcer_note_visibility` toggle to guild group metadata
- When enabled, enforcers can only see `AuditorNotes` on enforcement records they personally created
- Auditors and global operators always see all notes regardless of toggle
- Filters applied across 6 exposure paths: `/lookup` embeds, enforcement notice channel, edit modal, journal list RPC, record edit RPC, and updated enforcement messages

## Details

**Discord channel messages** (non-ephemeral) cannot do per-user filtering, so notes are excluded entirely from enforcement notice channel when toggle is active. Audit channel always shows notes.

**Edit modal** omits the notes field when an enforcer opens a record they didn't create. On submission, existing notes are preserved rather than overwritten.

**RPC responses** redact `AuditorNotes` and `EditLog` on records where `EnforcerUserID` doesn't match the caller.

## Test plan

- [x] `go build ./server/...` compiles cleanly
- [x] All existing tests pass
- [x] New `TestCreateSuspensionDetailsEmbedField_CallerFiltering` tests cover:
  - Empty callerUserID shows all notes (auditor/operator path)
  - Caller sees only own records' notes
  - Unrelated enforcer sees no notes but user notices remain visible
  - Void notes filtered for non-creator enforcers
- [ ] Manual: set toggle in guild metadata, verify enforcer A sees own notes, enforcer B does not, auditor sees all

🤖 Generated with [Claude Code](https://claude.com/claude-code)