### PR TITLE
fix: ambassador error message shows only failing conditions

### DIFF
--- a/server/evr_ambassador.go
+++ b/server/evr_ambassador.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -104,6 +105,20 @@ func ApplyAmbassadorMuReduction(mu, reduction float64) float64 {
 	return result
 }
 
+// ambassadorEligibilityMessage returns a user-facing message describing which
+// ambassador requirements the player has not yet met.
+func ambassadorEligibilityMessage(gamesPlayed int, mu float64, minGames int, minMu float64) string {
+	var reasons []string
+	if gamesPlayed < minGames {
+		reasons = append(reasons, fmt.Sprintf("at least %d games played (you have %d)", minGames, gamesPlayed))
+	}
+	if mu < minMu {
+		reasons = append(reasons, fmt.Sprintf("a mu of %.0f+ (yours is %.1f)", minMu, mu))
+	}
+	return fmt.Sprintf("You need %s to be an ambassador. Keep playing and you'll get there!",
+		strings.Join(reasons, " and "))
+}
+
 // handleAmbassadorCommand toggles the player's ambassador mode via /ambassador.
 func (d *DiscordAppBot) handleAmbassadorCommand(ctx context.Context, logger runtime.Logger, s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User, member *discordgo.Member, userID string, groupID string) error {
 	if userID == "" {
@@ -139,10 +154,8 @@ func (d *DiscordAppBot) handleAmbassadorCommand(ctx context.Context, logger runt
 		}
 
 		if !IsEligibleAmbassador(gamesPlayed, rating.Mu, mm.AmbassadorMinGamesPlayed, mm.AmbassadorMinMu) {
-			return editInteractionResponse(s, i, fmt.Sprintf(
-				"You need at least %d games played and a mu of %.0f+ to be an ambassador. "+
-					"Keep playing and you'll get there!",
-				mm.AmbassadorMinGamesPlayed, mm.AmbassadorMinMu))
+			return editInteractionResponse(s, i, ambassadorEligibilityMessage(
+				gamesPlayed, rating.Mu, mm.AmbassadorMinGamesPlayed, mm.AmbassadorMinMu))
 		}
 
 		state.IsActive = true

--- a/server/evr_ambassador_test.go
+++ b/server/evr_ambassador_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -261,6 +262,57 @@ func TestAmbassadorProgramEnabled(t *testing.T) {
 	settings.EnableAmbassadorProgram = &disabled
 	if settings.AmbassadorProgramEnabled() {
 		t.Error("AmbassadorProgramEnabled should return false when set to false")
+	}
+}
+
+func TestAmbassadorEligibilityMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		gamesPlayed int
+		mu          float64
+		minGames    int
+		minMu       float64
+		wantContain string
+		wantOmit    string
+	}{
+		{
+			name:        "only mu failing",
+			gamesPlayed: 100,
+			mu:          5.0,
+			minGames:    0,
+			minMu:       10.0,
+			wantContain: "mu of 10+",
+			wantOmit:    "games played",
+		},
+		{
+			name:        "only games failing",
+			gamesPlayed: 50,
+			mu:          35.0,
+			minGames:    200,
+			minMu:       10.0,
+			wantContain: "200 games played",
+			wantOmit:    "mu of",
+		},
+		{
+			name:        "both failing",
+			gamesPlayed: 50,
+			mu:          5.0,
+			minGames:    200,
+			minMu:       10.0,
+			wantContain: "games played",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := ambassadorEligibilityMessage(tt.gamesPlayed, tt.mu, tt.minGames, tt.minMu)
+			if !strings.Contains(msg, tt.wantContain) {
+				t.Errorf("message %q should contain %q", msg, tt.wantContain)
+			}
+			if tt.wantOmit != "" && strings.Contains(msg, tt.wantOmit) {
+				t.Errorf("message %q should not contain %q", msg, tt.wantOmit)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- The `/ambassador` command error message previously showed both conditions (games played AND mu) regardless of which one actually failed
- When `AmbassadorMinGamesPlayed` is set to 0, the message showed "at least 0 games played" which is confusing since everyone meets that requirement
- Now the message only mentions the condition(s) the player actually fails, and includes their current values (e.g., "You need a mu of 10+ (yours is 5.0)")

## Test plan
- [x] Unit tests for new `ambassadorEligibilityMessage` function covering: only mu failing, only games failing, both failing
- [x] All existing ambassador tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)