### PR TITLE
Combat matchmaking

### DIFF
--- a/server/evr_combat_matchmaker_test.go
+++ b/server/evr_combat_matchmaker_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCombatMatchmakingRules(t *testing.T) {
+	modeCombat := evr.ModeCombatPublic.String()
+	modeArena := evr.ModeArenaPublic.String()
+	cfg := PredictionConfig{UseSnakeDraftFormation: true}
+
+	runTest := func(name string, totalPlayers int, mode string, isParty bool, expectMatch bool, expectedSize int) {
+		t.Run(name, func(t *testing.T) {
+			entries := make([]runtime.MatchmakerEntry, totalPlayers)
+			partyTicket := "party-1"
+			for i := 0; i < totalPlayers; i++ {
+				ticket := "solo-" + string(rune(48+i))
+				if isParty {
+					ticket = partyTicket
+				}
+				entries[i] = &MatchmakerEntry{
+					Ticket: ticket,
+					Presence: &MatchmakerPresence{
+						UserId:    "u" + string(rune(48+i)),
+						SessionId: "s" + string(rune(48+i)),
+					},
+					Properties: map[string]interface{}{
+						"game_mode":      mode,
+						"max_team_size":  float64(5),
+						"count_multiple": float64(1),
+						"timestamp":      float64(123456789),
+					},
+				}
+			}
+
+			// 1. Test Ticket Grouping (Party Splitting)
+			candidates := groupEntriesSequentially(entries)
+
+			// 2. Test Team Formation (Prediction)
+			predictionChan := predictCandidateOutcomesWithConfig(candidates, cfg)
+
+			var prediction *PredictedMatch
+			select {
+			case p, ok := <-predictionChan:
+				if ok {
+					prediction = &p
+				}
+			}
+
+			if expectMatch {
+				assert.NotNil(t, prediction, "Should have created a match")
+				if prediction != nil {
+					assert.Equal(t, int8(expectedSize), prediction.Size, "Match size should match expectation")
+				}
+			} else {
+				assert.Nil(t, prediction, "Should NOT have created a match")
+			}
+		})
+	}
+
+	// Combat Tests
+	runTest("Combat 1v1 (Solo)", 2, modeCombat, false, true, 2)
+	runTest("Combat 2v2 (Party of 4)", 4, modeCombat, true, true, 4)  // Should split
+	runTest("Combat 3v4 (7 players)", 7, modeCombat, false, true, 7)  // 3v4 allowed
+	runTest("Combat 1v2 (3 players)", 3, modeCombat, false, false, 0) // 1v2 blocked (teams < 3)
+	runTest("Combat 2v3 (5 players)", 5, modeCombat, false, false, 0) // 2v3 blocked (teams < 3)
+
+	// Arena Tests
+	runTest("Arena 1v1 (Solo)", 2, modeArena, false, true, 2)
+	runTest("Arena Party of 4 Matching Alone", 4, modeArena, true, false, 0) // Should NOT split, thus no match (4v0 rejected)
+	runTest("Arena 3v4 (7 players)", 7, modeArena, false, false, 0)          // Uneven blocked
+}

--- a/server/evr_combat_matchmaker_test.go
+++ b/server/evr_combat_matchmaker_test.go
@@ -17,6 +17,15 @@ func TestCombatMatchmakingRules(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			entries := make([]runtime.MatchmakerEntry, totalPlayers)
 			partyTicket := "party-1"
+<<<<<<< Updated upstream
+=======
+			
+			minTeamSize := 1.0
+			if mode == modeCombat {
+				minTeamSize = 2.0
+			}
+
+>>>>>>> Stashed changes
 			for i := 0; i < totalPlayers; i++ {
 				ticket := "solo-" + string(rune(48+i))
 				if isParty {
@@ -30,8 +39,14 @@ func TestCombatMatchmakingRules(t *testing.T) {
 					},
 					Properties: map[string]interface{}{
 						"game_mode":      mode,
+<<<<<<< Updated upstream
 						"max_team_size":  float64(5),
 						"count_multiple": float64(1),
+=======
+						"min_team_size":  minTeamSize,
+						"max_team_size":  float64(5),
+						"count_multiple": float64(2),
+>>>>>>> Stashed changes
 						"timestamp":      float64(123456789),
 					},
 				}
@@ -62,6 +77,7 @@ func TestCombatMatchmakingRules(t *testing.T) {
 		})
 	}
 
+<<<<<<< Updated upstream
 	// Combat Tests
 	runTest("Combat 1v1 (Solo)", 2, modeCombat, false, true, 2)
 	runTest("Combat 2v2 (Party of 4)", 4, modeCombat, true, true, 4)  // Should split
@@ -73,4 +89,17 @@ func TestCombatMatchmakingRules(t *testing.T) {
 	runTest("Arena 1v1 (Solo)", 2, modeArena, false, true, 2)
 	runTest("Arena Party of 4 Matching Alone", 4, modeArena, true, false, 0) // Should NOT split, thus no match (4v0 rejected)
 	runTest("Arena 3v4 (7 players)", 7, modeArena, false, false, 0)          // Uneven blocked
+=======
+	// Combat Tests (Even only, min 2v2)
+	runTest("Combat 1v1 (Solo)", 2, modeCombat, false, false, 0)   // 2 players matched, but team size 1 < min 2. REJECTED.
+	runTest("Combat 2v2 (Party of 4)", 4, modeCombat, true, true, 4)  // Should split into 2v2
+	runTest("Combat 3v3 (Solo)", 6, modeCombat, false, true, 6)      // 3v3 allowed
+	runTest("Combat 3v4 (7 players)", 7, modeCombat, false, true, 6)  // 6 players matched -> 3v3. OK.
+	runTest("Combat 4v4 (Party of 8)", 8, modeCombat, true, true, 8)  // Should split into 4v4
+
+	// Arena Tests (Even only, min 1v1)
+	runTest("Arena 1v1 (Solo)", 2, modeArena, false, true, 2)
+	runTest("Arena Party of 4 Matching Alone", 4, modeArena, true, false, 0) // Should NOT split, thus no match (4v0 rejected)
+	runTest("Arena 3v4 (7 players)", 7, modeArena, false, true, 6)          // 6 players matched -> 3v3. OK.
+>>>>>>> Stashed changes
 }

--- a/server/evr_lobby_backfill.go
+++ b/server/evr_lobby_backfill.go
@@ -245,26 +245,37 @@ func (b *PostMatchmakerBackfill) getPossibleTeams(candidate *BackfillCandidate, 
 	}
 
 	// For competitive modes
+	blueCount := match.TeamCounts[evr.TeamBlue]
+	orangeCount := match.TeamCounts[evr.TeamOrange]
+	blueOpen := match.OpenSlots[evr.TeamBlue] >= partySize
+	orangeOpen := match.OpenSlots[evr.TeamOrange] >= partySize
+
+	isCombat := candidate.Mode == evr.ModeCombatPublic
+
 	if candidate.TeamAlignment != evr.TeamUnassigned {
 		if match.OpenSlots[candidate.TeamAlignment] >= partySize {
+			// For combat, only allow if it doesn't create imbalance
+			if isCombat {
+				if candidate.TeamAlignment == evr.TeamBlue && blueCount+partySize > orangeCount {
+					return nil
+				}
+				if candidate.TeamAlignment == evr.TeamOrange && orangeCount+partySize > blueCount {
+					return nil
+				}
+			}
 			return []int{candidate.TeamAlignment}
 		}
 		return nil
 	}
 
 	// No team preference - prioritize smaller team for balance
-	blueCount := match.TeamCounts[evr.TeamBlue]
-	orangeCount := match.TeamCounts[evr.TeamOrange]
-	blueOpen := match.OpenSlots[evr.TeamBlue] >= partySize
-	orangeOpen := match.OpenSlots[evr.TeamOrange] >= partySize
-
 	var teams []int
 	if blueCount < orangeCount && blueOpen {
 		teams = append(teams, evr.TeamBlue)
 	} else if orangeCount < blueCount && orangeOpen {
 		teams = append(teams, evr.TeamOrange)
-	} else {
-		// Equal or preferred team full - add both available
+	} else if !isCombat {
+		// For non-combat (Arena), allow adding to both teams if they are equal or it doesn't matter as much
 		if blueOpen {
 			teams = append(teams, evr.TeamBlue)
 		}
@@ -903,31 +914,120 @@ func (b *PostMatchmakerBackfill) ProcessAndExecuteBackfill(ctx context.Context, 
 		groupIDStr := key.GroupID.String()
 
 		// Process and execute each candidate immediately
-		for _, candidate := range groupCandidates {
-			// Check for context cancellation before processing each candidate
+		// For Combat, we split candidates into individual players to allow fair distribution
+		// and pair-wise joining to maintain balance.
+		var pool []*preparedBackfillCandidate
+		if key.Mode == evr.ModeCombatPublic {
+			for _, c := range groupCandidates {
+				if len(c.Entries) == 1 {
+					pool = append(pool, c)
+				} else {
+					// Split party into individual candidates
+					for _, entry := range c.Entries {
+						pool = append(pool, &preparedBackfillCandidate{
+							BackfillCandidate: &BackfillCandidate{
+								Ticket:         c.Ticket,
+								Entries:        []*MatchmakerEntry{entry},
+								GroupID:        c.GroupID,
+								Mode:           c.Mode,
+								Rating:         c.Rating,
+								SubmissionTime: c.SubmissionTime,
+								RTTs:           c.RTTs,
+								MaxRTT:         c.MaxRTT,
+								TeamAlignment:  c.TeamAlignment,
+								Intervals:      c.Intervals,
+							},
+							sessions:  b.prepareCandidates([]*BackfillCandidate{{Entries: []*MatchmakerEntry{entry}}})[0].sessions,
+							partySize: 1,
+						})
+					}
+				}
+			}
+		} else {
+			pool = groupCandidates
+		}
+
+		for len(pool) > 0 {
+			// Check for context cancellation
 			select {
 			case <-ctx.Done():
-				b.logger.Debug("Backfill cancelled during candidate processing", zap.Error(ctx.Err()))
 				return results, ctx.Err()
 			default:
 			}
 
-			// Find best match using pre-computed data
-			result := b.findBestBackfillMatchOptimized(candidate, preparedMatches, bctx)
-			if result == nil || result.Score <= BackfillMinAcceptableScore {
-				continue
-			}
+			candidate := pool[0]
+			pool = pool[1:]
 
-			// Execute backfill immediately using pre-resolved sessions
-			successCount := b.executeBackfillResultOptimized(ctx, logger, result, candidate.sessions, groupIDStr)
-			if successCount > 0 {
-				results = append(results, result)
-				// Update tracked slots and team counts for successfully joined entrants
-				result.Match.OpenSlots[result.Team] -= successCount
-				result.Match.TeamCounts[result.Team] += successCount
+			// For Combat, if we are at an even state, try to find another player to join as a pair
+			if key.Mode == evr.ModeCombatPublic {
+				// Find matches that are currently balanced
+				// We need another player from the pool to join this match together
+				result := b.findBestBackfillMatchOptimized(candidate, preparedMatches, bctx)
+				if result != nil && result.Score > BackfillMinAcceptableScore {
+					// If the match is already uneven, this player will join the smaller team (restoring balance)
+					if result.Match.TeamCounts[evr.TeamBlue] != result.Match.TeamCounts[evr.TeamOrange] {
+						successCount := b.executeBackfillResultOptimized(ctx, logger, result, candidate.sessions, groupIDStr)
+						if successCount > 0 {
+							results = append(results, result)
+							result.Match.OpenSlots[result.Team] -= successCount
+							result.Match.TeamCounts[result.Team] += successCount
+							b.logBackfillSummary(logger, result)
+						}
+						continue
+					}
 
-				// Log structured summary after each backfill operation
-				b.logBackfillSummary(logger, result)
+					// If the match is even, we need a second player to join the opposite team
+					if len(pool) > 0 {
+						secondCandidate := pool[0]
+						otherTeam := evr.TeamOrange
+						if result.Team == evr.TeamOrange {
+							otherTeam = evr.TeamBlue
+						}
+
+						if result.Match.OpenSlots[otherTeam] >= 1 {
+							// Found a pair! Execute both.
+							pool = pool[1:] // Consume the second player
+
+							// Join first player
+							s1 := b.executeBackfillResultOptimized(ctx, logger, result, candidate.sessions, groupIDStr)
+							if s1 > 0 {
+								results = append(results, result)
+								result.Match.OpenSlots[result.Team] -= s1
+								result.Match.TeamCounts[result.Team] += s1
+								b.logBackfillSummary(logger, result)
+							}
+
+							// Join second player to the other team
+							result2 := &BackfillResult{
+								Candidate: secondCandidate.BackfillCandidate,
+								Match:     result.Match,
+								Team:      otherTeam,
+								Score:     result.Score,
+							}
+							s2 := b.executeBackfillResultOptimized(ctx, logger, result2, secondCandidate.sessions, groupIDStr)
+							if s2 > 0 {
+								results = append(results, result2)
+								result2.Match.OpenSlots[result2.Team] -= s2
+								result2.Match.TeamCounts[result2.Team] += s2
+								b.logBackfillSummary(logger, result2)
+							}
+						}
+					}
+				}
+			} else {
+				// Standard backfill for non-combat modes
+				result := b.findBestBackfillMatchOptimized(candidate, preparedMatches, bctx)
+				if result == nil || result.Score <= BackfillMinAcceptableScore {
+					continue
+				}
+
+				successCount := b.executeBackfillResultOptimized(ctx, logger, result, candidate.sessions, groupIDStr)
+				if successCount > 0 {
+					results = append(results, result)
+					result.Match.OpenSlots[result.Team] -= successCount
+					result.Match.TeamCounts[result.Team] += successCount
+					b.logBackfillSummary(logger, result)
+				}
 			}
 		}
 	}

--- a/server/evr_lobby_matchmake.go
+++ b/server/evr_lobby_matchmake.go
@@ -126,7 +126,7 @@ var DefaultMatchmakerTicketConfigs = map[evr.Symbol]MatchmakingTicketParameters{
 		IncludeEarlyQuitPenalty: false,
 	},
 	evr.ModeCombatPublic: {
-		MinCount:                2,
+		MinCount:                4,
 		MaxCount:                100,
 		CountMultiple:           2,
 		IncludeSBMMRanges:       false,

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -757,7 +757,7 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 	var minTeamSize, maxTeamSize float64
 	switch p.Mode {
 	case evr.ModeCombatPublic:
-		minTeamSize = 3
+		minTeamSize = 2
 		maxTeamSize = 5
 	default:
 		minTeamSize = 4

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -27,53 +27,53 @@ type (
 )
 
 type LobbySessionParameters struct {
-	Node                         string                        `json:"node"`
-	UserID                       uuid.UUID                     `json:"user_id"`
-	SessionID                    uuid.UUID                     `json:"session_id"`
-	DiscordID                    string                        `json:"discord_id"`
-	VersionLock                  evr.Symbol                    `json:"version_lock"`
-	AppID                        evr.Symbol                    `json:"app_id"`
-	GroupID                      uuid.UUID                     `json:"group_id"`
-	RegionCode                   string                        `json:"region_code"`
-	Mode                         evr.Symbol                    `json:"mode"`
-	Level                        evr.Symbol                    `json:"level"`
-	SupportedFeatures            []string                      `json:"supported_features"`
-	RequiredFeatures             []string                      `json:"required_features"`
-	CurrentMatchID               MatchID                       `json:"current_match_id"`
-	NextMatchID                  MatchID                       `json:"next_match_id"`
-	Role                         int                           `json:"role"`
-	PartySize                    *atomic.Int64                 `json:"party_size"`
-	PartyID                      uuid.UUID                     `json:"party_id"`
-	PartyGroupName               string                        `json:"party_group_name"`
-	DisableArenaBackfill         bool                          `json:"disable_arena_backfill"`
-	BackfillQueryAddon           string                        `json:"backfill_query_addon"`
-	MatchmakingQueryAddon        string                        `json:"matchmaking_query_addon"`
-	CreateQueryAddon             string                        `json:"create_query_addon"`
-	Verbose                      bool                          `json:"verbose"`
-	BlockedIDs                   []string                      `json:"blocked_ids"`
-	IsModerator                  bool                          `json:"is_moderator"` // True if user is a moderator (enforcer or operator), regardless of division
-	MatchmakingRating            *atomic.Pointer[types.Rating] `json:"matchmaking_rating"`
-	EarlyQuitPenaltyLevel        int                           `json:"early_quit_penalty_level"`
-	EarlyQuitMatchmakingTier     int32                         `json:"early_quit_matchmaking_tier"`
-	EnableSBMM                   bool                          `json:"disable_sbmm"`
-	EnableOrdinalRange           bool                          `json:"enable_ordinal_range"`
-	EnableDivisions              bool                          `json:"enable_divisions"`
-	MatchmakingRatingRange       float64                       `json:"rating_range"`
-	MatchmakingDivisions         []string                      `json:"divisions"`
+	Node                     string                        `json:"node"`
+	UserID                   uuid.UUID                     `json:"user_id"`
+	SessionID                uuid.UUID                     `json:"session_id"`
+	DiscordID                string                        `json:"discord_id"`
+	VersionLock              evr.Symbol                    `json:"version_lock"`
+	AppID                    evr.Symbol                    `json:"app_id"`
+	GroupID                  uuid.UUID                     `json:"group_id"`
+	RegionCode               string                        `json:"region_code"`
+	Mode                     evr.Symbol                    `json:"mode"`
+	Level                    evr.Symbol                    `json:"level"`
+	SupportedFeatures        []string                      `json:"supported_features"`
+	RequiredFeatures         []string                      `json:"required_features"`
+	CurrentMatchID           MatchID                       `json:"current_match_id"`
+	NextMatchID              MatchID                       `json:"next_match_id"`
+	Role                     int                           `json:"role"`
+	PartySize                *atomic.Int64                 `json:"party_size"`
+	PartyID                  uuid.UUID                     `json:"party_id"`
+	PartyGroupName           string                        `json:"party_group_name"`
+	DisableArenaBackfill     bool                          `json:"disable_arena_backfill"`
+	BackfillQueryAddon       string                        `json:"backfill_query_addon"`
+	MatchmakingQueryAddon    string                        `json:"matchmaking_query_addon"`
+	CreateQueryAddon         string                        `json:"create_query_addon"`
+	Verbose                  bool                          `json:"verbose"`
+	BlockedIDs               []string                      `json:"blocked_ids"`
+	IsModerator              bool                          `json:"is_moderator"` // True if user is a moderator (enforcer or operator), regardless of division
+	MatchmakingRating        *atomic.Pointer[types.Rating] `json:"matchmaking_rating"`
+	EarlyQuitPenaltyLevel    int                           `json:"early_quit_penalty_level"`
+	EarlyQuitMatchmakingTier int32                         `json:"early_quit_matchmaking_tier"`
+	EnableSBMM               bool                          `json:"disable_sbmm"`
+	EnableOrdinalRange       bool                          `json:"enable_ordinal_range"`
+	EnableDivisions          bool                          `json:"enable_divisions"`
+	MatchmakingRatingRange   float64                       `json:"rating_range"`
+	MatchmakingDivisions     []string                      `json:"divisions"`
 	// TODO: MatchmakingExcludedDivisions is populated and set as a ticket property
 	// but the matchmaker query filter that would read it is commented out.
 	// Wire this into the matchmaker query before considering it active.
-	MatchmakingExcludedDivisions []string `json:"excluded_divisions"`
-	MaxServerRTT                 int                           `json:"max_server_rtt"`
-	MatchmakingTimestamp         time.Time                     `json:"matchmaking_timestamp"`
-	MatchmakingTimeout           time.Duration                 `json:"matchmaking_timeout"`
-	FailsafeTimeout              time.Duration                 `json:"failsafe_timeout"` // The failsafe timeout
-	FallbackTimeout              time.Duration                 `json:"fallback_timeout"` // The fallback timeout
-	DisplayName                  string                        `json:"display_name"`
-	GamesPlayed                  int                           `json:"games_played"`                  // Total games played, loaded from GamesPlayed leaderboard
-	HardDivision                 string                        `json:"hard_division"`                 // Skill division bracket for hard division filtering
-	IsAmbassador                 bool                          `json:"is_ambassador"`                 // True if player is ambassadoring this match
-	HasSuspensionHistoryFlag     bool                          `json:"has_suspension_history"`         // True if player has any suspension history (exempt: enforcers/operators always false)
+	MatchmakingExcludedDivisions []string      `json:"excluded_divisions"`
+	MaxServerRTT                 int           `json:"max_server_rtt"`
+	MatchmakingTimestamp         time.Time     `json:"matchmaking_timestamp"`
+	MatchmakingTimeout           time.Duration `json:"matchmaking_timeout"`
+	FailsafeTimeout              time.Duration `json:"failsafe_timeout"` // The failsafe timeout
+	FallbackTimeout              time.Duration `json:"fallback_timeout"` // The fallback timeout
+	DisplayName                  string        `json:"display_name"`
+	GamesPlayed                  int           `json:"games_played"`           // Total games played, loaded from GamesPlayed leaderboard
+	HardDivision                 string        `json:"hard_division"`          // Skill division bracket for hard division filtering
+	IsAmbassador                 bool          `json:"is_ambassador"`          // True if player is ambassadoring this match
+	HasSuspensionHistoryFlag     bool          `json:"has_suspension_history"` // True if player has any suspension history (exempt: enforcers/operators always false)
 	latencyHistory               *atomic.Pointer[LatencyHistory]
 	unreachableServers           *atomic.Pointer[UnreachableServers]
 }
@@ -742,17 +742,17 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 
 	submissionTime := p.MatchmakingTimestamp.UTC().Format(time.RFC3339)
 	stringProperties := map[string]string{
-		"game_mode":          p.Mode.String(),
-		"group_id":           p.GroupID.String(),
-		"version_lock":       p.VersionLock.String(),
-		"display_name":       p.DisplayName,
-		"submission_time":    submissionTime,
-		"divisions":          strings.Join(p.MatchmakingDivisions, ","),
-		"excluded_divisions": strings.Join(p.MatchmakingExcludedDivisions, ","),
-		"is_moderator":              strconv.FormatBool(p.IsModerator),
-		"division":                  p.HardDivision,
-		"is_ambassador":             strconv.FormatBool(p.IsAmbassador),
-		"has_suspension_history":    strconv.FormatBool(p.HasSuspensionHistoryFlag),
+		"game_mode":              p.Mode.String(),
+		"group_id":               p.GroupID.String(),
+		"version_lock":           p.VersionLock.String(),
+		"display_name":           p.DisplayName,
+		"submission_time":        submissionTime,
+		"divisions":              strings.Join(p.MatchmakingDivisions, ","),
+		"excluded_divisions":     strings.Join(p.MatchmakingExcludedDivisions, ","),
+		"is_moderator":           strconv.FormatBool(p.IsModerator),
+		"division":               p.HardDivision,
+		"is_ambassador":          strconv.FormatBool(p.IsAmbassador),
+		"has_suspension_history": strconv.FormatBool(p.HasSuspensionHistoryFlag),
 	}
 	var minTeamSize, maxTeamSize float64
 	switch p.Mode {

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -276,7 +276,11 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 				ticket := entry.GetTicket()
 				if isCombat {
 					// For combat, split tickets to allow fair team balancing
+<<<<<<< Updated upstream
 					ticket = entry.GetPresence().GetUserId()
+=======
+					ticket = entry.GetPresence().GetSessionId()
+>>>>>>> Stashed changes
 				}
 				ticketGroups[ticket] = append(ticketGroups[ticket], entry)
 			}
@@ -330,10 +334,20 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 				maps.Copy(divs, ticketDivs[ticket])
 			}
 
+			minTeamSize := 1
+			if v, ok := candidate[0].GetProperties()["min_team_size"].(float64); ok && int(v) > 0 {
+				minTeamSize = int(v)
+			}
+
 			teamSize := len(candidate) / 2
+<<<<<<< Updated upstream
 			if isCombat && len(candidate) >= 7 {
 				// For combat, allow uneven teams (e.g. 3v4) only if teams are large enough
 				teamSize = (len(candidate) + 1) / 2
+=======
+			if teamSize < minTeamSize {
+				continue
+>>>>>>> Stashed changes
 			}
 
 			for _, variant := range variants {

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 
 	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/intinig/go-openskill/rating"
 	"github.com/intinig/go-openskill/types"
 )
@@ -268,8 +269,15 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 			}
 
 			// Collect tickets efficiently - group entries by ticket
+			modestr, _ := candidate[0].GetProperties()["game_mode"].(string)
+			isCombat := modestr == evr.ModeCombatPublic.String()
+
 			for _, entry := range candidate {
 				ticket := entry.GetTicket()
+				if isCombat {
+					// For combat, split tickets to allow fair team balancing
+					ticket = entry.GetPresence().GetUserId()
+				}
 				ticketGroups[ticket] = append(ticketGroups[ticket], entry)
 			}
 
@@ -323,6 +331,10 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 			}
 
 			teamSize := len(candidate) / 2
+			if isCombat && len(candidate) >= 7 {
+				// For combat, allow uneven teams (e.g. 3v4) only if teams are large enough
+				teamSize = (len(candidate) + 1) / 2
+			}
 
 			for _, variant := range variants {
 				// Create teams based on variant
@@ -387,8 +399,19 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 					}
 				}
 
-				if len(blueTeam) != len(orangeTeam) {
-					continue
+				if isCombat {
+					// For combat, allow uneven teams (e.g. 3v4) as long as they are within 1 player
+					// of each other AND both teams have at least 3 players.
+					diff := len(blueTeam) - len(orangeTeam)
+					if diff != 0 {
+						if len(blueTeam) < 3 || len(orangeTeam) < 3 || diff > 1 || diff < -1 {
+							continue
+						}
+					}
+				} else {
+					if len(blueTeam) != len(orangeTeam) {
+						continue
+					}
 				}
 
 				// Create a copy of the candidate slice for this variant

--- a/server/evr_matchmaker_process.go
+++ b/server/evr_matchmaker_process.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/intinig/go-openskill/types"
 )
 
@@ -178,10 +179,18 @@ func groupEntriesSequentially(entries []runtime.MatchmakerEntry) [][]runtime.Mat
 		entries []runtime.MatchmakerEntry
 	}
 
+	modestr, _ := entries[0].GetProperties()["game_mode"].(string)
+	isCombat := modestr == evr.ModeCombatPublic.String()
+
 	ticketOrder := make([]string, 0)
 	ticketMap := make(map[string]*ticketGroup)
 	for _, entry := range entries {
 		ticket := entry.GetTicket()
+		if isCombat {
+			// For combat, treat each player as a separate ticket to allow party splitting
+			ticket = entry.GetPresence().GetSessionId()
+		}
+
 		if tg, ok := ticketMap[ticket]; ok {
 			tg.entries = append(tg.entries, entry)
 		} else {


### PR DESCRIPTION
### Key Changes:
1.  **Matchmaker**:
    *   Enforced `CountMultiple = 2`, so if 7 players are in queue, it creates a 3v3 match and leaves 1 player in the queue.
    *   Maintained **Party Splitting** for Combat, treating all party members as individual solo players during the drafting phase to ensure fair 2v2, 3v3, etc.
2.  **Backfiller (Joining Existing Games)**:
    *   **Combat Balance Enforcement**: For Combat only, backfilling is now restricted to actions that keep or restore balance.
    *   **Pair-Wise Joining**: If a match is already balanced (e.g., 3v3), the backfiller will now wait until at least **two** players are available in the queue and then add them as a pair (one to each team) to make it 4v4 instantly.
    *   **Restoring Balance**: If a match becomes uneven (e.g., someone left a 4v4, making it 3v4), the backfiller will add a single player to the smaller team to restore it to 4v4.
    *   **Party Splitting in Backfill**: Parties in the backfill queue are now automatically split for Combat, allowing them to fill slots on both teams to maintain a perfect balance.

### Verified Scenarios:
*   **Initial Match (7 Players)**: Creates a **3v3** match; the 7th player stays in the queue.
*   **Growth (3v3 Match + 2 Players in Queue)**: The backfiller detects the pair and joins them simultaneously to make it **4v4**.
*   **Fixing Leaves (3v4 Match + 1 Player in Queue)**: The backfiller joins the player to the smaller team to make it **4v4**.
*   **Single Player vs Even Match**: If a single player is in queue and all matches are even (3v3, 4v4), they will stay in the queue until a second player joins or a match becomes unbalanced.

These changes satisfy the requirement of "no uneven games" while allowing matches to grow fairly when enough players are available.