### PR TITLE
fix(lobby): fall back to fresh metadata when entrant presence is missing

### DIFF
--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -8,8 +8,8 @@ import (
 	"slices"
 	"time"
 
-	"github.com/bwmarrin/discordgo"
 	rtapi "buf.build/gen/go/echotools/nevr-api/protocolbuffers/go/gameservice/v1"
+	"github.com/bwmarrin/discordgo"
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"go.uber.org/zap"
@@ -163,9 +163,13 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 		// Use the existing entrant metadata.
 		entrantMeta := tracker.GetLocalBySessionIDStreamUserID(e.SessionID, entrantStream, e.UserID)
 		if entrantMeta == nil {
-			return errors.New("failed to get entrant metadata")
-		}
-		if err := json.Unmarshal([]byte(entrantMeta.Status), e); err != nil {
+			// Presence was cleaned up (reconnect/disconnect race); fall back to treating as new.
+			logger.Warn("entrant metadata not found, falling back to fresh metadata", zap.String("uid", e.UserID.String()), zap.String("sid", e.SessionID.String()))
+			freshMeta := PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: e.String(), Hidden: false}
+			if success := tracker.Update(sessionCtx, e.SessionID, entrantStream, e.UserID, freshMeta); !success {
+				return ErrFailedToTrackEntrantStream
+			}
+		} else if err := json.Unmarshal([]byte(entrantMeta.Status), e); err != nil {
 			return fmt.Errorf("failed to unmarshal entrant metadata: %w", err)
 		}
 	}


### PR DESCRIPTION
## Problem

Players received 'internal error' when matchmaking into social lobbies. Root cause: 106 occurrences of `failed to get entrant metadata` in production logs.

When `isNew=false` (match handler thinks the player was already in the lobby) but the tracker lookup via `GetLocalBySessionIDStreamUserID` returns `nil`, the old code hard-errored. This nil case occurs in reconnect/disconnect/timing races where the entrant presence was cleaned up before the join completes.

## Fix

In the `else` branch of `LobbyJoinEntrants`, when `entrantMeta` is nil, fall back to creating fresh metadata (same as the `isNew=true` path) instead of returning an error. Logs a `Warn` so the race is still observable.

## Testing

- `go build ./server/...` ✅