### PR TITLE
fix(matchmaker): release party follower to matchmaking when leader's match is full

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -108,18 +108,25 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 					if ctx.Err() != nil {
 						return ctx.Err()
 					}
-					// The follower could not follow the leader (e.g. leader
-					// is in an active arena/combat game). Send them to a
-					// social lobby so they aren't stuck at a loading screen.
-					logger.Info("Follower cannot join leader's match, redirecting to social lobby")
-					lobbyParams.Mode = evr.ModeSocialPublic
-					lobbyParams.Level = evr.LevelUnspecified
-					lobbyParams.SetPartySize(1)
-					followerEntrants, err := PrepareEntrantPresences(ctx, logger, p.nk, p.nk.sessionRegistry, lobbyParams, session.id)
-					if err != nil {
-						return fmt.Errorf("failed to prepare follower entrant: %w", err)
+					// The follower could not follow the leader (e.g. leader is in a
+					// full arena/combat match). If the original request was for a
+					// social mode, redirect to social. Otherwise release the follower
+					// to independent matchmaking for their original mode.
+					if lobbyParams.Mode == evr.ModeSocialPublic || lobbyParams.Mode == evr.ModeSocialNPE {
+						logger.Info("Follower cannot join leader's match, redirecting to social lobby")
+						lobbyParams.Level = evr.LevelUnspecified
+						lobbyParams.SetPartySize(1)
+						followerEntrants, err := PrepareEntrantPresences(ctx, logger, p.nk, p.nk.sessionRegistry, lobbyParams, session.id)
+						if err != nil {
+							return fmt.Errorf("failed to prepare follower entrant: %w", err)
+						}
+						return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
 					}
-					return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
+					// Non-social mode: release the follower to independent matchmaking.
+					logger.Info("Follower cannot join leader's match, releasing to independent matchmaking",
+						zap.String("mode", lobbyParams.Mode.String()))
+					lobbyParams.SetPartySize(1)
+					// Fall through to normal matchmaking below.
 				}
 			}
 		} else {


### PR DESCRIPTION
## Problem

When a party follower's leader is in a full arena/combat match, the follower was force-redirected to a social lobby regardless of the original request mode.

## Root Cause

In `server/evr_lobby_find.go`, the `else` block handling follower-cannot-follow-leader always set `lobbyParams.Mode = evr.ModeSocialPublic` and returned early via `lobbyFindOrCreateSocial`, even when the original request was for `echo_arena` or `combat`.

## Fix

Only redirect to social if the original mode was already social (`ModeSocialPublic` or `ModeSocialNPE`). For non-social modes, set party size to 1 and fall through to normal matchmaking so the follower finds their own pub match.

## Testing

- `go build ./server/...` passes