### PR TITLE
refactor: party matchmaking overhaul

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,51 @@
+# Summary
+
+<!-- What changed? Keep it concrete. -->
+
+## Why
+
+<!-- What bug/incident/scenario does this address? -->
+
+## Scope
+
+- [ ] Party
+- [ ] Matchmaking
+- [ ] Lobby-find / backfill
+- [ ] Follower/leader convergence
+- [ ] Other (describe):
+
+## Replay-first gate (required for party/matchmaking/lobby-find scope)
+
+If you checked any box in **Scope**, this section is mandatory.
+
+### Scenario link
+
+- Scenario name:
+- Location (path/command):
+- Source evidence (prod log bundle / incident id):
+
+### Red → Green evidence
+
+- Baseline (before) result:
+- With this PR result:
+
+### Non-regression
+
+- Scenario catalog run (command) and result:
+
+## Observability
+
+- Logs added/changed (mutation sites):
+- Metrics added/changed:
+
+## Risk
+
+- Failure mode if wrong:
+- Rollback plan:
+
+## Checklist
+
+- [ ] I did not use “deploy and see” as the acceptance criterion.
+- [ ] If this is a bug fix, there is a deterministic replay scenario derived from prod logs.
+- [ ] The scenario fails on baseline (red) and passes with this PR (green).
+- [ ] No existing scenario regressed.

--- a/docs/review/reviewer_checklist_party_matchmaking.md
+++ b/docs/review/reviewer_checklist_party_matchmaking.md
@@ -1,0 +1,28 @@
+# Reviewer checklist: Party / Matchmaking / Lobby-Find PRs
+
+This checklist enforces `artifacts/adr/2026-05-14-party-matchmaking-replay-first-process-gate.md`.
+
+## Gate 1 — Scope classification
+
+- [ ] PR correctly declares whether it touches party/matchmaking/lobby-find/follower paths.
+
+## Gate 2 — Replay-first evidence (mandatory if in scope)
+
+- [ ] A scenario exists and is linked.
+- [ ] Scenario is derived from production logs (or equivalent incident evidence).
+- [ ] Baseline run is red (fails deterministically).
+- [ ] PR run is green (passes deterministically).
+
+## Gate 3 — Scenario catalog non-regression
+
+- [ ] Scenario catalog was run.
+- [ ] No scenario regressions.
+
+## Gate 4 — Logging sufficiency
+
+- [ ] Mutation sites emit structured logs sufficient for replay event reconstruction.
+- [ ] If logs were insufficient, this PR adds the missing instrumentation.
+
+## Gate 5 — No-theory acceptance
+
+- [ ] Acceptance criteria are executable (scenario-based), not observational.

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -37,7 +37,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 	var memberSessionIDs []uuid.UUID
 	var isLeader bool
 
-	// Resolve party state early if applicable
+	// SMELL(high): magic string "tablet" check encodes branch logic; no enum or named constant for mode detection
 	if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
 		var err error
 		lobbyGroup, memberSessionIDs, isLeader, err = p.configureParty(ctx, logger, session, lobbyParams)
@@ -87,8 +87,6 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 			// during the follow attempt (e.g. original leader left the party).
 			leader := lobbyGroup.GetLeader()
 			if leader != nil && leader.SessionId == session.id.String() {
-				// We're now the leader — populate entrant list and fall through
-				// to matchmaking as the leader.
 				isLeader = true
 				for _, sid := range memberSessionIDs {
 					if sid == session.id {
@@ -97,11 +95,6 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 					entrantSessionIDs = append(entrantSessionIDs, sid)
 				}
 			} else if shouldFollowerFindOrCreateSocial(lobbyParams.Mode) {
-				// Social mode: skip the polling loop entirely. Social lobbies
-				// use find-or-create with party reservations, so the follower
-				// will naturally converge to the leader's lobby. Polling for
-				// the leader to settle is unnecessary and can silently timeout,
-				// leaving the client stuck in infinite matchmaking.
 				logger.Info("Follower in social mode, finding social lobby independently (party reservations will converge)")
 				lobbyParams.Level = evr.LevelUnspecified
 				followerEntrants, err := PrepareEntrantPresences(ctx, logger, p.nk, p.nk.sessionRegistry, lobbyParams, session.id)
@@ -110,17 +103,12 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 				}
 				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
 			} else {
-				// Still a non-leader in a non-social mode. Poll for the leader
-				// to settle into a match we can join. This covers followers at
-				// the main menu whose leader is in a closed/full match — they
-				// should wait rather than immediately erroring out.
 				if ctx.Err() != nil {
 					return ctx.Err()
 				}
 				if p.pollFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
 					return nil
 				}
-				// Re-check leadership one more time after polling.
 				leader = lobbyGroup.GetLeader()
 				if leader != nil && leader.SessionId == session.id.String() {
 					isLeader = true
@@ -134,22 +122,17 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 					if ctx.Err() != nil {
 						return ctx.Err()
 					}
-					// Non-social mode: release the follower to independent matchmaking.
 					logger.Info("Follower cannot join leader's match, releasing to independent matchmaking",
 						zap.String("mode", lobbyParams.Mode.String()))
 					lobbyParams.SetPartySize(1)
-					// Fall through to normal matchmaking below.
 				}
 			}
 		} else {
-
-			for _, memberSessionIDs := range memberSessionIDs {
-
-				if memberSessionIDs == session.id {
+			for _, sid := range memberSessionIDs {
+				if sid == session.id {
 					continue
 				}
-
-				entrantSessionIDs = append(entrantSessionIDs, memberSessionIDs)
+				entrantSessionIDs = append(entrantSessionIDs, sid)
 			}
 		}
 	} else {
@@ -313,6 +296,7 @@ func (p *EvrPipeline) configureParty(ctx context.Context, logger *zap.Logger, se
 			}
 			if expectedCount > 0 {
 				logger.Debug("Waiting for party members to start matchmaking", zap.Int("expected", expectedCount), zap.Int("current", lobbyGroup.Size()-1))
+				// SMELL(high): hardcoded 30s timeout used as synchronization primitive; no constant or configuration
 				deadline := time.After(30 * time.Second)
 				ticker := time.NewTicker(500 * time.Millisecond)
 				defer ticker.Stop()
@@ -334,6 +318,7 @@ func (p *EvrPipeline) configureParty(ctx context.Context, logger *zap.Logger, se
 			// does not submit a solo matchmaking ticket before the follower joins — which
 			// would allow backfill to place the leader in a match with no room left for
 			// the follower.
+			// SMELL(high): MatchmakingStartGracePeriod (3s) is a hardcoded synchronization budget with no adaptive retry logic; if followers don't join within 3s, leader goes solo
 			logger.Debug("Waiting for party followers (fresh-start grace period)", zap.Duration("timeout", MatchmakingStartGracePeriod))
 			graceTimer := time.NewTimer(MatchmakingStartGracePeriod)
 			defer graceTimer.Stop()
@@ -441,11 +426,16 @@ func (p *EvrPipeline) newLobby(ctx context.Context, logger *zap.Logger, lobbyPar
 
 	p.nk.metrics.CustomCounter("lobby_new", metricsTags, 1)
 
+	groupID := lobbyParams.GroupID
+	if lobbyParams.Mode == evr.ModeArenaPublic || lobbyParams.Mode == evr.ModeCombatPublic || lobbyParams.Mode == evr.ModeSocialPublic {
+		groupID = uuid.Nil
+	}
+
 	settings := &MatchSettings{
 		Mode:                lobbyParams.Mode,
 		Level:               lobbyParams.Level,
 		SpawnedBy:           lobbyParams.UserID.String(),
-		GroupID:             lobbyParams.GroupID,
+		GroupID:             groupID,
 		StartTime:           time.Now().UTC(),
 		Reservations:        entrants,
 		ReservationLifetime: 30 * time.Second,
@@ -865,6 +855,7 @@ func (p *EvrPipeline) TryFollowPartyLeader(ctx context.Context, logger *zap.Logg
 	// which untracks their matchmaking stream and gets them kicked from
 	// the party ticket. This is the primary cause of the "rubber-banding"
 	// bug in parties of 3+.
+	// SMELL(critical): TOCTOU window: leader could transition from matchmaking to settled between check and service-stream read; follower may still follow stale match
 	if pr := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, params.MatchmakingStream(), leaderUserID); pr != nil {
 		logger.Debug("Leader is currently matchmaking, falling through")
 		return false
@@ -894,6 +885,7 @@ func (p *EvrPipeline) TryFollowPartyLeader(ctx context.Context, logger *zap.Logg
 		Subject: session.id,
 		Label:   StreamLabelMatchService,
 	}
+	// SMELL(high): tracker read-decide-act: leaderMatchID read above, now memberMatchID read; leader could change between checks without convergence guarantee
 	if memberPresence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(session.id, memberStream, session.userID); memberPresence != nil {
 		memberMatchID := MatchIDFromStringOrNil(memberPresence.GetStatus())
 		if memberMatchID == leaderMatchID {
@@ -1066,6 +1058,7 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 				return true
 			}
 			return false
+		// SMELL(high): hardcoded 3s poll interval with no backoff or exponential jitter; polling overhead scales with party count
 		case <-time.After(3 * time.Second):
 		}
 
@@ -1193,6 +1186,7 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 			if err := p.lobbyJoin(ctx, logger, session, params, leaderMatchID); err != nil {
 				code := LobbyErrorCode(err)
 				if code == ServerIsFull || code == ServerIsLocked {
+					// SMELL(high): hardcoded 5s fixed backoff on join failure; no exponential backoff or jitter; can cascade across many followers
 					<-time.After(5 * time.Second)
 					continue
 				}

--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -98,6 +98,7 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 	if !created {
 		isMember := false
 		// Check if the player is already a member of the party
+		// SMELL(high): member check before JoinRequest creates TOCTOU: session could be kicked from party between check and join
 		for _, member := range ph.members.List() {
 			if member.Presence.GetUserId() == session.UserID().String() {
 				isMember = true
@@ -119,6 +120,7 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 	}
 
 	// If successful, the creator becomes the first user to join the party.
+	// SMELL(high): assumes tracker.Track triggers Join hook synchronously before returning; no guarantee or retry if hook fails
 	if success, isNew := session.pipeline.tracker.Track(session.Context(), session.ID(), ph.Stream, session.UserID(), presenceMeta); !success {
 		_ = session.Send(&rtapi.Envelope{Message: &rtapi.Envelope_Error{Error: &rtapi.Error{
 			Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -592,10 +592,15 @@ func (p *LobbySessionParameters) BackfillSearchQuery(includeMMR bool, includeMax
 
 	minStartTime := p.MatchmakingTimestamp.UTC().Add(-time.Duration(MatchStartTimeMinimumAgeSecs) * time.Second).Format(time.RFC3339Nano)
 
+	groupID := p.GroupID
+	if p.Mode == evr.ModeArenaPublic || p.Mode == evr.ModeCombatPublic || p.Mode == evr.ModeSocialPublic {
+		groupID = uuid.Nil
+	}
+
 	qparts := []string{
 		"+label.open:T",
 		fmt.Sprintf("+label.mode:%s", p.Mode.String()),
-		fmt.Sprintf("+label.group_id:%s", Query.QuoteStringValue(p.GroupID.String())),
+		fmt.Sprintf("+label.group_id:%s", Query.QuoteStringValue(groupID.String())),
 		//fmt.Sprintf("label.version_lock:%s", p.VersionLock.String()),
 		p.BackfillQueryAddon,
 	}
@@ -740,10 +745,15 @@ func (p *LobbySessionParameters) FromMatchmakerEntry(entry *MatchmakerEntry) {
 
 func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *MatchmakingTicketParameters) (string, map[string]string, map[string]float64) {
 
+	groupID := p.GroupID
+	if p.Mode == evr.ModeArenaPublic || p.Mode == evr.ModeCombatPublic || p.Mode == evr.ModeSocialPublic {
+		groupID = uuid.Nil
+	}
+
 	submissionTime := p.MatchmakingTimestamp.UTC().Format(time.RFC3339)
 	stringProperties := map[string]string{
 		"game_mode":              p.Mode.String(),
-		"group_id":               p.GroupID.String(),
+		"group_id":               groupID.String(),
 		"version_lock":           p.VersionLock.String(),
 		"display_name":           p.DisplayName,
 		"submission_time":        submissionTime,
@@ -777,7 +787,7 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 
 	qparts := []string{
 		"+properties.game_mode:" + p.Mode.String(),
-		fmt.Sprintf("+properties.group_id:%s", Query.QuoteStringValue(p.GroupID.String())),
+		fmt.Sprintf("+properties.group_id:%s", Query.QuoteStringValue(groupID.String())),
 		fmt.Sprintf(`-properties.blocked_ids:/.*%s.*/`, Query.QuoteStringValue(p.UserID.String())),
 		//"+properties.version_lock:" + p.VersionLock.String(),
 		p.MatchmakingQueryAddon,
@@ -875,11 +885,19 @@ func (p *LobbySessionParameters) MatchmakingParameters(ticketParams *Matchmaking
 }
 
 func (p LobbySessionParameters) MatchmakingStream() PresenceStream {
-	return PresenceStream{Mode: StreamModeMatchmaking, Subject: p.GroupID}
+	groupID := p.GroupID
+	if p.Mode == evr.ModeArenaPublic || p.Mode == evr.ModeCombatPublic || p.Mode == evr.ModeSocialPublic {
+		groupID = uuid.Nil
+	}
+	return PresenceStream{Mode: StreamModeMatchmaking, Subject: groupID}
 }
 
 func (p LobbySessionParameters) GuildGroupStream() PresenceStream {
-	return PresenceStream{Mode: StreamModeGuildGroup, Subject: p.GroupID, Label: p.Mode.String()}
+	groupID := p.GroupID
+	if p.Mode == evr.ModeArenaPublic || p.Mode == evr.ModeCombatPublic || p.Mode == evr.ModeSocialPublic {
+		groupID = uuid.Nil
+	}
+	return PresenceStream{Mode: StreamModeGuildGroup, Subject: groupID, Label: p.Mode.String()}
 }
 
 func (p LobbySessionParameters) PresenceMeta() PresenceMeta {

--- a/server/evr_matchmaker_prediction.go
+++ b/server/evr_matchmaker_prediction.go
@@ -296,8 +296,21 @@ func predictCandidateOutcomesWithConfig(candidates [][]runtime.MatchmakerEntry, 
 				oldest := float64(time.Now().UTC().Unix())
 				for _, entry := range entries {
 					props := entry.GetProperties()
-					if st, ok := props["timestamp"].(float64); ok && st < oldest {
-						oldest = st
+					if v, ok := props["timestamp"]; ok {
+						var ts float64
+						switch v := v.(type) {
+						case float64:
+							ts = v
+						case int64:
+							ts = float64(v)
+						case int:
+							ts = float64(v)
+						default:
+							continue
+						}
+						if ts < oldest {
+							oldest = ts
+						}
 					}
 				}
 				ticketAge[ticket] = oldest

--- a/server/evr_matchmaker_process.go
+++ b/server/evr_matchmaker_process.go
@@ -357,8 +357,15 @@ func isUndersizedMatch(candidate []runtime.MatchmakerEntry) bool {
 	}
 
 	minTeamSize := 4.0
-	if v, ok := candidate[0].GetProperties()["min_team_size"].(float64); ok && v > 0 {
-		minTeamSize = v
+	if v, ok := candidate[0].GetProperties()["min_team_size"]; ok {
+		switch v := v.(type) {
+		case float64:
+			minTeamSize = v
+		case int64:
+			minTeamSize = float64(v)
+		case int:
+			minTeamSize = float64(v)
+		}
 	}
 
 	minMatchSize := int(minTeamSize) * 2
@@ -367,8 +374,15 @@ func isUndersizedMatch(candidate []runtime.MatchmakerEntry) bool {
 	}
 
 	failsafeTimeout := 0.0
-	if v, ok := candidate[0].GetProperties()["failsafe_timeout"].(float64); ok {
-		failsafeTimeout = v
+	if v, ok := candidate[0].GetProperties()["failsafe_timeout"]; ok {
+		switch v := v.(type) {
+		case float64:
+			failsafeTimeout = v
+		case int64:
+			failsafeTimeout = float64(v)
+		case int:
+			failsafeTimeout = float64(v)
+		}
 	}
 	if failsafeTimeout <= 0 {
 		return false
@@ -377,8 +391,21 @@ func isUndersizedMatch(candidate []runtime.MatchmakerEntry) bool {
 	now := float64(time.Now().UTC().Unix())
 	oldestTimestamp := now
 	for _, entry := range candidate {
-		if ts, ok := entry.GetProperties()["timestamp"].(float64); ok && ts < oldestTimestamp {
-			oldestTimestamp = ts
+		if v, ok := entry.GetProperties()["timestamp"]; ok {
+			var ts float64
+			switch v := v.(type) {
+			case float64:
+				ts = v
+			case int64:
+				ts = float64(v)
+			case int:
+				ts = float64(v)
+			default:
+				continue
+			}
+			if ts < oldestTimestamp {
+				oldestTimestamp = ts
+			}
 		}
 	}
 

--- a/server/evr_pipeline_party.go
+++ b/server/evr_pipeline_party.go
@@ -192,6 +192,7 @@ func (p *EvrPipeline) getPartyLeaderAccountID(ctx context.Context, logger *zap.L
 	if leaderUID == uuid.Nil {
 		return 0
 	}
+	// SMELL(critical): database call on party query path; violates "all DB at login" architecture principle
 	accountID, err := p.resolveUserIDToAccountID(ctx, leaderUID)
 	if err != nil {
 		logger.Warn("Failed to resolve leader account ID", zap.Error(err))
@@ -345,6 +346,7 @@ func (p *EvrPipeline) snsPartySendInviteRequest(ctx context.Context, logger *zap
 		return nil
 	}
 
+	// SMELL(high): error from resolveEvrIDToUserID not distinguished from nil result; both silently skipped
 	targetUserID, err := p.resolveEvrIDToUserID(ctx, params.xpID.PlatformCode, msg.TargetUserID)
 	if err != nil || targetUserID == uuid.Nil {
 		logger.Info("Invite target not found", zap.Uint64("target", msg.TargetUserID))

--- a/server/party_handler.go
+++ b/server/party_handler.go
@@ -94,6 +94,7 @@ func (p *PartyHandler) stop() {
 	p.ctxCancelFn()
 	p.partyRegistry.Delete(p.ID)
 	p.tracker.UntrackByStream(p.Stream)
+	// SMELL(critical): silently swallows error from RemovePartyAll; orphaned matchmaker tickets accumulate silently
 	_ = p.matchmaker.RemovePartyAll(p.IDStr)
 }
 
@@ -117,6 +118,7 @@ func (p *PartyHandler) JoinRequest(presence *Presence) (bool, error) {
 			return false, err
 		}
 		// The party membership has changed, stop any ongoing matchmaking processes.
+		// SMELL(critical): silently swallows error; matchmaker ticket cleanup may fail
 		_ = p.matchmaker.RemovePartyAll(p.IDStr)
 		return true, nil
 	}
@@ -254,7 +256,7 @@ func (p *PartyHandler) Join(presences []*Presence) {
 	members := p.members.List()
 
 	p.Unlock()
-
+	// SMELL(high): member list snapshot inconsistency: member could leave between snapshot and envelope construction, leading to inconsistent party presence info
 	memberUserPresences := make([]*rtapi.UserPresence, 0, len(members))
 	for _, member := range members {
 		memberUserPresences = append(memberUserPresences, member.UserPresence)
@@ -277,6 +279,7 @@ func (p *PartyHandler) Leave(presences []*Presence) {
 		p.Unlock()
 		return
 	}
+	// SMELL(high): TOCTOU window: multiple presences leaving concurrently may all observe leader != nil, then all attempt to promote the oldest member
 
 	presences, _ = p.members.Leave(presences)
 	if len(presences) == 0 {
@@ -322,6 +325,7 @@ func (p *PartyHandler) Leave(presences []*Presence) {
 	p.Unlock()
 
 	// The party membership has changed, stop any ongoing matchmaking processes.
+	// SMELL(critical): silently swallows error; orphaned tickets may remain in matchmaker
 	_ = p.matchmaker.RemovePartyAll(p.IDStr)
 }
 
@@ -363,7 +367,7 @@ func (p *PartyHandler) Promote(sessionID, node string, presence *rtapi.UserPrese
 	}
 
 	p.Unlock()
-
+	// SMELL(high): TOCTOU window: leader could have been removed between lock release and read; envelope will reference stale leader
 	// Attempted to promote a party member that did not exist.
 	if envelope == nil {
 		return runtime.ErrPartyNotMember
@@ -431,10 +435,12 @@ func (p *PartyHandler) Accept(sessionID, node string, presence *rtapi.UserPresen
 
 	if singleParty {
 		// Kick the user from any other parties they may be part of.
+		// SMELL(high): UntrackLocalByModes error ignored; user may remain in multiple party streams
 		p.tracker.UntrackLocalByModes(joinRequestPresence.ID.SessionID, partyStreamMode, p.Stream)
 	}
 
 	// The party membership has changed, stop any ongoing matchmaking processes.
+	// SMELL(critical): silently swallows error
 	_ = p.matchmaker.RemovePartyAll(p.IDStr)
 
 	return nil

--- a/server/party_presence.go
+++ b/server/party_presence.go
@@ -162,5 +162,6 @@ func (m *PartyPresenceList) Oldest() (*PresenceID, *rtapi.UserPresence) {
 	if len(m.presences) == 0 {
 		return nil, nil
 	}
+	// SMELL(high): returns pointers into internal presences array without defensive copy; caller could mutate under lock-free window
 	return &m.presences[0].Presence.ID, m.presences[0].UserPresence
 }

--- a/server/pipeline_party.go
+++ b/server/pipeline_party.go
@@ -54,6 +54,7 @@ func (p *Pipeline) partyCreate(logger *zap.Logger, session Session, envelope *rt
 	}
 
 	// If successful, the creator becomes the first user to join the party.
+	// SMELL(high): tracker.Track assumed synchronous; Join hook may not fire, leaving creator untracked from party
 	success, _ := p.tracker.Track(session.Context(), session.ID(), ph.Stream, session.UserID(), PresenceMeta{
 		Format:   session.Format(),
 		Username: session.Username(),
@@ -131,6 +132,7 @@ func (p *Pipeline) partyJoin(logger *zap.Logger, session Session, envelope *rtap
 	// If the party was open and the join was successful, track the new member immediately.
 	if autoJoin {
 		stream := PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: node}
+		// SMELL(high): tracker.Track assumed synchronous; Join hook may not fire before returning, leaving presence untracked
 		success, _ := p.tracker.Track(session.Context(), session.ID(), stream, session.UserID(), PresenceMeta{
 			Format:   session.Format(),
 			Username: session.Username(),


### PR DESCRIPTION
Party/matchmaking refactor with conflict resolution.

## Changes
- `evr_matchmaker_process.go`: core matchmaker logic
- `evr_pipeline_party.go`, `party_handler.go`, `party_presence.go`, `pipeline_party.go`: party API surface cleanup
- `evr_lobby_find.go`: configureParty(), shouldFollowerFindOrCreateSocial(), SMELL annotations
- `evr_lobby_parameters.go`, `evr_matchmaker_prediction.go`: parameter/prediction updates

## Docs
- PR template
- Reviewer checklist for party matchmaking