### PR TITLE
fix: cosmetic profile bugs (race, mutation, unlock check, typo)

### DIFF
--- a/server/evr/core_account.go
+++ b/server/evr/core_account.go
@@ -103,14 +103,14 @@ func (s ServerProfile) IsUnlocked(id string) bool {
 		return false
 	}
 	for _, m := range s.UnlockedCosmetics {
-		if _, ok := m[id]; ok {
+		if v, ok := m[id]; ok && v {
 			return true
 		}
 	}
 	return false
 }
 
-func (p ServerProfile) MarshallJSON() ([]byte, error) {
+func (p ServerProfile) MarshalJSON() ([]byte, error) {
 	type Alias ServerProfile
 	a := &struct {
 		*Alias

--- a/server/evr/core_packet_test.go
+++ b/server/evr/core_packet_test.go
@@ -322,8 +322,8 @@ func TestParsePacket_TooManyMessages(t *testing.T) {
 
 	// bytes.Split on a packet starting with the marker produces an empty
 	// leading chunk plus one chunk per message. With MaxMessagesPerPacket
-	// messages we get MaxMessagesPerPacket+1 chunks, which exceeds the limit.
-	count := MaxMessagesPerPacket // produces count+1 chunks after split
+	// messages we get MaxMessagesPerPacket+2 chunks, which exceeds the limit.
+	count := MaxMessagesPerPacket + 1 // produces count+1 chunks after split
 	var packet []byte
 	for i := 0; i < count; i++ {
 		packet = append(packet, msg...)

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -425,13 +425,15 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 	var lastErr error
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
+			// On version conflict, reload the full profile. This is a "last-write-wins" conflict
+			// resolution, where the caller's intended mutations are discarded on retry.
+			// This is safer than accidentally writing stale data. The caller is expected
+			// to implement their own retry loop if they need to preserve their changes.
 			fresh, err := EVRProfileLoad(ctx, nk, userID)
 			if err != nil {
 				lastErr = err
 			} else {
-				meta := md.StorageMeta()
-				meta.Version = fresh.StorageMeta().Version
-				md.SetStorageMeta(meta)
+				*md = *fresh
 			}
 		}
 

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -219,19 +219,24 @@ func NewClientProfile(ctx context.Context, evrProfile *EVRProfile, serverProfile
 	if evrProfile.NewUnlocks == nil {
 		evrProfile.NewUnlocks = []int64{}
 	}
+
+	// Copy the slice to avoid mutating the original backing array.
+	newUnlocks := make([]int64, len(evrProfile.NewUnlocks))
+	copy(newUnlocks, evrProfile.NewUnlocks)
+
 	// Remove newunlocks for cosmetics that the user does not have unlocked
-	for i := 0; i < len(evrProfile.NewUnlocks); i++ {
-		sym := evr.ToSymbol(evrProfile.NewUnlocks[i])
+	for i := 0; i < len(newUnlocks); i++ {
+		sym := evr.ToSymbol(newUnlocks[i])
 		name := sym.String()
 		if !serverProfile.IsUnlocked(name) {
-			evrProfile.NewUnlocks = slices.Delete(evrProfile.NewUnlocks, i, i+1)
+			newUnlocks = slices.Delete(newUnlocks, i, i+1)
 			i--
 		}
 	}
 
 	// Remove kissy lips from new unlocks
-	if i := slices.Index(evrProfile.NewUnlocks, -6079176325296842000); i != -1 {
-		evrProfile.NewUnlocks = slices.Delete(evrProfile.NewUnlocks, i, i+1)
+	if i := slices.Index(newUnlocks, -6079176325296842000); i != -1 {
+		newUnlocks = slices.Delete(newUnlocks, i, i+1)
 	}
 
 	var customizationPOIs *evr.Customization
@@ -280,7 +285,7 @@ func NewClientProfile(ctx context.Context, evrProfile *EVRProfile, serverProfile
 			SetupVersion:           1,
 			Channel:                serverProfile.Social.Channel,
 		},
-		NewUnlocks: evrProfile.NewUnlocks, // This could pull from the wallet ledger
+		NewUnlocks: newUnlocks, // This could pull from the wallet ledger
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #401 — four cosmetic profile bugs:

- **EVRProfileUpdate lost-update race (HIGH):** On version conflict retry, was only reloading the version number but keeping stale profile data. Now reloads the full profile (`*md = *fresh`) to prevent silent data corruption. Caller's mutations are discarded on retry (last-write-wins), which is safer than writing stale data with a new version.

- **NewClientProfile mutates NewUnlocks in-place (Medium):** `slices.Delete()` was operating on the shared backing array via pointer. Now copies the slice before filtering to avoid corrupting the original.

- **IsUnlocked checks key existence, not value (Low):** `_, ok := m[id]` returned true for blocked items (value=false). Now checks `v, ok := m[id]; ok && v`.

- **MarshallJSON typo (Low):** Double-L `MarshallJSON` doesn't satisfy `json.Marshaler` interface. Renamed to `MarshalJSON`.

**Bonus:** Fixed `TestParsePacket_TooManyMessages` — was sending exactly `MaxMessagesPerPacket` messages (within limits) but expecting an error. Now sends `MaxMessagesPerPacket + 1`.

## Test plan

- [x] `go build ./...` passes
- [x] No new test failures (all failures are pre-existing on main)
- [x] `TestParsePacket_TooManyMessages` now passes (was failing on main)
- [ ] Manual verification of cosmetic profile loading in-game

Co-Authored-By: Andrew Bates <a@sprock.io>
Co-Authored-By: Gemini 2.5 Pro <noreply@google.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>