### PR TITLE
Infinite matchmaking when in party

### DIFF
--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -562,7 +562,7 @@ func TestPoll_LeaderStillMatchmaking_KeepsPolling(t *testing.T) {
 func TestPoll_LeaderStillMatchmaking_ThenSettles_FollowerInMatch_ReturnsTrue(t *testing.T) {
 	// Leader starts matchmaking, then finishes and settles into a match.
 	// Follower is also placed in the same match. Poll should eventually return true.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	env.setLeaderMatch(matchB)
@@ -637,7 +637,7 @@ func TestPoll_LeaderNilMatchID_KeepsPolling(t *testing.T) {
 func TestPoll_LeaderSwitchesMatches_FollowerInNewMatch_ReturnsTrue(t *testing.T) {
 	// Leader is in Match B, then switches to Match C during the poll.
 	// Follower ends up in Match C. Poll should detect Match C, not Match B.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	matchC := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
@@ -705,7 +705,7 @@ func TestPoll_LeaderChangesPartway_NewLeaderInMatch_ReturnsTrue(t *testing.T) {
 	// Original leader is matchmaking. A third player becomes leader during
 	// the poll and is already in a match. The follower is also in that match.
 	// Poll should detect the new leader's match.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	newLeaderSID := uuid.Must(uuid.NewV4())

--- a/server/evr_lobby_join.go
+++ b/server/evr_lobby_join.go
@@ -26,9 +26,6 @@ func (p *EvrPipeline) lobbyJoin(ctx context.Context, logger *zap.Logger, session
 		logger.Warn("Match not found", zap.String("mid", matchID.UUID.String()))
 		return ErrMatchNotFound
 	}
-	if label.Mode != evr.ModeArenaPublic && label.Mode != evr.ModeCombatPublic {
-		LeavePartyStream(session)
-	}
 
 	lobbyParams.GroupID = label.GetGroupID()
 	lobbyParams.Mode = label.Mode

--- a/server/evr_lobby_session.go
+++ b/server/evr_lobby_session.go
@@ -79,14 +79,12 @@ func (p *EvrPipeline) handleLobbySessionRequest(ctx context.Context, logger *zap
 		return nil
 
 	case *evr.LobbyJoinSessionRequest:
-		LeavePartyStream(session)
 		p.nk.metrics.CustomCounter("lobby_join_session", lobbyParams.MetricsTags(), 1)
 		logger.Info("Joining session", zap.String("mid", lobbyParams.CurrentMatchID.String()), zap.String("role", TeamIndex(lobbyParams.Role).String()))
 
 		return p.lobbyJoin(ctx, logger, session, lobbyParams, lobbyParams.CurrentMatchID)
 
 	case *evr.LobbyCreateSessionRequest:
-
 		if len(lobbyParams.RequiredFeatures) > 0 {
 			// Reject public creation
 			if lobbyParams.Mode == evr.ModeArenaPublic || lobbyParams.Mode == evr.ModeCombatPublic || lobbyParams.Mode == evr.ModeSocialPublic {
@@ -94,7 +92,6 @@ func (p *EvrPipeline) handleLobbySessionRequest(ctx context.Context, logger *zap
 			}
 		}
 
-		LeavePartyStream(session)
 		p.nk.metrics.CustomCounter("lobby_create_session", lobbyParams.MetricsTags(), 1)
 		logger.Info("Creating session", zap.String("mode", lobbyParams.Mode.String()), zap.String("level", lobbyParams.Level.String()), zap.String("region", lobbyParams.RegionCode))
 		matchID, err = p.lobbyCreate(ctx, logger, session, lobbyParams)


### PR DESCRIPTION
Here is the changelog for the changes made to fix the party following glitch:

### Changelog

**Fix: Resolved "Infinite Matchmaking" for Party Members**
*   **Description**: Fixed a bug where party members would fail to follow the leader into social lobbies or private matches after a match ended.
*   **Root Cause**: The server was forcing the party leader to leave the party's tracking stream whenever they transitioned to a non-public-arena/combat lobby, making them "disappear" from the party in the eyes of the followers.

**Modified Files:**
*   **`server/evr_lobby_join.go`**
    *   Removed automatic `LeavePartyStream` call during the `lobbyJoin` process. Players now remain in their party stream when entering any lobby type.
*   **`server/evr_lobby_session.go`**
    *   Removed `LeavePartyStream` calls from the manual session join (`LobbyJoinSessionRequest`) and creation (`LobbyCreateSessionRequest`) handlers to ensure party persistence.
*   **`server/evr_lobby_follow_test.go`**
    *   Improved test stability by properly initializing the Nakama module mock (`withMockNK`) in several poll-based tests to prevent intermittent nil-pointer panics during match validation.
    
@metis-sprock please check the changelog and decide on if this is is correct