### PR TITLE
fix(backfill): join entrants sequentially to prevent lobby-full race

### DIFF
--- a/server/evr_lobby_backfill.go
+++ b/server/evr_lobby_backfill.go
@@ -2,11 +2,11 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/gofrs/uuid/v5"
@@ -335,41 +335,42 @@ func (b *PostMatchmakerBackfill) executeBackfillResultOptimized(
 		return 0
 	}
 
-	var wg sync.WaitGroup
-	var mu sync.Mutex
 	successCount := 0
 	successfulUserIDs := make([]string, 0, len(entrantsToJoin))
 
 	for _, data := range entrantsToJoin {
-		wg.Add(1)
-		go func(sess Session, ent *EvrMatchPresence) {
-			defer wg.Done()
-			if err := LobbyJoinEntrants(logger, b.matchRegistry, b.tracker, sess, serverSession, result.Match.Label, ent); err != nil {
-				logger.Info("Failed to join entrant to backfill match",
-					zap.Error(err),
-					zap.String("match_id", result.Match.Label.ID.String()),
-					zap.String("user_id", ent.GetUserId()))
-			} else {
-				mu.Lock()
-				successCount++
-				successfulUserIDs = append(successfulUserIDs, ent.GetUserId())
-				mu.Unlock()
-				b.metrics.CustomCounter("lobby_join_post_matchmaker_backfill", result.Match.Label.MetricsTags(), 1)
-				logger.Info("Successfully backfilled player",
-					zap.String("match_id", result.Match.Label.ID.String()),
-					zap.String("user_id", ent.GetUserId()),
-					zap.Int("team", result.Team),
-					zap.Float64("score", result.Score))
+		if err := LobbyJoinEntrants(logger, b.matchRegistry, b.tracker, data.session, serverSession, result.Match.Label, data.entrant); err != nil {
+			if isLobbyFullError(err) {
+				// Match is full; no point trying remaining entrants.
+				break
 			}
-		}(data.session, data.entrant)
+			logger.Info("Failed to join entrant to backfill match",
+				zap.Error(err),
+				zap.String("match_id", result.Match.Label.ID.String()),
+				zap.String("user_id", data.entrant.GetUserId()))
+		} else {
+			successCount++
+			successfulUserIDs = append(successfulUserIDs, data.entrant.GetUserId())
+			b.metrics.CustomCounter("lobby_join_post_matchmaker_backfill", result.Match.Label.MetricsTags(), 1)
+			logger.Info("Successfully backfilled player",
+				zap.String("match_id", result.Match.Label.ID.String()),
+				zap.String("user_id", data.entrant.GetUserId()),
+				zap.Int("team", result.Team),
+				zap.Float64("score", result.Score))
+		}
 	}
-
-	wg.Wait()
 
 	// Store the successful user IDs in the result for summary logging
 	result.PlayerUserIDs = successfulUserIDs
 
 	return successCount
+}
+
+// isLobbyFullError returns true when the join was rejected because the match is
+// full or the join was otherwise not permitted, meaning further attempts against
+// the same match are pointless.
+func isLobbyFullError(err error) bool {
+	return errors.Is(err, LobbyErrJoinNotAllowed)
 }
 
 // PostMatchmakerBackfill handles backfilling players into existing matches after the matchmaker runs


### PR DESCRIPTION
## Problem

The backfill path in `evr_lobby_backfill.go` joins entrants in **parallel goroutines** against a match label fetched once. By the time goroutine N tries to join, earlier goroutines have already filled the slots. This produced **129 "lobby full" warnings in 8 hours** of production logs and directly contributes to party splits — backfill fills the last slot before a party follower can join.

## Fix

Replace parallel goroutines with sequential joins:
- Each entrant joins one at a time
- On "lobby full" error → break (match is full, stop trying)
- On other errors → log and continue to next entrant
- Removed `sync.WaitGroup` and `sync.Mutex` (no longer needed)

Sequential is correct here because all entrants are joining the same match — there's no performance benefit to racing against shared state.

## Impact

- Eliminates ~129 spurious "lobby full" warnings per 8 hours
- Reduces party split rate (currently 10.5% baseline per party-split-detector #424)
- Combined with #410 (party slot reservation), should significantly improve party reliability

Closes #416

Co-Authored-By: Andrew Bates <a@sprock.io>