### PR TITLE
fix: handle username-already-exists error during headset linking

### DIFF
--- a/server/evr_discord_appbot_linking.go
+++ b/server/evr_discord_appbot_linking.go
@@ -10,6 +10,8 @@ import (
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (d *DiscordAppBot) linkHeadset(ctx context.Context, logger runtime.Logger, user *discordgo.Member, linkCode string) error {
@@ -45,7 +47,7 @@ func (d *DiscordAppBot) linkHeadset(ctx context.Context, logger runtime.Logger, 
 		// Authenticate/create an account.
 		if userID == "" {
 			tags["new_account"] = "true"
-			userID, _, _, err = d.nk.AuthenticateCustom(ctx, discordID, username, true)
+			userID, _, err = authenticateOrResolveConflict(ctx, nk, discordID, username)
 			if err != nil {
 				return fmt.Errorf("failed to authenticate (or create) user %s: %w", discordID, err)
 			}
@@ -225,4 +227,63 @@ func (d *DiscordAppBot) handleUnlinkHeadset(ctx context.Context, logger runtime.
 	}
 
 	return editInteractionResponse(s, i, content)
+}
+
+// authenticateOrResolveConflict attempts to create an account via AuthenticateCustom.
+// If the username is already taken by a different account, it renames the conflicting
+// account and retries. The Discord username is authoritative: the new user keeps it.
+func authenticateOrResolveConflict(ctx context.Context, nk runtime.NakamaModule, discordID, username string) (string, string, error) {
+	userID, uname, _, err := nk.AuthenticateCustom(ctx, discordID, username, true)
+	if err == nil {
+		return userID, uname, nil
+	}
+
+	if status.Code(err) != codes.AlreadyExists {
+		return "", "", fmt.Errorf("failed to create account: %w", err)
+	}
+
+	// Username conflict. Look up who holds it.
+	users, err := nk.UsersGetUsername(ctx, []string{username})
+	if err != nil {
+		return "", "", fmt.Errorf("failed to look up conflicting username %q: %w", username, err)
+	}
+
+	if len(users) == 0 {
+		// Race condition: conflict gone. Retry once.
+		userID, uname, _, err = nk.AuthenticateCustom(ctx, discordID, username, true)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to create account after conflict resolved: %w", err)
+		}
+		return userID, uname, nil
+	}
+
+	conflicting := users[0]
+
+	// Check if the conflicting account belongs to the same Discord user.
+	conflictAccount, err := nk.AccountGetId(ctx, conflicting.Id)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to look up conflicting account %s: %w", conflicting.Id, err)
+	}
+	if conflictAccount.GetCustomId() == discordID {
+		// Same Discord user already owns this username. Return the existing account.
+		return conflicting.Id, conflicting.Username, nil
+	}
+
+	// Rename the conflicting account: append "_" + first 4 chars of their user ID.
+	suffix := conflicting.Id
+	if len(suffix) > 4 {
+		suffix = suffix[:4]
+	}
+	renamedUsername := username + "_" + suffix
+
+	if err := nk.AccountUpdateId(ctx, conflicting.Id, renamedUsername, nil, "", "", "", "", ""); err != nil {
+		return "", "", fmt.Errorf("failed to resolve username conflict: could not rename account %s: %w", conflicting.Id, err)
+	}
+
+	// Retry authentication with the now-available username.
+	userID, uname, _, err = nk.AuthenticateCustom(ctx, discordID, username, true)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create account after renaming conflicting user: %w", err)
+	}
+	return userID, uname, nil
 }

--- a/server/evr_discord_appbot_linking.go
+++ b/server/evr_discord_appbot_linking.go
@@ -262,7 +262,7 @@ func authenticateOrResolveConflict(ctx context.Context, nk runtime.NakamaModule,
 	// Check if the conflicting account belongs to the same Discord user.
 	conflictAccount, err := nk.AccountGetId(ctx, conflicting.Id)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to look up conflicting account %s: %w", conflicting.Id, err)
+		return "", "", fmt.Errorf("failed to resolve username conflict: %w", err)
 	}
 	if conflictAccount.GetCustomId() == discordID {
 		// Same Discord user already owns this username. Return the existing account.
@@ -274,10 +274,16 @@ func authenticateOrResolveConflict(ctx context.Context, nk runtime.NakamaModule,
 	if len(suffix) > 4 {
 		suffix = suffix[:4]
 	}
-	renamedUsername := username + "_" + suffix
+	// Truncate base username to leave room for "_" + suffix within 128-byte limit.
+	maxBase := 128 - 1 - len(suffix)
+	base := username
+	if len(base) > maxBase {
+		base = base[:maxBase]
+	}
+	renamedUsername := base + "_" + suffix
 
 	if err := nk.AccountUpdateId(ctx, conflicting.Id, renamedUsername, nil, "", "", "", "", ""); err != nil {
-		return "", "", fmt.Errorf("failed to resolve username conflict: could not rename account %s: %w", conflicting.Id, err)
+		return "", "", fmt.Errorf("failed to resolve username conflict: %w", err)
 	}
 
 	// Retry authentication with the now-available username.

--- a/server/evr_discord_appbot_linking_test.go
+++ b/server/evr_discord_appbot_linking_test.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// linkingMockNK implements a minimal mock of the NakamaModule for linking tests.
+type linkingMockNK struct {
+	runtime.NakamaModule
+
+	authenticateCustomFunc func(ctx context.Context, id, username string, create bool) (string, string, bool, error)
+	usersGetUsernameFunc   func(ctx context.Context, usernames []string) ([]*api.User, error)
+	accountGetIdFunc       func(ctx context.Context, userID string) (*api.Account, error)
+	accountUpdateIdFunc    func(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error
+}
+
+func (m *linkingMockNK) AuthenticateCustom(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+	return m.authenticateCustomFunc(ctx, id, username, create)
+}
+
+func (m *linkingMockNK) UsersGetUsername(ctx context.Context, usernames []string) ([]*api.User, error) {
+	return m.usersGetUsernameFunc(ctx, usernames)
+}
+
+func (m *linkingMockNK) AccountGetId(ctx context.Context, userID string) (*api.Account, error) {
+	return m.accountGetIdFunc(ctx, userID)
+}
+
+func (m *linkingMockNK) AccountUpdateId(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+	return m.accountUpdateIdFunc(ctx, userID, username, metadata, displayName, timezone, location, langTag, avatarUrl)
+}
+
+func TestLinkAuthenticateWithUsernameConflict(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name           string
+		discordID      string
+		username       string
+		mock           *linkingMockNK
+		wantUserID     string
+		wantUsername   string
+		wantErr        bool
+		wantErrContain string
+	}{
+		{
+			name:      "no conflict - succeeds normally",
+			discordID: "discord123",
+			username:  "alice",
+			mock: &linkingMockNK{
+				authenticateCustomFunc: func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+					return "user-abc", "alice", true, nil
+				},
+			},
+			wantUserID:   "user-abc",
+			wantUsername: "alice",
+		},
+		{
+			name:      "username conflict - existing account renamed, retry succeeds",
+			discordID: "discord-new",
+			username:  "alice",
+			mock: func() *linkingMockNK {
+				callCount := 0
+				return &linkingMockNK{
+					authenticateCustomFunc: func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+						callCount++
+						if callCount == 1 {
+							return "", "", false, status.Error(codes.AlreadyExists, "Username is already in use.")
+						}
+						return "new-user-id", "alice", true, nil
+					},
+					usersGetUsernameFunc: func(ctx context.Context, usernames []string) ([]*api.User, error) {
+						return []*api.User{{Id: "conflict-user-id", Username: "alice"}}, nil
+					},
+					accountGetIdFunc: func(ctx context.Context, userID string) (*api.Account, error) {
+						return &api.Account{
+							User:     &api.User{Id: "conflict-user-id", Username: "alice"},
+							CustomId: "discord-other",
+						}, nil
+					},
+					accountUpdateIdFunc: func(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+						if userID != "conflict-user-id" {
+							t.Errorf("expected rename of conflict-user-id, got %s", userID)
+						}
+						if username != "alice_conf" {
+							t.Errorf("expected renamed username alice_conf, got %s", username)
+						}
+						return nil
+					},
+				}
+			}(),
+			wantUserID:   "new-user-id",
+			wantUsername: "alice",
+		},
+		{
+			name:      "conflicting account has same discord custom_id - returns existing account",
+			discordID: "discord-same",
+			username:  "alice",
+			mock: &linkingMockNK{
+				authenticateCustomFunc: func() func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+					callCount := 0
+					return func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+						callCount++
+						if callCount == 1 {
+							return "", "", false, status.Error(codes.AlreadyExists, "Username is already in use.")
+						}
+						return "existing-user-id", "alice", false, nil
+					}
+				}(),
+				usersGetUsernameFunc: func(ctx context.Context, usernames []string) ([]*api.User, error) {
+					return []*api.User{{Id: "existing-user-id", Username: "alice"}}, nil
+				},
+				accountGetIdFunc: func(ctx context.Context, userID string) (*api.Account, error) {
+					return &api.Account{
+						User:     &api.User{Id: "existing-user-id", Username: "alice"},
+						CustomId: "discord-same",
+					}, nil
+				},
+				accountUpdateIdFunc: func(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+					t.Error("AccountUpdateId should not be called when conflict is same discord user")
+					return nil
+				},
+			},
+			wantUserID:   "existing-user-id",
+			wantUsername: "alice",
+		},
+		{
+			name:      "rename fails - returns actionable error",
+			discordID: "discord-new",
+			username:  "alice",
+			mock: &linkingMockNK{
+				authenticateCustomFunc: func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+					return "", "", false, status.Error(codes.AlreadyExists, "Username is already in use.")
+				},
+				usersGetUsernameFunc: func(ctx context.Context, usernames []string) ([]*api.User, error) {
+					return []*api.User{{Id: "conflict-user-id", Username: "alice"}}, nil
+				},
+				accountGetIdFunc: func(ctx context.Context, userID string) (*api.Account, error) {
+					return &api.Account{
+						User:     &api.User{Id: "conflict-user-id", Username: "alice"},
+						CustomId: "discord-other",
+					}, nil
+				},
+				accountUpdateIdFunc: func(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+					return fmt.Errorf("database error")
+				},
+			},
+			wantErr:        true,
+			wantErrContain: "failed to resolve username conflict",
+		},
+		{
+			name:      "conflict lookup returns no results - retry without rename",
+			discordID: "discord-new",
+			username:  "alice",
+			mock: func() *linkingMockNK {
+				callCount := 0
+				return &linkingMockNK{
+					authenticateCustomFunc: func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+						callCount++
+						if callCount == 1 {
+							return "", "", false, status.Error(codes.AlreadyExists, "Username is already in use.")
+						}
+						return "new-user-id", "alice", true, nil
+					},
+					usersGetUsernameFunc: func(ctx context.Context, usernames []string) ([]*api.User, error) {
+						return []*api.User{}, nil
+					},
+				}
+			}(),
+			wantUserID:   "new-user-id",
+			wantUsername: "alice",
+		},
+		{
+			name:      "retry after rename still fails - returns actionable error",
+			discordID: "discord-new",
+			username:  "alice",
+			mock: &linkingMockNK{
+				authenticateCustomFunc: func(ctx context.Context, id, username string, create bool) (string, string, bool, error) {
+					return "", "", false, status.Error(codes.AlreadyExists, "Username is already in use.")
+				},
+				usersGetUsernameFunc: func(ctx context.Context, usernames []string) ([]*api.User, error) {
+					return []*api.User{{Id: "conflict-user-id", Username: "alice"}}, nil
+				},
+				accountGetIdFunc: func(ctx context.Context, userID string) (*api.Account, error) {
+					return &api.Account{
+						User:     &api.User{Id: "conflict-user-id", Username: "alice"},
+						CustomId: "discord-other",
+					}, nil
+				},
+				accountUpdateIdFunc: func(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+					return nil
+				},
+			},
+			wantErr:        true,
+			wantErrContain: "failed to create account",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			userID, username, err := authenticateOrResolveConflict(ctx, tt.mock, tt.discordID, tt.username)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.wantErrContain != "" && !strings.Contains(err.Error(), tt.wantErrContain) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErrContain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if userID != tt.wantUserID {
+				t.Errorf("userID = %q, want %q", userID, tt.wantUserID)
+			}
+			if username != tt.wantUsername {
+				t.Errorf("username = %q, want %q", username, tt.wantUsername)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Catch `codes.AlreadyExists` from `AuthenticateCustom` when a Discord username is already taken by a different Nakama account
- Rename the conflicting account (append `_XXXX` suffix from their user ID) and retry account creation
- Handle edge cases: same Discord user (return existing account), race conditions (retry without rename), rename failures (actionable error message)

## Test plan
- [x] `go test ./server/ -run TestLinkAuthenticateWithUsernameConflict -count=1 -v` passes (6 table-driven test cases)
- [x] `make nakama` builds clean
- [ ] Manual e2e test with live Discord bot (skipped - requires live environment)

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)