### PR TITLE
fix(matchmaker): relax quality floor for starving tickets and tune defaults

### DIFF
--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -443,11 +443,15 @@ func FixDefaultServiceSettings(logger runtime.Logger, data *ServiceSettingsData)
 	// Quality floor defaults -- disabled by default, needs tuning before enabling.
 	// When enabled, rejects match candidates whose predicted draw probability
 	// falls below a floor that decays with wait time.
+	//
+	// Defaults are intentionally conservative for small populations:
+	//   - Initial=0.05  (halved from 0.10) — 6-14 player pools rarely reach 10%
+	//   - DecayPerSecond=0.001 (doubled from 0.0005) — floor reaches 0 in 50s, not 200s
 	if data.Matchmaking.QualityFloorInitial == 0 {
-		data.Matchmaking.QualityFloorInitial = 0.10
+		data.Matchmaking.QualityFloorInitial = 0.05
 	}
 	if data.Matchmaking.QualityFloorDecayPerSecond == 0 {
-		data.Matchmaking.QualityFloorDecayPerSecond = 0.0005
+		data.Matchmaking.QualityFloorDecayPerSecond = 0.001
 	}
 	// QualityFloorMinimum defaults to 0.0 (zero value), no init needed.
 

--- a/server/evr_matchmaker_quality_floor.go
+++ b/server/evr_matchmaker_quality_floor.go
@@ -20,10 +20,22 @@ func passesQualityFloor(prediction PredictedMatch, floor float64) bool {
 // the dynamic quality floor. The floor is computed per-prediction based on the
 // oldest ticket timestamp in that candidate. Returns the filtered slice.
 //
+// Predictions that contain a starving ticket (oldest wait time >=
+// ReservationThresholdSecs) are exempt from the quality floor so that the
+// reservation system can always rescue long-waiting players, regardless of
+// draw probability.
+//
 // When settings are nil or EnableQualityFloor is false, all predictions pass through.
 func filterByQualityFloor(predictions []PredictedMatch, settings *GlobalMatchmakingSettings, nowUnix int64) []PredictedMatch {
 	if settings == nil || !settings.EnableQualityFloor {
 		return predictions
+	}
+
+	// Determine the starving threshold used by the reservation system.
+	// Default matches buildReservations (90s).
+	starvingThreshold := int64(90)
+	if settings.ReservationThresholdSecs > 0 {
+		starvingThreshold = int64(settings.ReservationThresholdSecs)
 	}
 
 	filtered := make([]PredictedMatch, 0, len(predictions))
@@ -32,6 +44,14 @@ func filterByQualityFloor(predictions []PredictedMatch, settings *GlobalMatchmak
 		if maxWaitSeconds < 0 {
 			maxWaitSeconds = 0
 		}
+
+		// Exempt starving candidates from the quality floor so the reservation
+		// system can always form a match for long-waiting players.
+		if nowUnix-p.OldestTicketTimestamp >= starvingThreshold {
+			filtered = append(filtered, p)
+			continue
+		}
+
 		floor := computeQualityFloor(settings, maxWaitSeconds)
 		if passesQualityFloor(p, floor) {
 			filtered = append(filtered, p)

--- a/server/evr_matchmaker_quality_floor_test.go
+++ b/server/evr_matchmaker_quality_floor_test.go
@@ -405,3 +405,132 @@ func TestFilterByQualityFloorNilSettings(t *testing.T) {
 		t.Fatalf("with nil settings, all predictions should pass; got %d, want 1", len(filtered))
 	}
 }
+
+// TestFilterByQualityFloor_StarvingExempt verifies that candidates whose oldest
+// ticket has been waiting at or beyond the reservation threshold are exempt from
+// quality floor filtering even when their draw probability is below the floor.
+// This ensures the reservation system can always rescue long-waiting players.
+func TestFilterByQualityFloor_StarvingExempt(t *testing.T) {
+	now := time.Now().UTC().Unix()
+
+	makeEntry := func(ticket, sessionID string) *MatchmakerEntry {
+		return &MatchmakerEntry{
+			Ticket:   ticket,
+			Presence: &MatchmakerPresence{SessionId: sessionID},
+			Properties: map[string]interface{}{
+				"rating_mu":    25.0,
+				"rating_sigma": 8.333,
+			},
+		}
+	}
+
+	settings := GlobalMatchmakingSettings{
+		EnableQualityFloor:         true,
+		QualityFloorInitial:        0.10,
+		QualityFloorDecayPerSecond: 0.0005,
+		QualityFloorMinimum:        0.0,
+		ReservationThresholdSecs:   90,
+	}
+
+	predictions := []PredictedMatch{
+		{
+			// Fresh candidate with low draw prob — should be filtered
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("t1", "s1"),
+				makeEntry("t1", "s2"),
+			},
+			DrawProb:              0.04,
+			Size:                  2,
+			OldestTicketTimestamp: now - 5, // 5s wait — not starving
+		},
+		{
+			// Starving candidate with low draw prob — exempt from floor, should pass
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("t2", "s3"),
+				makeEntry("t2", "s4"),
+			},
+			DrawProb:              0.04,
+			Size:                  2,
+			OldestTicketTimestamp: now - 90, // At starving threshold
+		},
+		{
+			// Starving candidate well beyond threshold — also exempt
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("t3", "s5"),
+				makeEntry("t3", "s6"),
+			},
+			DrawProb:              0.01,
+			Size:                  2,
+			OldestTicketTimestamp: now - 300, // 5 minutes — definitely starving
+		},
+	}
+
+	filtered := filterByQualityFloor(predictions, &settings, now)
+
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 predictions (two starving-exempt), got %d", len(filtered))
+	}
+	if filtered[0].OldestTicketTimestamp != now-90 {
+		t.Errorf("expected first result to be the 90s-wait candidate")
+	}
+	if filtered[1].OldestTicketTimestamp != now-300 {
+		t.Errorf("expected second result to be the 300s-wait candidate")
+	}
+}
+
+// TestFilterByQualityFloor_StarvingThresholdDefault verifies that when
+// ReservationThresholdSecs is 0 (unset), the default of 90s is used.
+func TestFilterByQualityFloor_StarvingThresholdDefault(t *testing.T) {
+	now := time.Now().UTC().Unix()
+
+	makeEntry := func(ticket, sessionID string) *MatchmakerEntry {
+		return &MatchmakerEntry{
+			Ticket:   ticket,
+			Presence: &MatchmakerPresence{SessionId: sessionID},
+			Properties: map[string]interface{}{
+				"rating_mu":    25.0,
+				"rating_sigma": 8.333,
+			},
+		}
+	}
+
+	settings := GlobalMatchmakingSettings{
+		EnableQualityFloor:         true,
+		QualityFloorInitial:        0.10,
+		QualityFloorDecayPerSecond: 0.0005,
+		QualityFloorMinimum:        0.0,
+		ReservationThresholdSecs:   0, // unset — should default to 90s
+	}
+
+	predictions := []PredictedMatch{
+		{
+			// 89s wait — just under default threshold — subject to floor, filtered
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("t1", "s1"),
+				makeEntry("t1", "s2"),
+			},
+			DrawProb:              0.04,
+			Size:                  2,
+			OldestTicketTimestamp: now - 89,
+		},
+		{
+			// 90s wait — at default threshold — exempt, passes
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("t2", "s3"),
+				makeEntry("t2", "s4"),
+			},
+			DrawProb:              0.04,
+			Size:                  2,
+			OldestTicketTimestamp: now - 90,
+		},
+	}
+
+	filtered := filterByQualityFloor(predictions, &settings, now)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 prediction (only the 90s starving-exempt one), got %d", len(filtered))
+	}
+	if filtered[0].OldestTicketTimestamp != now-90 {
+		t.Errorf("expected the 90s-wait candidate to be the survivor")
+	}
+}


### PR DESCRIPTION
## Problem
The matchmaker quality floor caused **939 consecutive 0-match cycles over 15.65 hours** in production. With default settings (initial=0.10, decay=0.0005/sec), small populations (6-14 players) naturally produce draw probabilities of 0.08-0.09 which are rejected for up to 200 seconds. The starving ticket system runs AFTER quality floor filtering, so it can never rescue rejected candidates.

## Fix
1. **Starving ticket exemption**: candidates with oldest ticket ≥ `ReservationThresholdSecs` (90s) bypass the quality floor entirely. This ensures the reservation system can always form matches for long-waiting players.
2. **Tuned defaults**: `QualityFloorInitial` 0.10→0.05, `QualityFloorDecayPerSecond` 0.0005→0.001 (floor reaches 0 in 50s instead of 200s)

## Tests
- `TestFilterByQualityFloor_StarvingExempt` — verifies starving exemption at/above 90s threshold
- `TestFilterByQualityFloor_StarvingThresholdDefault` — verifies 90s default when config is 0

## QA
Themis verdict: **APPROVED** (no conditions)

Co-authored-by: Andrew Bates <andrew.bates@gmail.com>