### PR TITLE
fix(matchmaker): wait for party followers before fresh-start ticket

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -309,6 +309,31 @@ func (p *EvrPipeline) configureParty(ctx context.Context, logger *zap.Logger, se
 					}
 				}
 			}
+		} else if lobbyParams.CurrentMatchID.IsNil() && lobbyGroup.Size() <= 1 && lobbyParams.Mode != evr.ModeSocialPublic {
+			// Fresh-start matchmaking: the party handler may have just been created and
+			// followers may not have called JoinPartyGroup yet. Wait briefly so the leader
+			// does not submit a solo matchmaking ticket before the follower joins — which
+			// would allow backfill to place the leader in a match with no room left for
+			// the follower.
+			logger.Debug("Waiting for party followers (fresh-start grace period)", zap.Duration("timeout", MatchmakingStartGracePeriod))
+			graceTimer := time.NewTimer(MatchmakingStartGracePeriod)
+			defer graceTimer.Stop()
+			graceTicker := time.NewTicker(200 * time.Millisecond)
+			defer graceTicker.Stop()
+		graceWaitLoop:
+			for lobbyGroup.Size() <= 1 {
+				select {
+				case <-ctx.Done():
+					return nil, nil, false, ctx.Err()
+				case <-graceTimer.C:
+					logger.Debug("Grace period elapsed; no followers joined, proceeding solo")
+					break graceWaitLoop
+				case <-graceTicker.C:
+				}
+			}
+			if lobbyGroup.Size() > 1 {
+				logger.Debug("Party followers joined during grace period", zap.Int("size", lobbyGroup.Size()))
+			}
 		}
 		memberUsernames := make([]string, 0, lobbyGroup.Size())
 


### PR DESCRIPTION
## Problem

When two players are in a party (e.g. MRS.P + mikey), both start lobby find from the main menu simultaneously. The party handler is newly created with only the leader. The leader calls `addTicket` before the follower's `JoinPartyGroup` completes, so a **solo ticket** is submitted.

The backfill (`partySize = len(entries) = 1`) then places the leader into an existing match with exactly one remaining slot, filling it completely. The follower's `TryFollowPartyLeader` detects `OpenPlayerSlots() < requiredSlots` and after one non-joinable cycle redirects the follower to a social lobby.

## Root Cause

`configureParty()` in `evr_lobby_find.go` has a wait loop that fires only when the leader is **leaving a previous non-social match** (`CurrentMatchID != nil`). Fresh starts from the main menu (`CurrentMatchID.IsNil()`) had no equivalent protection, creating a race condition.

`MatchmakingStartGracePeriod = 3*time.Second` was defined in `evr_lobby_matchmake.go` but never used — clearly intended for this purpose.

## Fix

In the `isLeader` block of `configureParty()`, add an `else if` branch that fires when:
- `CurrentMatchID.IsNil()` (fresh start, no previous match)  
- `lobbyGroup.Size() <= 1` (only the leader in the handler)  
- `lobbyParams.Mode != evr.ModeSocialPublic` (social lobbies use reservations and don't need this)

Poll `lobbyGroup.Size()` every 200ms for up to `MatchmakingStartGracePeriod` (3s). Once a follower calls `JoinPartyGroup` the loop exits and `addTicket` submits a **party ticket** with both members. The backfill then requires two slots, preventing the leader from being placed in a match the follower cannot join.

## Testing

`go build ./server/...` passes.