### PR TITLE
fix(match): restore slot reservation on capacity failure and return distinct error

### DIFF
--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -90,6 +90,8 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 		return nil
 	}
 
+	reservationViolated := reason == ErrJoinRejectReasonReservationViolated.Error()
+
 	switch {
 	case !found:
 		err = LobbyErrMatchNotFound
@@ -101,6 +103,10 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 	case reason == ErrJoinRejectReasonMatchClosed.Error():
 		// Assuming ErrJoinRejectReasonMatchClosed is defined elsewhere and its Error() method returns the specific string
 		err = LobbyErrMatchClosed
+	case reservationViolated:
+		// The lobby was genuinely over capacity despite the player holding a valid slot
+		// reservation. This is a consistency violation — log at ERROR so it is visible.
+		err = NewLobbyError(ServerIsFull, "lobby full: reservation violated — lobby was over capacity despite a valid slot reservation")
 	case !allowed:
 		// Wrap the base error with the specific reason provided by JoinAttempt
 		err = fmt.Errorf("%w: %s", LobbyErrJoinNotAllowed, reason)
@@ -119,7 +125,11 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 			groupID = label.GroupID.String()
 		}
 
-		logger.Warn("failed to join match",
+		logFn := logger.Warn
+		if reservationViolated {
+			logFn = logger.Error
+		}
+		logFn("failed to join match",
 			zap.Error(err),
 			// Match info
 			zap.String("mid", label.ID.UUID.String()),
@@ -134,6 +144,7 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 			zap.Int("entrant_count", len(entrants)),
 			zap.Strings("entrant_uids", entrantUserIDs),
 			zap.Strings("entrant_sids", entrantSessionIDs),
+			zap.Bool("reservation_violated", reservationViolated),
 		)
 		return fmt.Errorf("failed to join match: %w", err)
 	}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -197,6 +197,7 @@ var (
 	ErrJoinRejectReasonDuplicateJoin             = errors.New("duplicate join")
 	ErrJoinRejectDuplicateEvrID                  = errors.New("duplicate evr id")
 	ErrJoinRejectReasonLobbyFull                 = errors.New("lobby full")
+	ErrJoinRejectReasonReservationViolated       = errors.New("lobby full: reservation violated")
 	ErrJoinRejectReasonFailedToAssignTeam        = errors.New("failed to assign team")
 	ErrJoinInvalidRoleForLevel                   = errors.New("invalid role for level")
 	ErrJoinRejectReasonPartyMembersMustHaveRoles = errors.New("party members must have roles")
@@ -407,17 +408,31 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 	// at the OpenSlots gate before the reservation lookup is reached.
 	// First try by session ID (fast path). If that misses — e.g. the follower
 	// disconnected and reconnected with a new session — fall back to user ID.
-	var slotReservationPresence *EvrMatchPresence
-	if e, found := state.LoadAndDeleteReservation(meta.Presence.GetSessionId()); found {
-		slotReservationPresence = e
-	} else if e, found := state.LoadAndDeleteReservationByUserID(meta.Presence.GetUserId()); found {
-		slotReservationPresence = e
+	var consumedSlotReservation *slotReservation       // the full reservation (with original expiry)
+	var consumedSlotReservationSessionID string        // the map key to restore under
+	if r, found := state.LoadAndDeleteReservationRaw(meta.Presence.GetSessionId()); found {
+		consumedSlotReservation = r
+		consumedSlotReservationSessionID = meta.Presence.GetSessionId()
+	} else if r, found := state.LoadAndDeleteReservationByUserIDRaw(meta.Presence.GetUserId()); found {
+		consumedSlotReservation = r
+		consumedSlotReservationSessionID = r.Presence.GetSessionId()
 	}
-	if slotReservationPresence != nil {
-		meta.Presence.PartyID = slotReservationPresence.PartyID
-		meta.Presence.RoleAlignment = slotReservationPresence.RoleAlignment
+	if consumedSlotReservation != nil {
+		meta.Presence.PartyID = consumedSlotReservation.Presence.PartyID
+		meta.Presence.RoleAlignment = consumedSlotReservation.Presence.RoleAlignment
 		state.rebuildCache()
 		logger = logger.WithField("has_reservation", true)
+	}
+
+	// restoreSlotReservation puts the consumed slot reservation back into the map
+	// so the player can retry. Must be called whenever a join is rejected after a
+	// reservation was consumed, to avoid silently losing the reservation.
+	restoreSlotReservation := func() {
+		if consumedSlotReservation != nil && consumedSlotReservationSessionID != "" {
+			state.reservationMap[consumedSlotReservationSessionID] = consumedSlotReservation
+			state.rebuildCache()
+			consumedSlotReservation = nil // prevent double-restore
+		}
 	}
 
 	// Ensure the match has enough slots available.
@@ -428,6 +443,11 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 	}
 	if availableSlots < len(meta.Presences()) {
 		restoreReconnectReservation()
+		if consumedSlotReservationSessionID != "" {
+			restoreSlotReservation()
+			logger.WithField("session_id", consumedSlotReservationSessionID).Error("Lobby capacity exceeded despite valid slot reservation; reservation restored.")
+			return state, false, ErrJoinRejectReasonReservationViolated.Error()
+		}
 		return state, false, ErrJoinRejectReasonLobbyFull.Error()
 	}
 
@@ -478,9 +498,18 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 	// check the available slots
 	if slots, err := state.OpenSlotsByRole(meta.Presence.RoleAlignment); err != nil {
 		restoreReconnectReservation()
+		restoreSlotReservation()
 		return state, false, ErrJoinRejectReasonFailedToAssignTeam.Error()
 	} else if slots < len(meta.Presences()) {
 		restoreReconnectReservation()
+		if consumedSlotReservationSessionID != "" {
+			restoreSlotReservation()
+			logger.WithFields(map[string]any{
+				"session_id": consumedSlotReservationSessionID,
+				"role":       meta.Presence.RoleAlignment,
+			}).Error("Role slot capacity exceeded despite valid slot reservation; reservation restored.")
+			return state, false, ErrJoinRejectReasonReservationViolated.Error()
+		}
 		return state, false, ErrJoinRejectReasonLobbyFull.Error()
 	}
 

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -112,6 +112,40 @@ func (s *MatchLabel) LoadAndDeleteReservationByUserID(userID string) (*EvrMatchP
 	return nil, false
 }
 
+// LoadAndDeleteReservationRaw returns the full slotReservation (including its original
+// Expiry) and removes it from the map. Returns nil, false if absent or expired.
+// Use this when the caller needs to restore the reservation on failure.
+func (s *MatchLabel) LoadAndDeleteReservationRaw(sessionID string) (*slotReservation, bool) {
+	r, ok := s.reservationMap[sessionID]
+	if !ok || r.Expiry.Before(time.Now()) {
+		delete(s.reservationMap, sessionID)
+		return nil, false
+	}
+	delete(s.reservationMap, sessionID)
+	s.rebuildCache()
+	return r, true
+}
+
+// LoadAndDeleteReservationByUserIDRaw searches the reservation map for a reservation
+// matching the given user ID and returns the full slotReservation. This is the raw
+// counterpart of LoadAndDeleteReservationByUserID, preserving the original Expiry so
+// the caller can restore the reservation on failure.
+func (s *MatchLabel) LoadAndDeleteReservationByUserIDRaw(userID string) (*slotReservation, bool) {
+	for sessionID, r := range s.reservationMap {
+		if r.Presence.GetUserId() != userID {
+			continue
+		}
+		if r.Expiry.Before(time.Now()) {
+			delete(s.reservationMap, sessionID)
+			continue
+		}
+		delete(s.reservationMap, sessionID)
+		s.rebuildCache()
+		return r, true
+	}
+	return nil, false
+}
+
 func (s *MatchLabel) IsPublic() bool {
 	return s.LobbyType == PublicLobby
 }

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -2693,7 +2693,7 @@ func TestMatchJoinAttempt_LobbyFull_RoleSlots_WithReservation_ReturnsReservation
 	// TeamBlue has 4 presences + 1 reservation = 5 slots used (MaxSize for that team is 4)
 	blueSlots, _ := state.OpenSlotsByRole(evr.TeamBlue)
 	if blueSlots >= 0 {
-		t.Logf("Expected negative or zero slots for TeamBlue, got %d", blueSlots)
+		t.Fatalf("Expected negative or zero slots for TeamBlue, got %d", blueSlots)
 	}
 
 	// Follower tries to join, will be assigned to TeamBlue (from reservation)

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -2512,3 +2512,224 @@ func TestMatchJoinAttempt_PartyFollowerReconnectFindsReservation(t *testing.T) {
 		t.Error("Original reservation should have been consumed")
 	}
 }
+
+// TestMatchJoinAttempt_LobbyFull_WithoutReservation_ReturnsLobbyFull verifies the
+// baseline case: a full social lobby (12/12 players) with no reservations rejects
+// any new player without a reservation with the "lobby full" error.
+func TestMatchJoinAttempt_LobbyFull_WithoutReservation_ReturnsLobbyFull(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.LobbyType = PublicLobby
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+
+	// Fill the lobby to max capacity with 12 actual players, no reservations
+	for i := 0; i < SocialLobbyMaxSize; i++ {
+		player := reconnectTestPlayer(fmt.Sprintf("full-player-%d", i), evr.TeamSocial)
+		state.presenceMap[player.GetSessionId()] = player
+		state.presenceByEvrID[player.EvrID] = player
+		state.joinTimestamps[player.GetSessionId()] = time.Now().Add(-1 * time.Minute)
+	}
+	state.rebuildCache()
+
+	if state.OpenSlots() != 0 {
+		t.Fatalf("Expected 0 open slots, got %d", state.OpenSlots())
+	}
+
+	// New player without reservation tries to join
+	newPlayer := reconnectTestPlayer("new-player-no-reservation", evr.TeamSocial)
+	metadata := NewJoinMetadata(newPlayer).ToMatchMetadata()
+
+	ctx := context.Background()
+	logger := reconnectTestLogger()
+	nk := &reconnectTestNakamaModule{}
+	m := &EvrMatch{}
+
+	_, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, nil, 0, state, newPlayer, metadata)
+
+	if allowed {
+		t.Fatalf("Expected join to be rejected when lobby is full without reservation")
+	}
+	if reason != ErrJoinRejectReasonLobbyFull.Error() {
+		t.Errorf("Expected reason '%s', got '%s'", ErrJoinRejectReasonLobbyFull.Error(), reason)
+	}
+}
+
+// TestMatchJoinAttempt_LobbyFull_WithReservation_ReturnsReservationViolated verifies the
+// party reservation violation bug: a social lobby is full (counting the reservation),
+// a follower with a valid reservation tries to join but is rejected with "reservation violated",
+// and their reservation is RESTORED (not lost).
+func TestMatchJoinAttempt_LobbyFull_WithReservation_ReturnsReservationViolated(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.LobbyType = PublicLobby
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	followerSessionID := uuid.Must(uuid.NewV4())
+	partyID := uuid.Must(uuid.NewV4())
+
+	// Create a slot reservation for the follower
+	followerReservation := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerSessionID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 5000},
+		Username:      "reserved-follower",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+	}
+	state.reservationMap[followerSessionID.String()] = &slotReservation{
+		Presence: followerReservation,
+		Expiry:   time.Now().Add(5 * time.Minute),
+	}
+
+	// Fill the lobby with 12 actual players (not counting reservation yet)
+	for i := 0; i < SocialLobbyMaxSize; i++ {
+		player := reconnectTestPlayer(fmt.Sprintf("filled-player-%d", i), evr.TeamSocial)
+		state.presenceMap[player.GetSessionId()] = player
+		state.presenceByEvrID[player.EvrID] = player
+		state.joinTimestamps[player.GetSessionId()] = time.Now().Add(-1 * time.Minute)
+	}
+
+	state.rebuildCache()
+
+	// After rebuildCache, Size should be 13 (12 presences + 1 reservation)
+	// OpenSlots should be -1 (MaxSize 12 - Size 13)
+	if state.OpenSlots() != -1 {
+		t.Fatalf("Expected -1 open slots (due to reservation overflow), got %d", state.OpenSlots())
+	}
+
+	// Follower tries to join with their reservation
+	followerReconnected := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     uuid.Must(uuid.NewV4()), // Different session ID (reconnect)
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 5000},
+		Username:      "reserved-follower",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+	}
+	metadata := NewJoinMetadata(followerReconnected).ToMatchMetadata()
+
+	ctx := context.Background()
+	logger := reconnectTestLogger()
+	nk := &reconnectTestNakamaModule{}
+	m := &EvrMatch{}
+
+	resultState, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, nil, 0, state, followerReconnected, metadata)
+
+	stateAfter := resultState.(*MatchLabel)
+
+	// The join should be rejected because the lobby is genuinely full
+	if allowed {
+		t.Fatalf("Expected join to be rejected: lobby overflow despite reservation")
+	}
+
+	// The reason must be the distinct reservation-violated error
+	if reason != ErrJoinRejectReasonReservationViolated.Error() {
+		t.Errorf("Expected reason '%s', got '%s'", ErrJoinRejectReasonReservationViolated.Error(), reason)
+	}
+
+	// Most critically: the reservation must be RESTORED, not lost
+	if _, exists := stateAfter.reservationMap[followerSessionID.String()]; !exists {
+		t.Fatal("Reservation should be RESTORED after join rejection due to lobby full")
+	}
+}
+
+// TestMatchJoinAttempt_LobbyFull_RoleSlots_WithReservation_ReturnsReservationViolated verifies the
+// party reservation violation bug in role-based capacity (arena mode): a team is full,
+// a follower with a reservation for that team tries to join but is rejected,
+// and their reservation is RESTORED.
+func TestMatchJoinAttempt_LobbyFull_RoleSlots_WithReservation_ReturnsReservationViolated(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeArenaPublic
+	state.LobbyType = PublicLobby
+	state.MaxSize = 16
+	state.PlayerLimit = 8
+	state.TeamSize = 4
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	followerSessionID := uuid.Must(uuid.NewV4())
+	partyID := uuid.Must(uuid.NewV4())
+
+	// Create a slot reservation for follower assigned to TeamBlue
+	followerReservation := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerSessionID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 6000},
+		Username:      "reserved-follower-arena",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamBlue,
+		SessionExpiry: 9999999999,
+	}
+	state.reservationMap[followerSessionID.String()] = &slotReservation{
+		Presence: followerReservation,
+		Expiry:   time.Now().Add(5 * time.Minute),
+	}
+
+	// Fill TeamBlue with 4 players (full)
+	for i := 0; i < 4; i++ {
+		player := reconnectTestPlayer(fmt.Sprintf("blue-player-%d", i), evr.TeamBlue)
+		state.presenceMap[player.GetSessionId()] = player
+		state.presenceByEvrID[player.EvrID] = player
+		state.joinTimestamps[player.GetSessionId()] = time.Now().Add(-1 * time.Minute)
+	}
+
+	// Fill TeamOrange with 2 players (not full)
+	for i := 0; i < 2; i++ {
+		player := reconnectTestPlayer(fmt.Sprintf("orange-player-%d", i), evr.TeamOrange)
+		state.presenceMap[player.GetSessionId()] = player
+		state.presenceByEvrID[player.EvrID] = player
+		state.joinTimestamps[player.GetSessionId()] = time.Now().Add(-1 * time.Minute)
+	}
+
+	state.rebuildCache()
+
+	// TeamBlue has 4 presences + 1 reservation = 5 slots used (MaxSize for that team is 4)
+	blueSlots, _ := state.OpenSlotsByRole(evr.TeamBlue)
+	if blueSlots >= 0 {
+		t.Logf("Expected negative or zero slots for TeamBlue, got %d", blueSlots)
+	}
+
+	// Follower tries to join, will be assigned to TeamBlue (from reservation)
+	followerReconnected := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     uuid.Must(uuid.NewV4()), // Different session ID (reconnect)
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 6000},
+		Username:      "reserved-follower-arena",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamUnassigned, // Will be assigned from reservation
+		SessionExpiry: 9999999999,
+	}
+	metadata := NewJoinMetadata(followerReconnected).ToMatchMetadata()
+
+	ctx := context.Background()
+	logger := reconnectTestLogger()
+	nk := &reconnectTestNakamaModule{}
+	m := &EvrMatch{}
+
+	resultState, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, nil, 0, state, followerReconnected, metadata)
+
+	stateAfter := resultState.(*MatchLabel)
+
+	// The join should be rejected because the assigned team (TeamBlue) is full
+	if allowed {
+		t.Fatalf("Expected join to be rejected: TeamBlue is full despite reservation")
+	}
+
+	// The reason should indicate a reservation violation
+	if reason != ErrJoinRejectReasonReservationViolated.Error() {
+		t.Errorf("Expected reason '%s', got '%s'", ErrJoinRejectReasonReservationViolated.Error(), reason)
+	}
+
+	// Most critically: the reservation must be RESTORED, not lost
+	if _, exists := stateAfter.reservationMap[followerSessionID.String()]; !exists {
+		t.Fatal("Reservation should be RESTORED after join rejection due to role slot overflow")
+	}
+}


### PR DESCRIPTION
## Problem
When a party follower with a valid slot reservation joins a full lobby, the reservation is consumed (deleted) before the capacity check. When the check fails, the reservation is lost — never restored. The caller gets plain "lobby full" with no indication a reservation existed.

Production evidence: 52 lobby-full rejections in one day, including rejections at 6-8/12 capacity (reservation accounting inflation).

## Fix
- Added `restoreSlotReservation()` closure (mirrors `restoreReconnectReservation` pattern)
- Added `LoadAndDeleteReservationRaw` to preserve original expiry for restoration
- New `ErrJoinRejectReasonReservationViolated` error for distinct signaling
- ERROR-level logging with `reservation_violated` field when reservation is violated
- Same treatment for role-based capacity check

## Tests
3 tests: baseline lobby-full (no reservation), reservation violated (social/global), reservation violated (arena/role slots). All pass.

## QA
Themis verdict: **APPROVED** (condition addressed — t.Logf→t.Fatalf)

Co-authored-by: Andrew Bates <andrew.bates@gmail.com>