### PR TITLE
chore: demote noisy log messages to appropriate levels

### DIFF
--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -86,7 +86,7 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 	found, allowed, isNew, reason, labelStr, _ = matchRegistry.JoinAttempt(sessionCtx, label.ID.UUID, label.ID.Node, e.UserID, e.SessionID, e.Username, e.SessionExpiry, nil, e.ClientIP, e.ClientPort, label.ID.Node, metadata)
 
 	if reason == ErrJoinRejectReasonDuplicateJoin.Error() {
-		logger.Warn("duplicate join attempt; no-op", zap.String("uid", e.UserID.String()), zap.String("sid", e.SessionID.String()), zap.String("mid", label.ID.UUID.String()))
+		logger.Debug("duplicate join attempt; no-op", zap.String("uid", e.UserID.String()), zap.String("sid", e.SessionID.String()), zap.String("mid", label.ID.UUID.String()))
 		return nil
 	}
 

--- a/server/evr_lobby_matchmake.go
+++ b/server/evr_lobby_matchmake.go
@@ -281,7 +281,7 @@ func (p *EvrPipeline) addTicket(ctx context.Context, logger *zap.Logger, session
 		threshold := ServiceSettings().Matchmaking.NewPlayerMaxGames
 		archetypeStats, gamesPlayed, arcErr := LoadArchetypeStats(ctx, p.db, logger, session.UserID().String(), lobbyParams.GroupID.String())
 		if arcErr != nil {
-			logger.Warn("Failed to load archetype stats, defaulting to rookie", zap.Error(arcErr))
+			logger.Debug("Failed to load archetype stats, defaulting to rookie", zap.Error(arcErr))
 			stringProps["archetype"] = ArchetypeRookie
 		} else {
 			stringProps["archetype"] = DetectArchetype(archetypeStats, gamesPlayed, threshold)

--- a/server/evr_lobby_prejoin_ping.go
+++ b/server/evr_lobby_prejoin_ping.go
@@ -352,7 +352,7 @@ func (p *EvrPipeline) validatePreJoinPing(
 		allEntrantDetails = append(allEntrantDetails, fmt.Sprintf("uid=%s sid=%s user=%s", ent.UserID, ent.SessionID, EscapeDiscordMarkdown(ent.Username)))
 	}
 
-	logger.Warn("Pre-join ping validation failed",
+	logger.Info("Pre-join ping validation failed",
 		zap.String("mid", label.ID.UUID.String()),
 		zap.String("group_id", groupID),
 		zap.String("endpoint", endpoint.String()),

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -382,7 +382,7 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 					"uid":              p.GetUserId(),
 					"existing_session": e.GetSessionId(),
 					"new_session":      p.GetSessionId(),
-				}).Warn("Evicting stale presence for same-user duplicate EVR-ID.")
+				}).Info("Evicting stale presence for same-user duplicate EVR-ID.")
 				delete(state.presenceMap, e.GetSessionId())
 				delete(state.presenceByEvrID, e.EvrID)
 				delete(state.joinTimestamps, e.GetSessionId())

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -695,7 +695,7 @@ func (p *EvrPipeline) ProcessRequestEVR(logger *zap.Logger, session Session, in 
 		// If the session is not authenticated, log the error and return.
 		if session != nil && session.UserID() == uuid.Nil {
 
-			logger.Warn("Received unauthenticated message", zap.Any("message", in))
+			logger.Debug("Received unauthenticated message", zap.Any("message", in))
 
 			// Send an unrequire
 			if err := SendEVRMessages(session, false, unrequireMessage); err != nil {


### PR DESCRIPTION
## Summary

Demotes 5 warn-level messages that represent expected behavior to info/debug. Reduces production log noise by ~200+ warnings per 8 hours.

| Message | Was | Now | Reason |
|---------|-----|-----|--------|
| `Pre-join ping validation failed` | warn | info | Player had bad ping, rejected. Expected. |
| `Received unauthenticated message` | warn | debug | Clients sending before auth completes. Normal. |
| `Failed to load archetype stats, defaulting to rookie` | warn | debug | Context canceled = player disconnected. Benign. |
| `duplicate join attempt; no-op` | warn | debug | Handled gracefully already. |
| `Evicting stale presence for same-user duplicate EVR-ID` | warn | info | Stale session cleanup, working as designed. |

Clean logs = faster incident response. Real problems shouldn't be buried in expected behavior.

Found during production log audit 2026-04-25.

Closes #418

Co-Authored-By: Andrew Bates <a@sprock.io>