### PR TITLE
fix: skip server on pre-join ping failure instead of erroring the player

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -500,6 +500,10 @@ func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.L
 					logger.Debug("Server is full, ignoring.")
 					continue
 				}
+				if errors.Is(err, ErrPreJoinPingFailed) {
+					logger.Debug("Pre-join ping failed, skipping server.", zap.String("endpoint", l.GameServer.Endpoint.String()))
+					continue
+				}
 				return fmt.Errorf("failed to join existing social lobby: %w", err)
 			}
 			return nil
@@ -526,6 +530,10 @@ func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.L
 				if interval < maxInterval {
 					interval = min(interval*2, maxInterval)
 				}
+				continue
+			}
+			if errors.Is(err, ErrPreJoinPingFailed) {
+				logger.Debug("Pre-join ping failed on auto-created lobby, retrying.", zap.String("endpoint", label.GameServer.Endpoint.String()))
 				continue
 			}
 			return fmt.Errorf("failed to join auto-created social lobby: %w", err)

--- a/server/evr_lobby_prejoin_ping.go
+++ b/server/evr_lobby_prejoin_ping.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -20,6 +21,12 @@ const (
 	// preJoinPingRTTMax is the RTT ceiling sent in the ping request.
 	preJoinPingRTTMax = 250
 )
+
+// ErrPreJoinPingFailed is returned by validatePreJoinPing when one or more
+// party members cannot reach the target game server within the RTT threshold.
+// Callers that iterate over candidate servers should treat this as "skip and
+// try the next server" rather than a fatal error.
+var ErrPreJoinPingFailed = errors.New("pre-join ping validation failed")
 
 // preJoinPingWaiters tracks pending pre-join ping validations.
 // Key: session ID; value: channel that receives the ping response.
@@ -288,6 +295,6 @@ func (p *EvrPipeline) validatePreJoinPing(
 		logger.Warn("Failed to send pre-join ping error message", zap.Error(err))
 	}
 
-	return NewLobbyErrorf(InternalError, "pre-join ping validation failed: %d of %d party members could not reach server %s",
-		len(failures), len(entrants), endpoint.ExternalAddress())
+	return fmt.Errorf("%w: %w", ErrPreJoinPingFailed, NewLobbyErrorf(InternalError, "pre-join ping validation failed: %d of %d party members could not reach server %s",
+		len(failures), len(entrants), endpoint.ExternalAddress()))
 }

--- a/server/evr_lobby_prejoin_ping_test.go
+++ b/server/evr_lobby_prejoin_ping_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestErrPreJoinPingFailed_Sentinel verifies that the error returned by
+// validatePreJoinPing (simulated here via the same wrapping pattern) satisfies
+// errors.Is(err, ErrPreJoinPingFailed) so callers can skip the server rather
+// than returning the failure to the player.
+func TestErrPreJoinPingFailed_Sentinel(t *testing.T) {
+	// Reproduce the exact wrapping done in validatePreJoinPing.
+	inner := NewLobbyErrorf(InternalError, "pre-join ping validation failed: 1 of 1 party members could not reach server 157.211.9.85:6792")
+	wrapped := fmt.Errorf("%w: %w", ErrPreJoinPingFailed, inner)
+
+	t.Run("errors.Is detects sentinel", func(t *testing.T) {
+		require.True(t, errors.Is(wrapped, ErrPreJoinPingFailed),
+			"caller must be able to detect ping failure via errors.Is to skip the server")
+	})
+
+	t.Run("LobbyErrorCode still returns InternalError", func(t *testing.T) {
+		assert.Equal(t, InternalError, LobbyErrorCode(wrapped),
+			"LobbyErrorCode must unwrap to InternalError so the client error code is preserved on direct-join paths")
+	})
+
+	t.Run("unrelated error is not ErrPreJoinPingFailed", func(t *testing.T) {
+		unrelated := NewLobbyErrorf(ServerIsFull, "server is full")
+		require.False(t, errors.Is(unrelated, ErrPreJoinPingFailed))
+	})
+}


### PR DESCRIPTION
## Summary

- Introduces `ErrPreJoinPingFailed` sentinel in `evr_lobby_prejoin_ping.go` so callers can detect ping failures without broadly matching `InternalError`
- `validatePreJoinPing` wraps the return error with the sentinel via `fmt.Errorf("%w: %w", ...)`, preserving the `LobbyError(InternalError)` code for direct-join paths
- `lobbyFindOrCreateSocial` now `continue`s to the next candidate server on ping failure instead of returning the error to the player (both the backfill and auto-created lobby paths)

## Test plan

- [ ] `TestErrPreJoinPingFailed_Sentinel` — verifies `errors.Is` detects the sentinel, `LobbyErrorCode` still unwraps to `InternalError`, and unrelated errors don't match
- [ ] `go test ./server/... -run TestErrPreJoinPingFailed` passes
- [ ] Manual: player with high RTT to one server is silently moved to another rather than receiving an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)