### PR TITLE
infinite matchmaking when in parties

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -75,7 +75,6 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 
 	if lobbyGroup != nil {
 		if !isLeader {
-
 			if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
 				return nil
 			}

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -27,12 +27,26 @@ var ErrCreateLock = errors.New("failed to acquire create lock")
 func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyParams *LobbySessionParameters) error {
 
 	startTime := time.Now()
+	entrantSessionIDs := []uuid.UUID{session.id}
 
-	// If the leader is heading to a social lobby, force the mode to social.
-	if p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, nil) {
-		logger.Info("Leader is heading to a social lobby, forcing social mode for follower")
-		lobbyParams.Mode = evr.ModeSocialPublic
-		lobbyParams.Level = evr.LevelUnspecified
+	var lobbyGroup *LobbyGroup
+	var memberSessionIDs []uuid.UUID
+	var isLeader bool
+
+	// Resolve party state early if applicable
+	if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
+		var err error
+		lobbyGroup, memberSessionIDs, isLeader, err = p.configureParty(ctx, logger, session, lobbyParams)
+		if err != nil {
+			return fmt.Errorf("failed to join party: %w", err)
+		}
+
+		// Synchronize mode if the leader is heading to Social
+		if !isLeader && p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, lobbyGroup) {
+			logger.Info("Leader is heading to a social lobby, forcing social mode for follower")
+			lobbyParams.Mode = evr.ModeSocialPublic
+			lobbyParams.Level = evr.LevelUnspecified
+		}
 	}
 
 	// Authorize the session
@@ -59,19 +73,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 	// Monitor the matchmaking status stream, canceling the context if the stream is closed.
 	go p.monitorMatchmakingStream(ctx, logger, session, lobbyParams, cancel)
 
-	entrantSessionIDs := []uuid.UUID{session.id}
-
-	var lobbyGroup *LobbyGroup
-
-	if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
-		var err error
-		var isLeader bool
-		var memberSessionIDs []uuid.UUID
-		lobbyGroup, memberSessionIDs, isLeader, err = p.configureParty(ctx, logger, session, lobbyParams)
-		if err != nil {
-			return fmt.Errorf("failed to join party: %w", err)
-		}
-
+	if lobbyGroup != nil {
 		if !isLeader {
 
 			if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
@@ -716,17 +718,6 @@ func (p *EvrPipeline) CheckServerPing(ctx context.Context, logger *zap.Logger, s
 }
 
 func (p *EvrPipeline) isLeaderHeadingToSocial(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup) bool {
-	if lobbyGroup == nil {
-		if lobbyParams.PartyGroupName == "" || lobbyParams.PartyGroupName == "tablet" {
-			return false
-		}
-		// Try to resolve the party group if not provided
-		var err error
-		lobbyGroup, _, _, err = p.configureParty(ctx, logger, session, lobbyParams)
-		if err != nil {
-			return false
-		}
-	}
 	leader := lobbyGroup.GetLeader()
 	if leader == nil || leader.SessionId == session.id.String() {
 		return false

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -66,6 +66,15 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 		}
 
 		if !isLeader {
+			// If the leader is heading to a social lobby, force the follower into social mode.
+			// This prevents the follower from getting stuck in arena matchmaking when the
+			// leader has moved on to a social lobby.
+			if p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, lobbyGroup) {
+				logger.Info("Leader is heading to a social lobby, forcing social mode for follower")
+				lobbyParams.Mode = evr.ModeSocialPublic
+				lobbyParams.Level = evr.LevelUnspecified
+			}
+
 			if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
 				return nil
 			}
@@ -705,6 +714,48 @@ func (p *EvrPipeline) CheckServerPing(ctx context.Context, logger *zap.Logger, s
 	}
 
 	return nil
+}
+
+func (p *EvrPipeline) isLeaderHeadingToSocial(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup) bool {
+	leader := lobbyGroup.GetLeader()
+	if leader == nil || leader.SessionId == session.id.String() {
+		return false
+	}
+
+	leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
+	leaderUserID := uuid.FromStringOrNil(leader.UserId)
+
+	// 1. Check if the leader is already in a social lobby.
+	matchStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: leaderSessionID,
+		Label:   StreamLabelMatchService,
+	}
+	if presence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, matchStream, leaderUserID); presence != nil {
+		if matchID := MatchIDFromStringOrNil(presence.GetStatus()); !matchID.IsNil() {
+			if label, err := MatchLabelByID(ctx, p.nk, matchID); err == nil && label != nil {
+				if label.Mode == evr.ModeSocialPublic || label.Mode == evr.ModeSocialNPE {
+					return true
+				}
+			}
+		}
+	}
+
+	// 2. Check if the leader is matchmaking for a social lobby.
+	mmStream := PresenceStream{
+		Mode:    StreamModeMatchmaking,
+		Subject: lobbyParams.GroupID,
+	}
+	if presence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, mmStream, leaderUserID); presence != nil {
+		var leaderParams LobbySessionParameters
+		if err := json.Unmarshal([]byte(presence.GetStatus()), &leaderParams); err == nil {
+			if leaderParams.Mode == evr.ModeSocialPublic || leaderParams.Mode == evr.ModeSocialNPE {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func PrepareEntrantPresences(ctx context.Context, logger *zap.Logger, nk runtime.NakamaModule, sessionRegistry SessionRegistry, lobbyParams *LobbySessionParameters, sessionIDs ...uuid.UUID) ([]*EvrMatchPresence, error) {

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -28,7 +28,14 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 
 	startTime := time.Now()
 
-	// Do authorization checks related to the guild.
+	// If the leader is heading to a social lobby, force the mode to social.
+	if p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, nil) {
+		logger.Info("Leader is heading to a social lobby, forcing social mode for follower")
+		lobbyParams.Mode = evr.ModeSocialPublic
+		lobbyParams.Level = evr.LevelUnspecified
+	}
+
+	// Authorize the session
 	if err := p.lobbyAuthorize(ctx, logger, session, lobbyParams); err != nil {
 		return err
 	}
@@ -66,14 +73,6 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 		}
 
 		if !isLeader {
-			// If the leader is heading to a social lobby, force the follower into social mode.
-			// This prevents the follower from getting stuck in arena matchmaking when the
-			// leader has moved on to a social lobby.
-			if p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, lobbyGroup) {
-				logger.Info("Leader is heading to a social lobby, forcing social mode for follower")
-				lobbyParams.Mode = evr.ModeSocialPublic
-				lobbyParams.Level = evr.LevelUnspecified
-			}
 
 			if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
 				return nil
@@ -717,6 +716,17 @@ func (p *EvrPipeline) CheckServerPing(ctx context.Context, logger *zap.Logger, s
 }
 
 func (p *EvrPipeline) isLeaderHeadingToSocial(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup) bool {
+	if lobbyGroup == nil {
+		if lobbyParams.PartyGroupName == "" || lobbyParams.PartyGroupName == "tablet" {
+			return false
+		}
+		// Try to resolve the party group if not provided
+		var err error
+		lobbyGroup, _, _, err = p.configureParty(ctx, logger, session, lobbyParams)
+		if err != nil {
+			return false
+		}
+	}
 	leader := lobbyGroup.GetLeader()
 	if leader == nil || leader.SessionId == session.id.String() {
 		return false

--- a/server/evr_lobby_force_social_test.go
+++ b/server/evr_lobby_force_social_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
 
-func TestLobbyFind_ForceSocialFollower_Reproduction(t *testing.T) {
+func TestLobbyFind_ForceSocialFollower_Unit(t *testing.T) {
 	env := newFollowTestEnv(t)
 	ctx := context.Background()
 	logger := loggerForTest(t)
@@ -27,12 +27,17 @@ func TestLobbyFind_ForceSocialFollower_Reproduction(t *testing.T) {
 	env.params.Mode = evr.ModeArenaPublic
 	env.params.GroupID = env.groupID
 
-	// Simulation: This is the logic we're adding to lobbyFind
-	if env.pipeline.isLeaderHeadingToSocial(ctx, logger, env.session, env.params, env.lobbyGroup) {
+	// Verify the helper function directly
+	isHeading := env.pipeline.isLeaderHeadingToSocial(ctx, logger, env.session, env.params, env.lobbyGroup)
+	if !isHeading {
+		t.Errorf("Expected isLeaderHeadingToSocial to return true")
+	}
+
+	// Simulation: Verify the logic effect
+	if isHeading {
 		env.params.Mode = evr.ModeSocialPublic
 	}
 
-	// Verify the result
 	if env.params.Mode != evr.ModeSocialPublic {
 		t.Errorf("Expected follower mode to be forced to %s, but got %s", evr.ModeSocialPublic.String(), env.params.Mode.String())
 	}

--- a/server/evr_lobby_force_social_test.go
+++ b/server/evr_lobby_force_social_test.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+func TestLobbyFind_ForceSocialFollower_Reproduction(t *testing.T) {
+	env := newFollowTestEnv(t)
+	ctx := context.Background()
+	logger := loggerForTest(t)
+
+	// Leader is matchmaking for Social
+	leaderParams := &LobbySessionParameters{
+		Mode:    evr.ModeSocialPublic,
+		GroupID: env.groupID,
+	}
+	// Track leader's matchmaking presence
+	env.tracker.Track(ctx, env.leaderSID,
+		PresenceStream{Mode: StreamModeMatchmaking, Subject: env.groupID},
+		env.leaderUID,
+		PresenceMeta{Status: leaderParams.String()})
+
+	// Follower starts with Arena mode
+	env.params.Mode = evr.ModeArenaPublic
+	env.params.GroupID = env.groupID
+
+	// Simulation: This is the logic we're adding to lobbyFind
+	if env.pipeline.isLeaderHeadingToSocial(ctx, logger, env.session, env.params, env.lobbyGroup) {
+		env.params.Mode = evr.ModeSocialPublic
+	}
+
+	// Verify the result
+	if env.params.Mode != evr.ModeSocialPublic {
+		t.Errorf("Expected follower mode to be forced to %s, but got %s", evr.ModeSocialPublic.String(), env.params.Mode.String())
+	}
+}


### PR DESCRIPTION
1.  **Added `isLeaderHeadingToSocial`**: This helper function checks the leader's current status via the Nakama tracker. It identifies if the leader is already in a social lobby or if they are currently matchmaking for one by parsing their `LobbySessionParameters` from the matchmaking stream.
2.  **Updated `lobbyFind`**: Right before the follower attempts to follow the leader, it now calls `isLeaderHeadingToSocial`. If true, the follower's `lobbyParams.Mode` is overridden to `evr.ModeSocialPublic`.
3.  **Ensured Convergence**: By forcing the mode to Social, the follower will hit the existing logic that calls `lobbyFindOrCreateSocial`, which uses party reservations to ensure all members land in the same lobby, even if their clients were originally requesting Arena.

This should resolve the "rubber-banding" issues where followers would remain stuck in Arena matchmaking while the leader has already moved to a Social lobby.