### PR TITLE
Unblock Cosmetics

### DIFF
--- a/server/evr/core_account.go
+++ b/server/evr/core_account.go
@@ -935,27 +935,26 @@ type ArenaUnlocks struct {
 	Tag0005                     bool `json:"rwd_tag_0005,omitempty"`
 	Tag0006                     bool `json:"rwd_tag_0006,omitempty"`
 	Tag0007                     bool `json:"rwd_tag_0007,omitempty"`
-	Tag0012                     bool `json:"rwd_tag_0012" validate:"blocked"`
-	Tag0013                     bool `json:"rwd_tag_0013" validate:"blocked"`
-	Tag0014                     bool `json:"rwd_tag_0014" validate:"blocked"`
-	Tag0015                     bool `json:"rwd_tag_0015" validate:"blocked"`
-	Tag0018                     bool `json:"rwd_tag_0018" validate:"blocked"`
-	Tag0019                     bool `json:"rwd_tag_0019" validate:"blocked"`
-	Tag0020                     bool `json:"rwd_tag_0020" validate:"blocked"`
-	Tag0021                     bool `json:"rwd_tag_0021" validate:"blocked"`
-	Tag0023                     bool `json:"rwd_tag_0023" validate:"blocked"`
-	Tag0025                     bool `json:"rwd_tag_0025" validate:"blocked"`
-	Tag0026                     bool `json:"rwd_tag_0026" validate:"blocked"`
-	Tag0027                     bool `json:"rwd_tag_0027" validate:"blocked"`
-	Tag0028                     bool `json:"rwd_tag_0028" validate:"blocked"`
-	Tag0029                     bool `json:"rwd_tag_0029" validate:"blocked"`
-	Tag0030                     bool `json:"rwd_tag_0030" validate:"blocked"`
-	Tag0031                     bool `json:"rwd_tag_0031" validate:"blocked"`
-	Tag0033                     bool `json:"rwd_tag_0033" validate:"blocked"`
-	Tag0034                     bool `json:"rwd_tag_0034" validate:"blocked"`
-	// TODO: identify the VRML event these belong to (emissive_0038 = "Springtime"; 2-tier event between S5 and S6)
-	TagVRMLUnknown0038          bool `json:"rwd_tag_0038" validate:"restricted"`
-	TagVRMLUnknown0039          bool `json:"rwd_tag_0039" validate:"restricted"`
+	TagExhaust                  bool `json:"rwd_tag_0012,omitempty"`
+	TagShiv                     bool `json:"rwd_tag_0013,omitempty"`
+	TagBarbed                   bool `json:"rwd_tag_0014,omitempty"`
+	TagBoost                    bool `json:"rwd_tag_0015,omitempty"`
+	TagLeviathan                bool `json:"rwd_tag_0018,omitempty"`
+	TagHunter                   bool `json:"rwd_tag_0019,omitempty"`
+	TagAmbush                   bool `json:"rwd_tag_0020,omitempty"`
+	TagSwell                    bool `json:"rwd_tag_0021,omitempty"`
+	TagOrnate                   bool `json:"rwd_tag_0023,omitempty"`
+	TagGardenia                 bool `json:"rwd_tag_0025,omitempty"`
+	TagDivergence               bool `json:"rwd_tag_0026,omitempty"`
+	TagMosaic                   bool `json:"rwd_tag_0027,omitempty"`
+	TagStriation                bool `json:"rwd_tag_0028,omitempty"`
+	TagBanderole                bool `json:"rwd_tag_0029,omitempty"`
+	TagBolt                     bool `json:"rwd_tag_0030,omitempty"`
+	TagTatter                   bool `json:"rwd_tag_0031,omitempty"`
+	TagLiana                    bool `json:"rwd_tag_0033,omitempty"`
+	TagShuriken                 bool `json:"rwd_tag_0034,omitempty"`
+	TagStand                    bool `json:"rwd_tag_0038,omitempty"`
+	TagLiminal                  bool `json:"rwd_tag_0039,omitempty"`
 	TagDefault                  bool `json:"rwd_tag_default,omitempty"`
 	TagDeveloper                bool `json:"rwd_tag_s1_developer" validate:"restricted"`
 	TagDiamonds                 bool `json:"rwd_tag_diamonds_a,omitempty"`

--- a/server/evr_runtime_vrml_entitlements.go
+++ b/server/evr_runtime_vrml_entitlements.go
@@ -51,10 +51,9 @@ const (
 	TagVRMLS5         = "rwd_tag_0035"
 	TagVRMLS5Champion = "rwd_tag_0037"
 	TagVRMLS5Finalist = "rwd_tag_0036"
-	// TODO: identify the VRML event these belong to (emissive_0038 = "Springtime"; 2-tier event between S5 and S6).
-	// Add the season ID constant and a vrmlCosmeticMap entry once the event is identified.
-	TagVRMLUnknown0038 = "rwd_tag_0038"
-	TagVRMLUnknown0039 = "rwd_tag_0039"
+	// rwd_tag_0038: Stand store item; rwd_tag_0039: Liminal event item.
+	TagStand   = "rwd_tag_0038"
+	TagLiminal = "rwd_tag_0039"
 	TagVRMLS6          = "rwd_tag_0040"
 	TagVRMLS6Champion = "rwd_tag_0042"
 	TagVRMLS6Finalist = "rwd_tag_0041"


### PR DESCRIPTION
20 tags were blocked/restricted, all of these tags were available before shutdown and are either store items or echo pass items.

**rwd_tag_0012: Exhaust s5 tag (safe)
rwd_tag_0013: Shiv s5 tag (safe)
rwd_tag_0014: Barbed s5 tag (safe)
rwd_tag_0015: Boost s5 tag (safe)
rwd_tag_0018: Leviathan s6 tag (safe)
rwd_tag_0019: Hunter s6 tag (safe)
rwd_tag_0020: Ambush s6 tag (safe)
rwd_tag_0021: Swell s6 tag (safe)
rwd_tag_0023: Ornate store item (safe)
rwd_tag_0025: Gardenia store item (safe)
rwd_tag_0026: Divergence store item (safe)
rwd_tag_0027: Mosaic s7 tag (safe)
rwd_tag_0028: Striation s7 tag (safe)
rwd_tag_0029: Banderole s7 tag (safe)
rwd_tag_0030: Bolt s7 tag (safe)
rwd_tag_0031: Tatter s7 tag (safe)
rwd_tag_0033: Liana store item (safe)
rwd_tag_0034: Shuriken store item (safe)
rwd_tag_0038: Stand store item (safe)
rwd_tag_0039: Liminal event item (safe)**

Used Cosmetics-Editor to find all of these items.