### PR TITLE
Fix 99+ notifications on loading into lobby

### DIFF
--- a/server/evr/core_account.go
+++ b/server/evr/core_account.go
@@ -35,10 +35,10 @@ type EarlyQuitFeatures struct {
 }
 
 type Customization struct {
-	BattlePassSeasonPoiVersion uint64 `json:"battlepass_season_poi_version,omitempty"` // Battle pass season point of interest version (manually set to 3246)
-	NewUnlocksPoiVersion       uint64 `json:"new_unlocks_poi_version,omitempty"`       // New unlocks point of interest version
-	StoreEntryPoiVersion       uint64 `json:"store_entry_poi_version,omitempty"`       // Store entry point of interest version
-	ClearNewUnlocksVersion     uint64 `json:"clear_new_unlocks_version,omitempty"`     // Clear new unlocks version
+	BattlePassSeasonPoiVersion uint64 `json:"battlepass_season_poi_version"` // Battle pass season point of interest version (manually set to 3246)
+	NewUnlocksPoiVersion       uint64 `json:"new_unlocks_poi_version"`       // New unlocks point of interest version
+	StoreEntryPoiVersion       uint64 `json:"store_entry_poi_version"`       // Store entry point of interest version
+	ClearNewUnlocksVersion     uint64 `json:"clear_new_unlocks_version"`     // Clear new unlocks version
 }
 
 type Players struct {
@@ -1289,9 +1289,9 @@ func NewClientProfile() ClientProfile {
 			OrangeTintTabSeen: Versioned{Version: 1},
 		},
 		Customization: &Customization{
-			BattlePassSeasonPoiVersion: 0,
+			BattlePassSeasonPoiVersion: 3246,
 			NewUnlocksPoiVersion:       1,
-			StoreEntryPoiVersion:       0,
+			StoreEntryPoiVersion:       1,
 			ClearNewUnlocksVersion:     1,
 		},
 		Social: ClientSocial{

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -489,6 +489,15 @@ func BuildEVRProfileFromAccount(account *api.Account) (*EVRProfile, error) {
 	if a.NewUnlocks == nil {
 		a.NewUnlocks = make([]int64, 0)
 	}
+
+	if a.CustomizationPOIs == nil {
+		a.CustomizationPOIs = &evr.Customization{
+			BattlePassSeasonPoiVersion: 3246,
+			NewUnlocksPoiVersion:       1,
+			StoreEntryPoiVersion:       1,
+			ClearNewUnlocksVersion:     1,
+		}
+	}
 	a.account = account
 	return a, nil
 }

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -239,10 +239,8 @@ func NewClientProfile(ctx context.Context, evrProfile *EVRProfile, serverProfile
 		newUnlocks = slices.Delete(newUnlocks, i, i+1)
 	}
 
-	var customizationPOIs *evr.Customization
-	if evrProfile.CustomizationPOIs != nil {
-		customizationPOIs = evrProfile.CustomizationPOIs
-	} else {
+	customizationPOIs := evrProfile.CustomizationPOIs
+	if customizationPOIs == nil {
 		customizationPOIs = &evr.Customization{
 			BattlePassSeasonPoiVersion: 3246,
 			NewUnlocksPoiVersion:       1,


### PR DESCRIPTION
1.  **Updated Version Defaults**: Changed the default `BattlePassSeasonPoiVersion` from `0` to `3246` (the version used by the last official EchoVR season) in both the profile initialization and the cache logic.
2.  **Removed `omitempty`**: Removed the `omitempty` JSON tag from the version fields in `server/evr/core_account.go`. This ensures that even if a version is 0, it is explicitly sent to the client instead of being skipped.
3.  **Ensured Persistence**: Updated the profile loading logic in `server/evr_account.go` to automatically initialize these versions if they are missing from an existing account. This ensures that the corrected versions are saved to your database the next time you log in.
4.  **Synced Store Versions**: Ensured `StoreEntryPoiVersion` and other relevant versions are also set to `1` by default to clear any persistent store-related notifications.

### Files Updated:
- `server/evr/core_account.go`
- `server/evr_account.go`
- `server/evr_profile_cache.go`

These changes should permanently clear the "99+ notifications" after your next login and profile update.