### PR TITLE
fix: include guild name in role-based suspension messages

### DIFF
--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -343,7 +343,14 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 
 	// User is suspended from the group.
 	if gg.IsSuspended(userID, &params.xpID) {
-		go SendUserMessage(context.Background(), p.discordCache.dg, lobbyParams.DiscordID, roleSuspensionDMMessage(gg.Name()))
+		go func() {
+			if p.discordCache.dg == nil {
+				return
+			}
+			if _, err := SendUserMessage(context.Background(), p.discordCache.dg, lobbyParams.DiscordID, roleSuspensionDMMessage(gg.Name())); err != nil {
+				p.logger.Warn("Failed to send suspension DM", zap.Error(err))
+			}
+		}()
 		return joinRejected("suspended_user", roleSuspensionUserMessage(gg.Name()), roleSuspensionAuditMessage(gg.Name(), gg.RoleMap.Suspended))
 	}
 
@@ -585,10 +592,10 @@ func roleSuspensionUserMessage(guildName string) string {
 
 // roleSuspensionAuditMessage returns the audit log message for a role-based suspension rejection.
 func roleSuspensionAuditMessage(guildName, suspendedRoleID string) string {
-	return fmt.Sprintf("is suspended from %s via role: <@&%s>", guildName, suspendedRoleID)
+	return fmt.Sprintf("is suspended from %s via role: <@&%s>", EscapeDiscordMarkdown(guildName), suspendedRoleID)
 }
 
 // roleSuspensionDMMessage returns the Discord DM content sent to a role-suspended user.
 func roleSuspensionDMMessage(guildName string) string {
-	return fmt.Sprintf("You have been suspended from **%s** via a server role. Contact a moderator of that server for more information.", guildName)
+	return fmt.Sprintf("You have been suspended from **%s** via a server role. Contact a moderator of that server for more information.", EscapeDiscordMarkdown(guildName))
 }

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -343,8 +343,8 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 
 	// User is suspended from the group.
 	if gg.IsSuspended(userID, &params.xpID) {
-		// User is suspended from the group.
-		return joinRejected("suspended_user", "You are suspended from this guild. (role-based)", "is suspended via role: <@&"+gg.RoleMap.Suspended+">")
+		go SendUserMessage(context.Background(), p.discordCache.dg, lobbyParams.DiscordID, roleSuspensionDMMessage(gg.Name()))
+		return joinRejected("suspended_user", roleSuspensionUserMessage(gg.Name()), roleSuspensionAuditMessage(gg.Name(), gg.RoleMap.Suspended))
 	}
 
 	// Re-read enforcement journals from storage to catch suspensions issued after login.
@@ -576,4 +576,19 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 	session.Logger().Info("Authorized access to lobby session", zap.String("gid", groupID), zap.String("display_name", displayName))
 
 	return nil
+}
+
+// roleSuspensionUserMessage returns the in-game message shown to a user suspended via guild role.
+func roleSuspensionUserMessage(guildName string) string {
+	return fmt.Sprintf("You are suspended from %s.", guildName)
+}
+
+// roleSuspensionAuditMessage returns the audit log message for a role-based suspension rejection.
+func roleSuspensionAuditMessage(guildName, suspendedRoleID string) string {
+	return fmt.Sprintf("is suspended from %s via role: <@&%s>", guildName, suspendedRoleID)
+}
+
+// roleSuspensionDMMessage returns the Discord DM content sent to a role-suspended user.
+func roleSuspensionDMMessage(guildName string) string {
+	return fmt.Sprintf("You have been suspended from **%s** via a server role. Contact a moderator of that server for more information.", guildName)
 }

--- a/server/evr_lobby_joinentrant_test.go
+++ b/server/evr_lobby_joinentrant_test.go
@@ -1,0 +1,79 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSuspensionRoleBased_MessageIncludesGuildName(t *testing.T) {
+	tests := []struct {
+		name      string
+		guildName string
+		want      string
+	}{
+		{
+			name:      "includes guild name",
+			guildName: "Echo Combat League",
+			want:      "You are suspended from Echo Combat League.",
+		},
+		{
+			name:      "guild name with special characters",
+			guildName: "Guild <Test> & Friends",
+			want:      "You are suspended from Guild <Test> & Friends.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleSuspensionUserMessage(tt.guildName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSuspensionRoleBased_AuditMessageIncludesGuildName(t *testing.T) {
+	tests := []struct {
+		name          string
+		guildName     string
+		suspendedRole string
+		wantContains  []string
+	}{
+		{
+			name:          "audit message includes guild and role",
+			guildName:     "Echo Combat League",
+			suspendedRole: "123456789",
+			wantContains:  []string{"Echo Combat League", "<@&123456789>"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleSuspensionAuditMessage(tt.guildName, tt.suspendedRole)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
+}
+
+func TestSuspensionRoleBased_DMMessageIncludesGuildName(t *testing.T) {
+	tests := []struct {
+		name      string
+		guildName string
+		want      string
+	}{
+		{
+			name:      "DM includes guild name",
+			guildName: "Echo Combat League",
+			want:      "You have been suspended from **Echo Combat League** via a server role. Contact a moderator of that server for more information.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleSuspensionDMMessage(tt.guildName)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Role-based suspension rejection now includes the guild name in the in-game message (e.g., "You are suspended from Echo Combat League.")
- Audit log message updated to include guild name alongside the suspended role mention
- Non-blocking Discord DM sent to the suspended user with guild name and guidance to contact a moderator
- Uses `context.Background()` for the DM goroutine so parent context cancellation does not prevent delivery

Closes #107

## Test plan
- [x] `go test ./server/ -run TestSuspension -count=1 -v` passes (3 test functions covering user message, audit message, and DM message)
- [x] `make nakama` builds clean
- [ ] Manual: verify in-game suspension message displays guild name
- [ ] Manual: verify Discord DM is received on role-based suspension

🤖 Generated with [Claude Code](https://claude.com/claude-code)