### PR TITLE
fix: admin rename now establishes display name ownership, preserves overrides at login

### DIFF
--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -731,7 +731,10 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 				// This display name is owned by someone else.
 				for gID, gn := range params.profile.DisplayNamesByGroupID() {
 					if strings.EqualFold(gn, dn) {
-						// This display name is owned by someone else.
+						// Preserve admin-granted names even when another user claims ownership.
+						if ignData := params.profile.GetGroupIGNData(gID); ignData.IsOverride || ignData.IsLocked {
+							continue
+						}
 						params.profile.DeleteGroupDisplayName(gID)
 						if serviceSettings.DisplayNameInUseNotifications {
 							// Notify the player that this display name is in use.

--- a/server/evr_runtime_rpc.go
+++ b/server/evr_runtime_rpc.go
@@ -2313,8 +2313,9 @@ func AdminPlayerRenameRPC(ctx context.Context, logger runtime.Logger, db *sql.DB
 			if err := EVRProfileUpdate(ctx, nk, targetUserID, evrProfile); err != nil {
 				logger.Error("Failed to persist EVR profile rename", zap.Error(err), zap.String("user_id", targetUserID))
 			} else {
-				// Record the change in display name history for auditability.
-				if err := DisplayNameHistoryUpdate(ctx, nk, targetUserID, activeGroupID.String(), sanitizedName, account.User.Username, false); err != nil {
+				// Record the change in display name history and mark as active so the renamed
+				// user becomes the index owner of the new name, preventing login-time pruning.
+				if err := DisplayNameHistoryUpdate(ctx, nk, targetUserID, activeGroupID.String(), sanitizedName, account.User.Username, true); err != nil {
 					logger.Error("Failed to update display name history for admin rename", zap.Error(err), zap.String("user_id", targetUserID))
 				}
 			}


### PR DESCRIPTION
## Problem

When a moderator used `AdminPlayerRenameRPC` to rename a player (e.g. Spirit), the new display name was recorded in the display name history with `isInGame=false`. This means the name was written to `Histories[groupID]` but **not** to `InGameNames` or `LastUsed` — so it never appeared in the `active` field of the storage index (`DisplayNameHistoryCacheIndex`).

At the player's next login, `DisplayNameOwnerSearch` would find a *different* user as the sole indexed owner of that name (someone who had used it previously). Because the renamed player wasn't in the owner list, the login uniqueness check (`initializeSession`) would silently delete the admin-granted name and revert the player to their username. The rename appeared to work but was undone on first login.

A second gap: the login pruning loop had no awareness of `IsOverride` / `IsLocked` flags, so even names explicitly granted by an admin could be stripped if another user happened to hold the same name in their active cache.

## Changes

**`server/evr_runtime_rpc.go`** — `AdminPlayerRenameRPC`
- Pass `isInGame=true` to `DisplayNameHistoryUpdate` so the target user immediately becomes the indexed active owner of the new name. This is semantically correct: the admin is asserting this user *is currently using* this name.

**`server/evr_pipeline_login.go`** — `initializeSession` uniqueness check
- Before deleting a conflicting display name, check `IsOverride || IsLocked` on the IGN entry. If either flag is set the name was admin-granted and must not be stripped by the conflict-resolution path, regardless of who else claims it.

## Test

1. Rename a player to a display name currently held in another user's active history via `AdminPlayerRenameRPC`.
2. Have the renamed player log in.
3. Verify their display name is retained (not reverted to username) and they receive no "display name in use" DM.