### PR TITLE
Matchmaker changes

### DIFF
--- a/server/evr_lobby_matchmake.go
+++ b/server/evr_lobby_matchmake.go
@@ -126,7 +126,7 @@ var DefaultMatchmakerTicketConfigs = map[evr.Symbol]MatchmakingTicketParameters{
 		IncludeEarlyQuitPenalty: false,
 	},
 	evr.ModeCombatPublic: {
-		MinCount:                4,
+		MinCount:                2,
 		MaxCount:                100,
 		CountMultiple:           2,
 		IncludeSBMMRanges:       false,

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -372,6 +372,9 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 					// Original sequential filling (best groups fill blue team first)
 					for _, g := range groups {
 						ticket := g[0].GetTicket()
+						if isCombat {
+							ticket = g[0].GetPresence().GetUserId()
+						}
 						if len(blueTeam)+len(g) <= teamSize {
 							blueTeam = append(blueTeam, g...)
 							blueRatings = append(blueRatings, ticketRatings[ticket]...)
@@ -393,6 +396,9 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 					// - 8th → Blue
 					for idx, g := range groups {
 						ticket := g[0].GetTicket()
+						if isCombat {
+							ticket = g[0].GetPresence().GetUserId()
+						}
 
 						// Determine which team gets this group using snake pattern
 						// Group index 0: Blue, 1-2: Orange, 3-4: Blue, 5-6: Orange, 7: Blue


### PR DESCRIPTION
### Findings:
1.  **Matchmaker Minimum Player Count**: In `evr_lobby_matchmake.go`, the `MinCount` for Combat was still set to `4`. This meant Nakama's internal matchmaker would not even consider pairing 2 solo players until a "fallback" refresh occurred (which could take several minutes).
2.  **Team Rating Lookup Bug**: I found a bug in the team splitting logic (`evr_matchmaker_prediction.go`) where it was trying to look up player ratings using their original party ticket ID instead of their individual User ID. For Combat mode (where we split parties), this would result in "empty" ratings being used for team balancing, which could lead to inconsistent match predictions.

### Changes Made:
*   **[MODIFY] [evr_lobby_matchmake.go](file:///j:/EchoVR-Tools-Launcher/nakama/server/evr_lobby_matchmake.go)**: Updated the default `MinCount` for Combat Public matches from `4` to `2`. This allows the matchmaker to immediately consider forming 1v1 matches as soon as 2 players are available.
*   **[MODIFY] [evr_matchmaker_prediction.go](file:///j:/EchoVR-Tools-Launcher/nakama/server/evr_matchmaker_prediction.go)**: Fixed the rating lookup logic to correctly use individual User IDs when splitting parties in Combat mode.

### Verification:
*   Ran the unit test suite `TestCombatMatchmakingRules`.
*   Confirmed that `Combat 1v1 (Old)` (simulating players in queue for >60s) still passes and correctly forms a match.
*   Confirmed that the 60-second dynamic delay is still active for small matches to prevent premature 1v1s when more players might be joining soon.

These changes should ensure that 1v1 matches start as soon as the 60-second queue delay has elapsed.