### PR TITLE
feat: rolling win-rate from last 100 games

### DIFF
--- a/server/evr/core_account_statistics.go
+++ b/server/evr/core_account_statistics.go
@@ -210,6 +210,7 @@ func (s *PlayerStatistics) UnmarshalJSON(data []byte) error {
 }
 
 type ArenaStatistics struct {
+	RecentWinPercentage          *float64        `json:"-"` // In-memory override for rolling win rate
 	ArenaLosses                  *StatisticValue `json:"ArenaLosses,omitempty" op:"add,omitzero" type:"int"`
 	ArenaMVPPercentage           *StatisticValue `json:"ArenaMVPPercentage,omitempty" op:"rep,omitzero" type:"float"`
 	ArenaMVPs                    *StatisticValue `json:"ArenaMVPs,omitempty" op:"add,omitzero" type:"int"`
@@ -364,7 +365,12 @@ func (s *ArenaStatistics) CalculateFieldsWithOptions(countEarlyQuitsAsLosses boo
 			}
 		}
 
-		if s.ArenaWins != nil {
+		if s.RecentWinPercentage != nil {
+			s.ArenaWinPercentage = &StatisticValue{
+				Value: *s.RecentWinPercentage,
+				Count: 1,
+			}
+		} else if s.ArenaWins != nil {
 			// Validate ArenaWins value to prevent corrupted statistics
 			winsValue := s.ArenaWins.GetValue()
 			if winsValue < 0 || winsValue > gamesPlayed || winsValue > 1e6 {
@@ -569,6 +575,7 @@ func (s *ArenaStatistics) CalculateFieldsWithOptions(countEarlyQuitsAsLosses boo
 }
 
 type CombatStatistics struct {
+	RecentWinPercentage                *float64        `json:"-"` // In-memory override for rolling win rate
 	CombatAssists                      *StatisticValue `json:"CombatAssists,omitempty" op:"add,omitzero" type:"int"`
 	CombatAverageEliminationDeathRatio *StatisticValue `json:"CombatAverageEliminationDeathRatio" op:"rep,omitzero" type:"float"`
 	CombatBestEliminationStreak        *StatisticValue `json:"CombatBestEliminationStreak,omitempty" op:"add,omitzero" type:"int"`
@@ -646,13 +653,21 @@ func (s *CombatStatistics) CalculateFieldsWithOptions(_ bool) {
 		Count: 1,
 	}
 
-	if s.CombatWins != nil && s.GamesPlayed != nil && s.GamesPlayed.Value != 0 {
+	if s.RecentWinPercentage != nil {
+		s.CombatWinPercentage = &StatisticValue{
+			Value: *s.RecentWinPercentage,
+			Count: 1,
+		}
+	} else if s.CombatWins != nil && s.GamesPlayed != nil && s.GamesPlayed.Value != 0 {
 		// Validate CombatWins value to prevent corrupted statistics
 		winsValue := s.CombatWins.GetValue()
 		if winsValue < 0 || winsValue > float64(gamesPlayed) || winsValue > 1e6 {
 			winsValue = 0
 		}
-		s.CombatWinPercentage.Value = winsValue / float64(s.GamesPlayed.Value) * 100
+		s.CombatWinPercentage = &StatisticValue{
+			Value: winsValue / float64(s.GamesPlayed.Value) * 100,
+			Count: 1,
+		}
 	}
 
 	if s.CombatAssists != nil && s.GamesPlayed != nil && s.GamesPlayed.Value != 0 {

--- a/server/evr_match_data_indexing.go
+++ b/server/evr_match_data_indexing.go
@@ -57,3 +57,33 @@ func EnsureMatchDataIndexes(ctx context.Context, mongoClient *mongo.Client) erro
 	_, err := collection.Indexes().CreateMany(ctx, indexes)
 	return err
 }
+
+// EnsurePlayerMatchResultIndexes creates indexes for the player match results collection.
+func EnsurePlayerMatchResultIndexes(ctx context.Context, mongoClient *mongo.Client) error {
+	if mongoClient == nil {
+		return nil
+	}
+
+	collection := mongoClient.Database(matchDataDatabaseName).Collection(playerMatchResultsCollectionName)
+
+	indexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "user_id", Value: 1},
+				{Key: "mode", Value: 1},
+				{Key: "created_at", Value: -1},
+			},
+			Options: options.Index().SetBackground(true).SetName("user_mode_created_at"),
+		},
+		{
+			Keys: bson.D{{Key: "created_at", Value: 1}},
+			Options: options.Index().
+				SetBackground(true).
+				SetName("created_at_ttl_90d").
+				SetExpireAfterSeconds(int32(90 * 24 * time.Hour.Seconds())),
+		},
+	}
+
+	_, err := collection.Indexes().CreateMany(ctx, indexes)
+	return err
+}

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -115,6 +115,30 @@ func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, n
 		return nil, fmt.Errorf("failed to get user tablet statistics: %w", err)
 	}
 
+	// Override win percentages with rolling last-100-games values from MongoDB.
+	if mc := globalMongoClient.Load(); mc != nil {
+		arenaGroup := evr.StatisticsGroup{Mode: evr.ModeArenaPublic, ResetSchedule: evr.ResetScheduleAllTime}
+		if arenaStats, ok := statsBySchedule[arenaGroup]; ok {
+			if arena, ok := arenaStats.(*evr.ArenaStatistics); ok {
+				if winRate, count, err := GetRecentWinRate(ctx, mc, evrProfile.ID(), evr.ModeArenaPublic.String(), 100); err != nil {
+					logger.Warn("Failed to get recent arena win rate", zap.Error(err))
+				} else if count > 0 {
+					arena.RecentWinPercentage = &winRate
+				}
+			}
+		}
+		combatGroup := evr.StatisticsGroup{Mode: evr.ModeCombatPublic, ResetSchedule: evr.ResetScheduleAllTime}
+		if combatStats, ok := statsBySchedule[combatGroup]; ok {
+			if combat, ok := combatStats.(*evr.CombatStatistics); ok {
+				if winRate, count, err := GetRecentWinRate(ctx, mc, evrProfile.ID(), evr.ModeCombatPublic.String(), 100); err != nil {
+					logger.Warn("Failed to get recent combat win rate", zap.Error(err))
+				} else if count > 0 {
+					combat.RecentWinPercentage = &winRate
+				}
+			}
+		}
+	}
+
 	if evrProfile.DisableAFKTimeout {
 		developerFeatures = &evr.DeveloperFeatures{
 			DisableAfkTimeout: true,

--- a/server/evr_recent_match_results.go
+++ b/server/evr_recent_match_results.go
@@ -60,6 +60,10 @@ func GetRecentWinRate(ctx context.Context, mongoClient *mongo.Client, userID str
 		}
 	}
 
+	if err := cursor.Err(); err != nil {
+		return -1, 0, fmt.Errorf("cursor error reading player match results: %w", err)
+	}
+
 	if total == 0 {
 		return -1, 0, nil
 	}

--- a/server/evr_recent_match_results.go
+++ b/server/evr_recent_match_results.go
@@ -1,0 +1,69 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// PlayerMatchResult records a single match outcome for a player.
+type PlayerMatchResult struct {
+	UserID    string    `bson:"user_id" json:"user_id"`
+	MatchID   string    `bson:"match_id" json:"match_id"`
+	Mode      string    `bson:"mode" json:"mode"`
+	Won       bool      `bson:"won" json:"won"`
+	CreatedAt time.Time `bson:"created_at" json:"created_at"`
+}
+
+// StorePlayerMatchResult inserts a match result document into MongoDB.
+func StorePlayerMatchResult(ctx context.Context, mongoClient *mongo.Client, result *PlayerMatchResult) error {
+	collection := mongoClient.Database(matchDataDatabaseName).Collection(playerMatchResultsCollectionName)
+	_, err := collection.InsertOne(ctx, result)
+	if err != nil {
+		return fmt.Errorf("failed to insert player match result: %w", err)
+	}
+	return nil
+}
+
+// GetRecentWinRate queries the last N match results for a user+mode and computes the win rate.
+// Returns (winRate, gamesCount, err). winRate is -1 if no games found.
+func GetRecentWinRate(ctx context.Context, mongoClient *mongo.Client, userID string, mode string, limit int) (float64, int, error) {
+	collection := mongoClient.Database(matchDataDatabaseName).Collection(playerMatchResultsCollectionName)
+
+	filter := bson.M{"user_id": userID, "mode": mode}
+	opts := options.Find().
+		SetSort(bson.D{{Key: "created_at", Value: -1}}).
+		SetLimit(int64(limit)).
+		SetProjection(bson.M{"won": 1})
+
+	cursor, err := collection.Find(ctx, filter, opts)
+	if err != nil {
+		return -1, 0, fmt.Errorf("failed to query player match results: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var wins, total int
+	for cursor.Next(ctx) {
+		var result struct {
+			Won bool `bson:"won"`
+		}
+		if err := cursor.Decode(&result); err != nil {
+			continue
+		}
+		total++
+		if result.Won {
+			wins++
+		}
+	}
+
+	if total == 0 {
+		return -1, 0, nil
+	}
+
+	winRate := float64(wins) / float64(total) * 100
+	return winRate, total, nil
+}

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -205,6 +205,10 @@ func InitializeEvrRuntimeModule(ctx context.Context, logger runtime.Logger, db *
 			logger.Warn("Failed to create guild audit log indexes", zap.Error(err))
 		}
 
+		if err := EnsurePlayerMatchResultIndexes(ctx, mongoClient); err != nil {
+			logger.Warn("Failed to create player match result indexes", zap.Error(err))
+		}
+
 		if err := RegisterSessionEventRPCs(ctx, logger, db, nk, initializer, mongoClient); err != nil {
 			return fmt.Errorf("unable to register session event RPCs: %w", err)
 		}

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -719,6 +719,25 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 				}
 			}
 
+			// Record per-player match result for rolling win-rate calculation.
+			if typeStats.ArenaWins > 0 || typeStats.ArenaLosses > 0 {
+				if mc := globalMongoClient.Load(); mc != nil {
+					go func(uid, mid, mode string, won bool) {
+						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+						defer cancel()
+						if err := StorePlayerMatchResult(ctx, mc, &PlayerMatchResult{
+							UserID:    uid,
+							MatchID:   mid,
+							Mode:      mode,
+							Won:       won,
+							CreatedAt: time.Now().UTC(),
+						}); err != nil {
+							logger.WithField("error", err).Warn("Failed to store player match result")
+						}
+					}(playerInfo.UserID, matchID.String(), label.Mode.String(), typeStats.ArenaWins > 0)
+				}
+			}
+
 			// Increment the completed matches for the player (arena only — early quit system doesn't apply to combat)
 			if label.Mode == evr.ModeArenaPublic {
 				if err := s.incrementCompletedMatches(ctx, logger, nk, db, sessionRegistry, playerInfo.UserID, playerInfo.SessionID, matchID); err != nil {

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -720,9 +720,20 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 			}
 
 			// Record per-player match result for rolling win-rate calculation.
+			// Arena uses ArenaWins/ArenaLosses; combat doesn't populate those
+			// fields, so derive the outcome from blueWins and team assignment.
+			var matchResultWon bool
+			var hasMatchResult bool
 			if typeStats.ArenaWins > 0 || typeStats.ArenaLosses > 0 {
+				matchResultWon = typeStats.ArenaWins > 0
+				hasMatchResult = true
+			} else if label.Mode == evr.ModeCombatPublic {
+				matchResultWon = (playerInfo.Team == BlueTeam && blueWins) || (playerInfo.Team == OrangeTeam && !blueWins)
+				hasMatchResult = true
+			}
+			if hasMatchResult {
 				if mc := globalMongoClient.Load(); mc != nil {
-					go func(uid, mid, mode string, won bool) {
+					go func(log runtime.Logger, uid, mid, mode string, won bool) {
 						ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 						defer cancel()
 						if err := StorePlayerMatchResult(ctx, mc, &PlayerMatchResult{
@@ -732,9 +743,9 @@ func (s *EventRemoteLogSet) processPostMatchMessages(ctx context.Context, logger
 							Won:       won,
 							CreatedAt: time.Now().UTC(),
 						}); err != nil {
-							logger.WithField("error", err).Warn("Failed to store player match result")
+							log.WithField("error", err).Warn("Failed to store player match result")
 						}
-					}(playerInfo.UserID, matchID.String(), label.Mode.String(), typeStats.ArenaWins > 0)
+					}(logger, playerInfo.UserID, matchID.String(), label.Mode.String(), matchResultWon)
 				}
 			}
 

--- a/server/evr_runtime_events.go
+++ b/server/evr_runtime_events.go
@@ -23,8 +23,9 @@ const (
 	EventSessionStart              = "session_start"
 	EventSessionEnd                = "session_end"
 	EventMatchData                 = "match_data"
-	matchDataDatabaseName          = "nevr"
-	matchDataCollectionName        = "match_data"
+	matchDataDatabaseName              = "nevr"
+	matchDataCollectionName            = "match_data"
+	playerMatchResultsCollectionName   = "player_match_results"
 	redisMatchDataJournalQueueKey  = "match_data_journal_queue"
 	matchDataJournalEventThreshold = 100
 	redisQueueBatchSize            = 10


### PR DESCRIPTION
## Summary

- Store per-player match results (`won`, `mode`, `user_id`) in a new `nevr.player_match_results` MongoDB collection during post-match processing
- Query the last 100 results at profile build time to compute a rolling win percentage
- Override `ArenaWinPercentage` and `CombatWinPercentage` with the rolling value (falls back to all-time when unavailable)
- Indexes: compound `{user_id, mode, created_at}` for the query + 90-day TTL for cleanup

## Test plan

- [ ] Build passes (`go build ./server/...`)
- [ ] Verify match result documents appear in MongoDB after a match completes
- [ ] Verify profile shows rolling win-rate after enough games are recorded
- [ ] Verify graceful fallback when MongoDB is unavailable
- [ ] Verify new player with no history gets all-time stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)