### PR TITLE
fix: ensure consistent Prometheus metric label sets

### DIFF
--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -95,6 +95,8 @@ func (s *SessionParameters) MetricsTags() map[string]string {
 		"is_pcvr":        fmt.Sprintf("%t", s.IsPCVR()),
 		"build_version":  fmt.Sprintf("%d", s.BuildNumber()),
 		"device_type":    s.DeviceType(),
+		"error":          "",
+		"device_linked":  "",
 	}
 }
 


### PR DESCRIPTION
## Problem

Prometheus metric registration fails on startup with "different label names" for `session_authenticate` and `session_initialize` counters.

## Root Cause

`MetricsTags()` returns 5 keys, but error paths in `authenticateSession` and `initializeSession` conditionally add `error` and `device_linked` keys. Prometheus requires identical label sets across all registrations of the same metric — the first call registers with 5 labels, subsequent calls with 6 or 7 labels trigger a conflict.

## Fix

Added `"error": ""` and `"device_linked": ""` as default empty keys in `MetricsTags()`. Now every call has a consistent 7-label set regardless of code path.

Closes #415

Co-Authored-By: Andrew Bates <a@sprock.io>