### PR TITLE
feat: per-guild customizable suspension DM footer

### DIFF
--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -990,10 +990,12 @@ func (d *DiscordAppBot) kickPlayer(logger runtime.Logger, i *discordgo.Interacti
 
 			// Send DM notification to the user
 			guildName := ""
+			customFooter := ""
 			if gg != nil {
 				guildName = gg.Name()
+				customFooter = gg.SuspensionDMFooter
 			}
-			sent, err := SendEnforcementNotification(ctx, d.dg, record, target.ID, guildName)
+			sent, err := SendEnforcementNotification(ctx, d.dg, record, target.ID, guildName, customFooter)
 			if err != nil {
 				// Note: DM failures are logged but don't block enforcement.
 				// Common failures: user has DMs disabled, blocked bot, or left shared servers.

--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -623,9 +623,10 @@ func createEnforcementActionComponents(record GuildEnforcementRecord, profile *E
 	}
 }
 
-// SendEnforcementNotification sends a DM to the user about their enforcement action
-// Returns whether the notification was sent successfully
-func SendEnforcementNotification(ctx context.Context, dg *discordgo.Session, record GuildEnforcementRecord, targetDiscordID, guildName string) (bool, error) {
+// SendEnforcementNotification sends a DM to the user about their enforcement action.
+// If customFooter is non-empty, it replaces the default footer in the notification message.
+// Returns whether the notification was sent successfully.
+func SendEnforcementNotification(ctx context.Context, dg *discordgo.Session, record GuildEnforcementRecord, targetDiscordID, guildName, customFooter string) (bool, error) {
 	if dg == nil {
 		return false, fmt.Errorf("discord session is nil")
 	}
@@ -634,7 +635,7 @@ func SendEnforcementNotification(ctx context.Context, dg *discordgo.Session, rec
 	}
 
 	// Get the formatted notification message
-	message := record.GetNotificationMessage(guildName)
+	message := record.GetNotificationMessage(guildName, customFooter)
 
 	// Attempt to send the DM
 	_, err := SendUserMessage(ctx, dg, targetDiscordID, message)

--- a/server/evr_enforcement_notification_test.go
+++ b/server/evr_enforcement_notification_test.go
@@ -8,11 +8,12 @@ import (
 
 func TestGuildEnforcementRecord_GetNotificationMessage(t *testing.T) {
 	tests := []struct {
-		name      string
-		record    GuildEnforcementRecord
-		guildName string
-		want      []string // Strings that should be present in the message
-		notWant   []string // Strings that should NOT be present
+		name         string
+		record       GuildEnforcementRecord
+		guildName    string
+		customFooter string
+		want         []string // Strings that should be present in the message
+		notWant      []string // Strings that should NOT be present
 	}{
 		{
 			name: "Basic suspension with rule violated",
@@ -147,11 +148,50 @@ func TestGuildEnforcementRecord_GetNotificationMessage(t *testing.T) {
 				"Guild:", // Should not show guild field if name is empty
 			},
 		},
+		{
+			name: "Empty custom footer uses default",
+			record: GuildEnforcementRecord{
+				ID:             "test-id-6",
+				UserID:         "user-6",
+				GroupID:        "group-6",
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+				UserNoticeText: "Test reason",
+				Expiry:         time.Now().Add(1 * time.Hour),
+			},
+			guildName:    "Test Guild",
+			customFooter: "",
+			want: []string{
+				"/whoami",
+				"contact a guild administrator",
+			},
+		},
+		{
+			name: "Custom footer replaces default",
+			record: GuildEnforcementRecord{
+				ID:             "test-id-7",
+				UserID:         "user-7",
+				GroupID:        "group-7",
+				CreatedAt:      time.Now(),
+				UpdatedAt:      time.Now(),
+				UserNoticeText: "Test reason",
+				Expiry:         time.Now().Add(1 * time.Hour),
+			},
+			guildName:    "Test Guild",
+			customFooter: "Contact us at #appeals in our Discord server.",
+			want: []string{
+				"Contact us at #appeals in our Discord server.",
+			},
+			notWant: []string{
+				"/whoami",
+				"contact a guild administrator",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.record.GetNotificationMessage(tt.guildName)
+			got := tt.record.GetNotificationMessage(tt.guildName, tt.customFooter)
 
 			// Check for expected strings
 			for _, want := range tt.want {

--- a/server/evr_enforcement_record.go
+++ b/server/evr_enforcement_record.go
@@ -101,8 +101,9 @@ func GetStandardEnforcementRules() []string {
 	return rulesCopy
 }
 
-// GetNotificationMessage returns a formatted message for DM notification to the user
-func (r GuildEnforcementRecord) GetNotificationMessage(guildName string) string {
+// GetNotificationMessage returns a formatted message for DM notification to the user.
+// If customFooter is non-empty, it replaces the default footer text.
+func (r GuildEnforcementRecord) GetNotificationMessage(guildName, customFooter string) string {
 	var parts []string
 
 	// Header
@@ -157,8 +158,12 @@ func (r GuildEnforcementRecord) GetNotificationMessage(guildName string) string 
 
 	// Footer with instructions
 	parts = append(parts, "")
-	parts = append(parts, "ℹ️ For more details, use the `/whoami` command in Discord or in-game.")
-	parts = append(parts, "If you believe this action was made in error, please contact a guild administrator.")
+	if customFooter != "" {
+		parts = append(parts, customFooter)
+	} else {
+		parts = append(parts, "ℹ️ For more details, use the `/whoami` command in Discord or in-game.")
+		parts = append(parts, "If you believe this action was made in error, please contact a guild administrator.")
+	}
 
 	return strings.Join(parts, "\n")
 }

--- a/server/evr_group_metadata.go
+++ b/server/evr_group_metadata.go
@@ -49,9 +49,10 @@ type GroupMetadata struct {
 
 	RestrictEnforcerNoteVisibility bool `json:"restrict_enforcer_note_visibility"` // Enforcers only see notes on their own records; auditors see all
 
-	KickPlayerAllowPrivates *bool    `json:"kick_player_allow_privates"` // Default allow_privates for /kick-player suspensions (default: true)
-	LoadoutCommandUsernames []string `json:"loadout_command_usernames"`  // Discord usernames allowed to use /loadout (legacy, prefer IDs)
-	LoadoutCommandDiscordIDs []string `json:"loadout_command_user_ids"` // Discord user IDs allowed to use /loadout
+	KickPlayerAllowPrivates  *bool    `json:"kick_player_allow_privates"`  // Default allow_privates for /kick-player suspensions (default: true)
+	LoadoutCommandUsernames  []string `json:"loadout_command_usernames"`   // Discord usernames allowed to use /loadout (legacy, prefer IDs)
+	LoadoutCommandDiscordIDs []string `json:"loadout_command_user_ids"`    // Discord user IDs allowed to use /loadout
+	SuspensionDMFooter       string   `json:"suspension_dm_footer"`        // Custom footer for suspension DM notifications; empty = default footer
 }
 
 func NewGuildGroupMetadata(guildID string) *GroupMetadata {


### PR DESCRIPTION
## Summary
- Add `SuspensionDMFooter` field to `GroupMetadata` for per-guild custom footer text in suspension DM notifications
- When set, the custom footer replaces the default `/whoami` + "contact a guild administrator" text
- Empty string (default) preserves existing behavior -- no migration needed

Closes #364

## Test plan
- [x] `TestGuildEnforcementRecord_GetNotificationMessage/Empty_custom_footer_uses_default` -- empty footer produces default message
- [x] `TestGuildEnforcementRecord_GetNotificationMessage/Custom_footer_replaces_default` -- custom footer replaces default, default text absent
- [x] All existing notification tests pass unchanged (backward compatible)
- [x] `make nakama` builds clean
- [ ] E2E: set `suspension_dm_footer` on a guild's group metadata, issue a suspension, verify DM contains custom footer (requires live Discord bot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)