### PR TITLE
feat: separate toxic players from new players in matchmaking

### DIFF
--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -146,6 +146,7 @@ type GlobalMatchmakingSettings struct {
 	CrashRecoveryWindowSecs        int                     `json:"crash_recovery_window_secs"`          // Seconds to hold a disconnected player's spot (default 60, 0 = use default, <0 = disabled)
 	RequirePreMatchPing            *bool                   `json:"require_pre_match_ping"`              // Require players to ping all candidate servers before matchmaking (default true)
 	NewPlayerMaxGames              int                     `json:"new_player_max_games"`                // Games played threshold below which a player is considered "new" (default 50)
+	EnableToxicSeparation          *bool                   `json:"enable_toxic_separation"`             // Prevent players with suspension history from matching with new players (default true)
 }
 
 type QueryAddons struct {
@@ -176,6 +177,12 @@ func (g ServiceSettingsData) UseSkillBasedMatchmaking() bool {
 // before entering matchmaking. Defaults to true when not explicitly configured.
 func (g GlobalMatchmakingSettings) RequiresPreMatchPing() bool {
 	return g.RequirePreMatchPing == nil || *g.RequirePreMatchPing
+}
+
+// ToxicSeparationEnabled returns whether players with suspension history
+// should be prevented from matching with new players. Defaults to true.
+func (g GlobalMatchmakingSettings) ToxicSeparationEnabled() bool {
+	return g.EnableToxicSeparation == nil || *g.EnableToxicSeparation
 }
 
 func ServiceSettingsLoad(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule) (*ServiceSettingsData, error) {
@@ -360,6 +367,11 @@ func FixDefaultServiceSettings(logger runtime.Logger, data *ServiceSettingsData)
 
 	if data.Matchmaking.NewPlayerMaxGames == 0 {
 		data.Matchmaking.NewPlayerMaxGames = 50
+	}
+
+	if data.Matchmaking.EnableToxicSeparation == nil {
+		t := true
+		data.Matchmaking.EnableToxicSeparation = &t
 	}
 
 	// Set default reducing precision settings for post-matchmaker backfill

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -67,7 +67,8 @@ type LobbySessionParameters struct {
 	FailsafeTimeout              time.Duration                 `json:"failsafe_timeout"` // The failsafe timeout
 	FallbackTimeout              time.Duration                 `json:"fallback_timeout"` // The fallback timeout
 	DisplayName                  string                        `json:"display_name"`
-	GamesPlayed                  int                           `json:"games_played"` // Total games played, loaded from GamesPlayed leaderboard
+	GamesPlayed                  int                           `json:"games_played"`                  // Total games played, loaded from GamesPlayed leaderboard
+	HasSuspensionHistoryFlag     bool                          `json:"has_suspension_history"`         // True if player has any suspension history (exempt: enforcers/operators always false)
 	latencyHistory               *atomic.Pointer[LatencyHistory]
 	unreachableServers           *atomic.Pointer[UnreachableServers]
 }
@@ -334,6 +335,38 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 		}
 	}
 
+	// Determine if user is a moderator (enforcer or operator), independent of division.
+	// Computed early because toxic separation exempts moderators.
+	isModerator := sessionParams.isGlobalOperator
+	if !isModerator && groupID != uuid.Nil {
+		if gg, ok := sessionParams.guildGroups[groupID.String()]; ok {
+			isModerator = gg.IsEnforcer(userID)
+		}
+	}
+
+	// Check suspension history for toxic player separation.
+	// Enforcers and global operators are exempt — they may have suspension
+	// history from admin work, not from being toxic.
+	hasSuspensionHistory := false
+	if globalSettings.ToxicSeparationEnabled() && !isModerator {
+		journal := NewGuildEnforcementJournal(userID)
+		if err := StorableRead(ctx, p.nk, userID, journal, true); err != nil {
+			logger.Warn("Failed to load enforcement journal for toxic separation", zap.Error(err))
+		} else {
+			for _, records := range journal.RecordsByGroupID {
+				for _, r := range records {
+					if r.IsSuspension() {
+						hasSuspensionHistory = true
+						break
+					}
+				}
+				if hasSuspensionHistory {
+					break
+				}
+			}
+		}
+	}
+
 	maxServerRTT := globalSettings.MaxServerRTT
 
 	if globalSettings.MaxServerRTT <= 60 {
@@ -350,15 +383,6 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 	if sessionParams.IsIGPOpen() {
 		matchmakingDivisions = []string{"green"}
 		matchmakingExcludedDivisions = []string{}
-	}
-
-	// Determine if user is a moderator (enforcer or operator), independent of division
-	isModerator := sessionParams.isGlobalOperator
-	// If not a global operator, check if they're an enforcer in their active group
-	if !isModerator && groupID != uuid.Nil {
-		if gg, ok := sessionParams.guildGroups[groupID.String()]; ok {
-			isModerator = gg.IsEnforcer(userID)
-		}
 	}
 
 	latencyHistory := sessionParams.latencyHistory.Load()
@@ -436,6 +460,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 		FallbackTimeout:              time.Duration(globalSettings.FallbackTimeoutSecs) * time.Second,
 		DisplayName:                  sessionParams.profile.GetGroupIGN(groupIDStr),
 		GamesPlayed:                  gamesPlayed,
+		HasSuspensionHistoryFlag:     hasSuspensionHistory,
 	}
 
 	// Check for an existing matchmaking credit to preserve queue position
@@ -646,7 +671,8 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 		"submission_time":    submissionTime,
 		"divisions":          strings.Join(p.MatchmakingDivisions, ","),
 		"excluded_divisions": strings.Join(p.MatchmakingExcludedDivisions, ","),
-		"is_moderator":       strconv.FormatBool(p.IsModerator),
+		"is_moderator":              strconv.FormatBool(p.IsModerator),
+		"has_suspension_history":    strconv.FormatBool(p.HasSuspensionHistoryFlag),
 	}
 	var minTeamSize, maxTeamSize float64
 	switch p.Mode {

--- a/server/evr_matchmaker_process.go
+++ b/server/evr_matchmaker_process.go
@@ -17,6 +17,12 @@ func (m *SkillBasedMatchmaker) processPotentialMatches(logger runtime.Logger, en
 	// Filter out players who are too far away from each other
 	filterCounts["max_rtt"] = m.filterWithinMaxRTT(candidates)
 
+	// Filter out candidates where a new player would be matched with a
+	// player who has suspension history (toxic player separation).
+	if settings := ServiceSettings(); settings != nil && settings.Matchmaking.ToxicSeparationEnabled() {
+		filterCounts["toxic_separation"] = FilterToxicNewPlayerCandidates(candidates, settings.Matchmaking.NewPlayerMaxGames)
+	}
+
 	config := PredictionConfig{}
 	if settings := ServiceSettings(); settings != nil {
 		mu := settings.SkillRating.Defaults.Mu

--- a/server/evr_toxic_separation.go
+++ b/server/evr_toxic_separation.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// HasSuspensionHistory returns true if the matchmaker entry has the
+// has_suspension_history string property set to "true".
+func HasSuspensionHistory(entry runtime.MatchmakerEntry) bool {
+	props := entry.GetProperties()
+	v, ok := props["has_suspension_history"].(string)
+	return ok && v == "true"
+}
+
+// CandidateContainsToxicNewPlayerMix returns true if the candidate contains
+// BOTH a new player (games_played < threshold) AND a player with suspension
+// history. Enforcers/global operators are exempt at ticket creation time
+// (their has_suspension_history is always "false").
+func CandidateContainsToxicNewPlayerMix(candidate []runtime.MatchmakerEntry, newPlayerThreshold int) bool {
+	if newPlayerThreshold <= 0 {
+		return false
+	}
+
+	hasNewPlayer := false
+	hasToxicPlayer := false
+
+	for _, entry := range candidate {
+		if IsNewPlayer(entry, newPlayerThreshold) {
+			hasNewPlayer = true
+		}
+		if HasSuspensionHistory(entry) {
+			hasToxicPlayer = true
+		}
+		if hasNewPlayer && hasToxicPlayer {
+			return true
+		}
+	}
+	return false
+}
+
+// FilterToxicNewPlayerCandidates nils out candidates that contain both a new
+// player and a player with suspension history. Returns the number of candidates
+// filtered.
+func FilterToxicNewPlayerCandidates(candidates [][]runtime.MatchmakerEntry, newPlayerThreshold int) int {
+	filtered := 0
+	for i, candidate := range candidates {
+		if candidate == nil {
+			continue
+		}
+		if CandidateContainsToxicNewPlayerMix(candidate, newPlayerThreshold) {
+			candidates[i] = nil
+			filtered++
+		}
+	}
+	return filtered
+}

--- a/server/evr_toxic_separation_test.go
+++ b/server/evr_toxic_separation_test.go
@@ -1,0 +1,266 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// toxicSepMockEntry implements runtime.MatchmakerEntry for toxic separation tests.
+type toxicSepMockEntry struct {
+	ticket     string
+	properties map[string]interface{}
+	presence   runtime.Presence
+}
+
+func (m *toxicSepMockEntry) GetTicket() string                      { return m.ticket }
+func (m *toxicSepMockEntry) GetPresence() runtime.Presence          { return m.presence }
+func (m *toxicSepMockEntry) GetPartyId() string                     { return "" }
+func (m *toxicSepMockEntry) GetCreateTime() int64                   { return 0 }
+func (m *toxicSepMockEntry) GetProperties() map[string]interface{} { return m.properties }
+
+// toxicSepMockPresence implements runtime.Presence for toxic separation tests.
+type toxicSepMockPresence struct {
+	sessionID string
+}
+
+func (p *toxicSepMockPresence) GetUserId() string    { return "" }
+func (p *toxicSepMockPresence) GetSessionId() string { return p.sessionID }
+func (p *toxicSepMockPresence) GetNodeId() string    { return "" }
+func (p *toxicSepMockPresence) GetHidden() bool      { return false }
+func (p *toxicSepMockPresence) GetPersistence() bool { return false }
+func (p *toxicSepMockPresence) GetUsername() string   { return "" }
+func (p *toxicSepMockPresence) GetStatus() string     { return "" }
+func (p *toxicSepMockPresence) GetReason() runtime.PresenceReason {
+	return runtime.PresenceReason(0)
+}
+
+func newToxicSepEntry(sessionID string, gamesPlayed float64, hasSuspensionHistory string) runtime.MatchmakerEntry {
+	return &toxicSepMockEntry{
+		ticket: "ticket-" + sessionID,
+		properties: map[string]interface{}{
+			"games_played":           gamesPlayed,
+			"has_suspension_history": hasSuspensionHistory,
+		},
+		presence: &toxicSepMockPresence{sessionID: sessionID},
+	}
+}
+
+func TestCandidateContainsToxicNewPlayerMix(t *testing.T) {
+	threshold := 50
+
+	tests := []struct {
+		name       string
+		candidate  []runtime.MatchmakerEntry
+		wantToxic  bool
+	}{
+		{
+			name: "new player + toxic player is rejected",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 10, "false"),   // new player
+				newToxicSepEntry("toxic1", 200, "true"), // toxic veteran
+			},
+			wantToxic: true,
+		},
+		{
+			name: "new player + clean player is accepted",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 10, "false"),    // new player
+				newToxicSepEntry("clean1", 200, "false"), // clean veteran
+			},
+			wantToxic: false,
+		},
+		{
+			name: "veteran + toxic player is accepted (no new player shield needed)",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("vet1", 100, "false"),  // veteran
+				newToxicSepEntry("toxic1", 200, "true"), // toxic veteran
+			},
+			wantToxic: false,
+		},
+		{
+			name: "new player + enforcer with suspensions is accepted (enforcer exempt)",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 10, "false"),    // new player
+				newToxicSepEntry("enforcer1", 200, "false"), // enforcer — exempt, so has_suspension_history="false"
+			},
+			wantToxic: false,
+		},
+		{
+			name: "all new players no toxic",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 5, "false"),
+				newToxicSepEntry("new2", 3, "false"),
+			},
+			wantToxic: false,
+		},
+		{
+			name: "all toxic veterans — no new players",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("toxic1", 200, "true"),
+				newToxicSepEntry("toxic2", 300, "true"),
+			},
+			wantToxic: false,
+		},
+		{
+			name: "mixed candidate with multiple new and one toxic",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 5, "false"),
+				newToxicSepEntry("new2", 10, "false"),
+				newToxicSepEntry("vet1", 100, "false"),
+				newToxicSepEntry("toxic1", 200, "true"),
+			},
+			wantToxic: true,
+		},
+		{
+			name: "missing has_suspension_history property treated as clean",
+			candidate: []runtime.MatchmakerEntry{
+				newToxicSepEntry("new1", 10, "false"),
+				&toxicSepMockEntry{
+					ticket: "ticket-nohistory",
+					properties: map[string]interface{}{
+						"games_played": float64(200),
+						// no has_suspension_history
+					},
+					presence: &toxicSepMockPresence{sessionID: "nohistory"},
+				},
+			},
+			wantToxic: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CandidateContainsToxicNewPlayerMix(tt.candidate, threshold)
+			if got != tt.wantToxic {
+				t.Errorf("CandidateContainsToxicNewPlayerMix() = %v, want %v", got, tt.wantToxic)
+			}
+		})
+	}
+}
+
+func TestToxicSeparationEnabled(t *testing.T) {
+	t.Run("default is true when nil", func(t *testing.T) {
+		g := GlobalMatchmakingSettings{}
+		if !g.ToxicSeparationEnabled() {
+			t.Error("expected ToxicSeparationEnabled() to return true when EnableToxicSeparation is nil")
+		}
+	})
+	t.Run("true when set to true", func(t *testing.T) {
+		v := true
+		g := GlobalMatchmakingSettings{EnableToxicSeparation: &v}
+		if !g.ToxicSeparationEnabled() {
+			t.Error("expected ToxicSeparationEnabled() to return true")
+		}
+	})
+	t.Run("false when set to false", func(t *testing.T) {
+		v := false
+		g := GlobalMatchmakingSettings{EnableToxicSeparation: &v}
+		if g.ToxicSeparationEnabled() {
+			t.Error("expected ToxicSeparationEnabled() to return false")
+		}
+	})
+}
+
+func TestToxicSeparationDefaultSetting(t *testing.T) {
+	data := &ServiceSettingsData{}
+	FixDefaultServiceSettings(nil, data)
+
+	if data.Matchmaking.EnableToxicSeparation == nil {
+		t.Fatal("expected EnableToxicSeparation to be set after FixDefaultServiceSettings")
+	}
+	if !*data.Matchmaking.EnableToxicSeparation {
+		t.Error("expected EnableToxicSeparation default to be true")
+	}
+}
+
+func TestHasSuspensionHistory(t *testing.T) {
+	tests := []struct {
+		name  string
+		props map[string]interface{}
+		want  bool
+	}{
+		{
+			name:  "true when set to true",
+			props: map[string]interface{}{"has_suspension_history": "true"},
+			want:  true,
+		},
+		{
+			name:  "false when set to false",
+			props: map[string]interface{}{"has_suspension_history": "false"},
+			want:  false,
+		},
+		{
+			name:  "false when missing",
+			props: map[string]interface{}{},
+			want:  false,
+		},
+		{
+			name:  "false when nil properties",
+			props: nil,
+			want:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := &toxicSepMockEntry{properties: tt.props}
+			got := HasSuspensionHistory(entry)
+			if got != tt.want {
+				t.Errorf("HasSuspensionHistory() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterToxicNewPlayerCandidates(t *testing.T) {
+	threshold := 50
+
+	t.Run("filters candidates with toxic-new mix", func(t *testing.T) {
+		candidates := [][]runtime.MatchmakerEntry{
+			{ // should be filtered: new + toxic
+				newToxicSepEntry("new1", 10, "false"),
+				newToxicSepEntry("toxic1", 200, "true"),
+			},
+			{ // should pass: no new players
+				newToxicSepEntry("vet1", 100, "false"),
+				newToxicSepEntry("toxic2", 200, "true"),
+			},
+			{ // should pass: new + clean
+				newToxicSepEntry("new2", 5, "false"),
+				newToxicSepEntry("clean1", 200, "false"),
+			},
+		}
+
+		count := FilterToxicNewPlayerCandidates(candidates, threshold)
+		if count != 1 {
+			t.Errorf("expected 1 filtered candidate, got %d", count)
+		}
+		if candidates[0] != nil {
+			t.Error("expected first candidate to be nil (filtered)")
+		}
+		if candidates[1] == nil {
+			t.Error("expected second candidate to pass (no new players)")
+		}
+		if candidates[2] == nil {
+			t.Error("expected third candidate to pass (new + clean)")
+		}
+	})
+
+	t.Run("disabled setting passes all candidates", func(t *testing.T) {
+		candidates := [][]runtime.MatchmakerEntry{
+			{
+				newToxicSepEntry("new1", 10, "false"),
+				newToxicSepEntry("toxic1", 200, "true"),
+			},
+		}
+
+		// threshold 0 means nobody is considered new, so no filtering
+		count := FilterToxicNewPlayerCandidates(candidates, 0)
+		if count != 0 {
+			t.Errorf("expected 0 filtered candidates with threshold 0, got %d", count)
+		}
+		if candidates[0] == nil {
+			t.Error("expected candidate to pass when threshold is 0")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Prevents players with suspension history from being matched with new players (games_played < NewPlayerMaxGames threshold)
- Enforcers and global operators are **exempt** -- their suspension records may come from admin work, not toxicity
- Only blocks candidates containing BOTH a new player AND a non-exempt player with `has_suspension_history = "true"`
- Veteran-only matches are unaffected -- this is a new-player shield, not a general punishment

## Implementation

- **`server/evr_toxic_separation.go`** -- `HasSuspensionHistory()`, `CandidateContainsToxicNewPlayerMix()`, `FilterToxicNewPlayerCandidates()` core logic
- **`server/evr_lobby_parameters.go`** -- Load enforcement journal at ticket creation, set `has_suspension_history` string property; moderators (enforcers/operators) always get `"false"`
- **`server/evr_global_settings.go`** -- `EnableToxicSeparation` setting (`*bool`, default true) with `ToxicSeparationEnabled()` helper
- **`server/evr_matchmaker_process.go`** -- Filter toxic-new-player candidates in `processPotentialMatches` before prediction

## Depends on

- `feat/games-played-tracking` (PR 1: `games_played` property + `IsNewPlayer` helper)

## Test plan

- [x] new player + toxic player -> candidate rejected
- [x] new player + clean player -> candidate accepted
- [x] veteran + toxic player -> candidate accepted (no new player = no shield)
- [x] new player + enforcer with suspensions -> accepted (enforcer exempt)
- [x] disabled setting (threshold 0) passes all candidates
- [x] missing `has_suspension_history` property treated as clean
- [x] `ToxicSeparationEnabled()` defaults to true, respects explicit true/false
- [x] `FixDefaultServiceSettings` sets default
- [x] `HasSuspensionHistory()` helper edge cases
- [x] `go build ./server/...` passes
- [x] `go test ./server/... -run "TestToxic|TestSeparation|TestHasSuspension|TestCandidateContains|TestFilter" -v` -- all 17 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)