### PR TITLE
Fix discord display names not correctly updating in-game

### DIFF
--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -302,7 +302,7 @@ func (a *EVRProfile) SetGroupDisplayName(groupID, displayName string) (updated b
 	a.InGameNames[groupID] = GroupInGameName{
 		GroupID:     groupID,
 		DisplayName: displayName,
-		IsOverride:  current.IsOverride,
+		IsOverride:  false,
 		IsLocked:    current.IsLocked,
 	}
 	return true

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -739,18 +739,17 @@ func (d *DiscordIntegrator) handleMemberUpdate(logger *zap.Logger, s *discordgo.
 		accountUpdate = true
 	}
 
-	if e.BeforeUpdate != nil && e.BeforeUpdate.User != nil {
-		// Update the username if it has changed.
-		if evrAccount.Username() != e.User.Username {
-			accountUpdate = true
-		}
+	// Update the username if it has changed.
+	if evrAccount.Username() != e.User.Username {
+		accountUpdate = true
+	}
 
-		if InGameName(e.Member) != InGameName(e.BeforeUpdate) {
-			if err := d.syncMembersIGN(ctx, logger, evrAccount, e.Member, group); err != nil {
-				return fmt.Errorf("error syncing display name: %w", err)
-			}
-			accountUpdate = true
+	// Update the display name if it has changed.
+	if InGameName(e.Member) != evrAccount.GetGroupIGNData(groupID).DisplayName {
+		if err := d.syncMembersIGN(ctx, logger, evrAccount, e.Member, group); err != nil {
+			return fmt.Errorf("error syncing display name: %w", err)
 		}
+		accountUpdate = true
 	}
 
 	if accountUpdate {
@@ -802,8 +801,8 @@ func (d *DiscordIntegrator) syncMembersIGN(ctx context.Context, logger *zap.Logg
 
 	// Check if the current IGN data is locked or an override - if so, don't update from Discord
 	currentIGN := profile.GetGroupIGNData(groupID)
-	if currentIGN.IsLocked || currentIGN.IsOverride {
-		// Don't update locked or overridden display names from Discord
+	if currentIGN.IsLocked {
+		// Don't update locked display names from Discord
 		return nil
 	}
 

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -692,7 +692,7 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 			}
 		}
 
-		if !groupIGN.IsOverride && !groupIGN.IsLocked {
+		if !groupIGN.IsLocked {
 			shouldRefreshFromDiscord := groupID == params.profile.ActiveGroupID || groupIGN.DisplayName == ""
 			if !shouldRefreshFromDiscord {
 				params.profile.SetGroupIGNData(groupID, groupIGN)


### PR DESCRIPTION
# Changelog: Discord Nickname Synchronization Fixes

## Problem Summary
Nickname synchronization between Discord and Echo VR was unreliable due to two main issues:
1.  **Cache Dependency:** The update handler relied on Discord's "previous state" (`BeforeUpdate`), which is often missing if the member hasn't recently interacted with the bot.
2.  **Override Logic:** Manual overrides (set by moderators via `/ign` or other commands) permanently blocked automated updates, even if they were not "Locked". This prevented users from returning to Discord-managed nicknames even after a temporary mod-assigned name was no longer needed.

## Changes & Fixes

### 1. Robust Member Update Detection
- **File:** `evr_discord_integrator.go`
- **Change:** Refactored `handleMemberUpdate` to remove dependency on the `BeforeUpdate` field.
- **Fix:** The server now compares the incoming Discord member state directly against the loaded Nakama profile. This ensures nickname and username changes are detected even if the member wasn't previously cached by the bot.

### 2. Improved Override/Lock Logic
- **Files:** `evr_discord_integrator.go`, `evr_pipeline_login.go`
- **Change:** Updated synchronization logic to only block updates if the display name is explicitly marked as **Locked**.
- **Fix:** Removed the check that skipped updates for entries marked as an "Override". This allows Discord nickname changes to update manual overrides (such as those set by moderators) as long as the moderator hasn't explicitly locked the name.

### 3. Automated Override Clearing
- **File:** `evr_account.go`
- **Change:** Updated `SetGroupDisplayName` to set `IsOverride` to `false` whenever a name is set.
- **Fix:** When a nickname is successfully updated from Discord, any existing "Override" status is cleared, returning the user to standard automated synchronization.

## Impact
- Nickname changes in Discord will now reflect in-game more reliably across all guilds.
- Moderators can still use the **Lock** feature to make a name strictly persistent against Discord changes.
- Manual renames (which are restricted to moderators via `/ign`) no longer "break" the automated sync permanently; the name remains flexible unless locked.