### PR TITLE
Party infinite matchmaking fix

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -83,11 +83,24 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 					}
 					entrantSessionIDs = append(entrantSessionIDs, sid)
 				}
+			} else if lobbyParams.Mode == evr.ModeSocialPublic || lobbyParams.Mode == evr.ModeSocialNPE {
+				// Social mode: skip the polling loop entirely. Social lobbies
+				// use find-or-create with party reservations, so the follower
+				// will naturally converge to the leader's lobby. Polling for
+				// the leader to settle is unnecessary and can silently timeout,
+				// leaving the client stuck in infinite matchmaking.
+				logger.Info("Follower in social mode, finding social lobby independently (party reservations will converge)")
+				lobbyParams.Level = evr.LevelUnspecified
+				followerEntrants, err := PrepareEntrantPresences(ctx, logger, p.nk, p.nk.sessionRegistry, lobbyParams, session.id)
+				if err != nil {
+					return fmt.Errorf("failed to prepare follower entrant: %w", err)
+				}
+				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
 			} else {
-				// Still a non-leader. Poll for the leader to settle into a
-				// match we can join. This covers followers at the main menu
-				// whose leader is in a closed/full match — they should wait
-				// rather than immediately erroring out.
+				// Still a non-leader in a non-social mode. Poll for the leader
+				// to settle into a match we can join. This covers followers at
+				// the main menu whose leader is in a closed/full match — they
+				// should wait rather than immediately erroring out.
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
@@ -107,20 +120,6 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 				} else {
 					if ctx.Err() != nil {
 						return ctx.Err()
-					}
-					// The follower could not follow the leader (e.g. leader is in a
-					// full arena/combat match). If the original request was for a
-					// social mode, redirect to social. Otherwise release the follower
-					// to independent matchmaking for their original mode.
-					if lobbyParams.Mode == evr.ModeSocialPublic || lobbyParams.Mode == evr.ModeSocialNPE {
-						logger.Info("Follower cannot join leader's match, redirecting to social lobby")
-						lobbyParams.Level = evr.LevelUnspecified
-						lobbyParams.SetPartySize(1)
-						followerEntrants, err := PrepareEntrantPresences(ctx, logger, p.nk, p.nk.sessionRegistry, lobbyParams, session.id)
-						if err != nil {
-							return fmt.Errorf("failed to prepare follower entrant: %w", err)
-						}
-						return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
 					}
 					// Non-social mode: release the follower to independent matchmaking.
 					logger.Info("Follower cannot join leader's match, releasing to independent matchmaking",

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -562,7 +562,7 @@ func TestPoll_LeaderStillMatchmaking_KeepsPolling(t *testing.T) {
 func TestPoll_LeaderStillMatchmaking_ThenSettles_FollowerInMatch_ReturnsTrue(t *testing.T) {
 	// Leader starts matchmaking, then finishes and settles into a match.
 	// Follower is also placed in the same match. Poll should eventually return true.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	env.setLeaderMatch(matchB)
@@ -637,7 +637,7 @@ func TestPoll_LeaderNilMatchID_KeepsPolling(t *testing.T) {
 func TestPoll_LeaderSwitchesMatches_FollowerInNewMatch_ReturnsTrue(t *testing.T) {
 	// Leader is in Match B, then switches to Match C during the poll.
 	// Follower ends up in Match C. Poll should detect Match C, not Match B.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	matchC := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
@@ -705,7 +705,7 @@ func TestPoll_LeaderChangesPartway_NewLeaderInMatch_ReturnsTrue(t *testing.T) {
 	// Original leader is matchmaking. A third player becomes leader during
 	// the poll and is already in a match. The follower is also in that match.
 	// Poll should detect the new leader's match.
-	env := newFollowTestEnv(t)
+	env := newFollowTestEnv(t).withMockNK(newMockFollowMatchRegistry())
 
 	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
 	newLeaderSID := uuid.Must(uuid.NewV4())

--- a/server/evr_lobby_join.go
+++ b/server/evr_lobby_join.go
@@ -26,9 +26,6 @@ func (p *EvrPipeline) lobbyJoin(ctx context.Context, logger *zap.Logger, session
 		logger.Warn("Match not found", zap.String("mid", matchID.UUID.String()))
 		return ErrMatchNotFound
 	}
-	if label.Mode != evr.ModeArenaPublic && label.Mode != evr.ModeCombatPublic {
-		LeavePartyStream(session)
-	}
 
 	lobbyParams.GroupID = label.GetGroupID()
 	lobbyParams.Mode = label.Mode

--- a/server/evr_lobby_session.go
+++ b/server/evr_lobby_session.go
@@ -79,14 +79,12 @@ func (p *EvrPipeline) handleLobbySessionRequest(ctx context.Context, logger *zap
 		return nil
 
 	case *evr.LobbyJoinSessionRequest:
-		LeavePartyStream(session)
 		p.nk.metrics.CustomCounter("lobby_join_session", lobbyParams.MetricsTags(), 1)
 		logger.Info("Joining session", zap.String("mid", lobbyParams.CurrentMatchID.String()), zap.String("role", TeamIndex(lobbyParams.Role).String()))
 
 		return p.lobbyJoin(ctx, logger, session, lobbyParams, lobbyParams.CurrentMatchID)
 
 	case *evr.LobbyCreateSessionRequest:
-
 		if len(lobbyParams.RequiredFeatures) > 0 {
 			// Reject public creation
 			if lobbyParams.Mode == evr.ModeArenaPublic || lobbyParams.Mode == evr.ModeCombatPublic || lobbyParams.Mode == evr.ModeSocialPublic {
@@ -94,7 +92,6 @@ func (p *EvrPipeline) handleLobbySessionRequest(ctx context.Context, logger *zap
 			}
 		}
 
-		LeavePartyStream(session)
 		p.nk.metrics.CustomCounter("lobby_create_session", lobbyParams.MetricsTags(), 1)
 		logger.Info("Creating session", zap.String("mode", lobbyParams.Mode.String()), zap.String("level", lobbyParams.Level.String()), zap.String("region", lobbyParams.RegionCode))
 		matchID, err = p.lobbyCreate(ctx, logger, session, lobbyParams)


### PR DESCRIPTION
Summary
The fix is a targeted change in 

evr_lobby_find.go

Root cause: When a game ends, leader and followers both enter lobbyFind() for social mode. The leader's JoinMatchmakingStream creates a matchmaking stream presence (even for social). The follower's TryFollowPartyLeader sees the leader in this stream and enters pollFollowPartyLeader, which can silently timeout — leaving the client stuck in "MATCHMAKING" with no response.

Fix: After TryFollowPartyLeader returns false, if the follower's mode is social (ModeSocialPublic/ModeSocialNPE), immediately redirect to lobbyFindOrCreateSocial instead of entering the polling loop. The party reservation system ensures the follower converges to the leader's social lobby without needing to poll.



I hope this is the fix for it.