### PR TITLE
fix(matchmaker): use max RTT instead of mean when party member exceeds threshold

### DIFF
--- a/server/evr_lobby_builder.go
+++ b/server/evr_lobby_builder.go
@@ -394,19 +394,35 @@ func (b *LobbyBuilder) rankEndpointsByAverageLatency(entrants []*MatchmakerEntry
 
 	latenciesByTeamByExtIP, latenciesByPlayerByExtIP := b.extractLatenciesFromEntrants(entrants)
 
+	maxServerRTT := ServiceSettings().Matchmaking.MaxServerRTT
+
 	meanRTTByExtIP := make(map[string]int, len(latenciesByTeamByExtIP))
 
 	for extIP, latenciesByTeam := range latenciesByTeamByExtIP {
-		// Calculate the mean RTT across the lobby
-		var sum float64
+		// Calculate the mean and max RTT across the lobby
+		var sum, maxLatency float64
+		anyOverThreshold := false
 		for _, teamLatencies := range latenciesByTeam {
 			for _, latency := range teamLatencies {
 				sum += latency
+				if latency > maxLatency {
+					maxLatency = latency
+				}
+				if maxServerRTT > 0 && int(latency) > maxServerRTT {
+					anyOverThreshold = true
+				}
 			}
 		}
 		meanRTT := sum / float64(len(entrants))
 
-		meanRTTByExtIP[extIP] = int(meanRTT)
+		// If any party member exceeds the MaxServerRTT threshold, use the max RTT
+		// instead of the mean. This prevents selecting a server that would pass for
+		// most members but fail pre-join ping validation for the outlier.
+		if anyOverThreshold {
+			meanRTTByExtIP[extIP] = int(maxLatency)
+		} else {
+			meanRTTByExtIP[extIP] = int(meanRTT)
+		}
 	}
 
 	return meanRTTByExtIP, latenciesByPlayerByExtIP

--- a/server/evr_lobby_builder_test.go
+++ b/server/evr_lobby_builder_test.go
@@ -359,3 +359,197 @@ func TestSelectNextMapCombatRandomizes(t *testing.T) {
 	assert.Greater(t, len(seen), 1,
 		"selectNextMap returned the same level on all 20 calls; queue rotation is broken")
 }
+
+// TestRankEndpointsByAverageLatency_SymmetricRTT_UsesMean verifies that when all
+// entrants have RTT values within the MaxServerRTT threshold, the mean RTT is used
+// as the score for each endpoint.
+func TestRankEndpointsByAverageLatency_SymmetricRTT_UsesMean(t *testing.T) {
+	// Setup: Save original settings and restore after test
+	originalSettings := ServiceSettings()
+	defer ServiceSettingsUpdate(originalSettings)
+
+	// Configure MaxServerRTT threshold
+	newSettings := &ServiceSettingsData{
+		Matchmaking: GlobalMatchmakingSettings{
+			MaxServerRTT: 180,
+		},
+	}
+	ServiceSettingsUpdate(newSettings)
+
+	// Create test data: 2 entrants, both with ~50ms RTT to server
+	entrants := []*MatchmakerEntry{
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user1",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 50.0,
+			},
+		},
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user2",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 50.0,
+			},
+		},
+	}
+
+	lb := &LobbyBuilder{}
+	meanRTTByExtIP, _ := lb.rankEndpointsByAverageLatency(entrants)
+
+	// Assert: result should be mean (50), not max
+	assert.Equal(t, 50, meanRTTByExtIP["1.2.3.4"],
+		"Expected mean RTT of 50ms for symmetric latencies")
+}
+
+// TestRankEndpointsByAverageLatency_AsymmetricRTT_OverThreshold_UsesMax verifies that
+// when any entrant exceeds MaxServerRTT, the max RTT is used as the score instead of mean.
+// This prevents selecting servers where one player would fail pre-join validation.
+func TestRankEndpointsByAverageLatency_AsymmetricRTT_OverThreshold_UsesMax(t *testing.T) {
+	// Setup: Save original settings and restore after test
+	originalSettings := ServiceSettings()
+	defer ServiceSettingsUpdate(originalSettings)
+
+	// Configure MaxServerRTT threshold to 180ms
+	newSettings := &ServiceSettingsData{
+		Matchmaking: GlobalMatchmakingSettings{
+			MaxServerRTT: 180,
+		},
+	}
+	ServiceSettingsUpdate(newSettings)
+
+	// Create test data: 2 entrants with asymmetric RTT [50ms, 250ms]
+	// Mean would be 150ms (looks acceptable) but max is 250ms (exceeds 180ms threshold)
+	entrants := []*MatchmakerEntry{
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user1",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 50.0,
+			},
+		},
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user2",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 250.0,
+			},
+		},
+	}
+
+	lb := &LobbyBuilder{}
+	meanRTTByExtIP, _ := lb.rankEndpointsByAverageLatency(entrants)
+
+	// Assert: result should be max (250), not mean (150)
+	// This ensures the server is penalized for the outlier latency
+	assert.Equal(t, 250, meanRTTByExtIP["1.2.3.4"],
+		"Expected max RTT of 250ms when any entrant exceeds threshold; mean-based selection would hide outlier")
+}
+
+// TestRankEndpointsByAverageLatency_AsymmetricRTT_UnderThreshold_UsesMean verifies that
+// when all entrants are below MaxServerRTT threshold, the mean is used even if there is asymmetry.
+func TestRankEndpointsByAverageLatency_AsymmetricRTT_UnderThreshold_UsesMean(t *testing.T) {
+	// Setup: Save original settings and restore after test
+	originalSettings := ServiceSettings()
+	defer ServiceSettingsUpdate(originalSettings)
+
+	// Configure MaxServerRTT threshold to 180ms
+	newSettings := &ServiceSettingsData{
+		Matchmaking: GlobalMatchmakingSettings{
+			MaxServerRTT: 180,
+		},
+	}
+	ServiceSettingsUpdate(newSettings)
+
+	// Create test data: 2 entrants with asymmetric RTT [50ms, 150ms]
+	// Mean is 100ms, max is 150ms, both under 180ms threshold
+	entrants := []*MatchmakerEntry{
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user1",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 50.0,
+			},
+		},
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user2",
+			},
+			Properties: map[string]any{
+				"rtt_1.2.3.4": 150.0,
+			},
+		},
+	}
+
+	lb := &LobbyBuilder{}
+	meanRTTByExtIP, _ := lb.rankEndpointsByAverageLatency(entrants)
+
+	// Assert: result should be mean (100), not max (150)
+	// All entrants are within acceptable threshold, so mean provides better scoring
+	assert.Equal(t, 100, meanRTTByExtIP["1.2.3.4"],
+		"Expected mean RTT of 100ms when all entrants are below threshold")
+}
+
+// TestRankEndpointsByAverageLatency_MultipleServers_MixedThresholds verifies the fix works
+// correctly across multiple servers with mixed threshold behaviors.
+func TestRankEndpointsByAverageLatency_MultipleServers_MixedThresholds(t *testing.T) {
+	// Setup: Save original settings and restore after test
+	originalSettings := ServiceSettings()
+	defer ServiceSettingsUpdate(originalSettings)
+
+	// Configure MaxServerRTT threshold to 180ms
+	newSettings := &ServiceSettingsData{
+		Matchmaking: GlobalMatchmakingSettings{
+			MaxServerRTT: 180,
+		},
+	}
+	ServiceSettingsUpdate(newSettings)
+
+	// Create test data: 2 entrants, 2 servers
+	// Server A (1.1.1.1): entrant1=40ms, entrant2=60ms → both under, use mean=50
+	// Server B (2.2.2.2): entrant1=50ms, entrant2=300ms → one over, use max=300
+	entrants := []*MatchmakerEntry{
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user1",
+			},
+			Properties: map[string]any{
+				"rtt_1.1.1.1": 40.0,
+				"rtt_2.2.2.2": 50.0,
+			},
+		},
+		{
+			Ticket: "ticket1",
+			Presence: &MatchmakerPresence{
+				UserId: "user2",
+			},
+			Properties: map[string]any{
+				"rtt_1.1.1.1": 60.0,
+				"rtt_2.2.2.2": 300.0,
+			},
+		},
+	}
+
+	lb := &LobbyBuilder{}
+	meanRTTByExtIP, _ := lb.rankEndpointsByAverageLatency(entrants)
+
+	// Assert server A uses mean (both under threshold)
+	assert.Equal(t, 50, meanRTTByExtIP["1.1.1.1"],
+		"Expected mean RTT of 50ms for server A (both entrants under threshold)")
+
+	// Assert server B uses max (one over threshold)
+	assert.Equal(t, 300, meanRTTByExtIP["2.2.2.2"],
+		"Expected max RTT of 300ms for server B (one entrant exceeds threshold)")
+}


### PR DESCRIPTION
## Problem

When the matchmaker selects a server for a party, `rankEndpointsByAverageLatency` computes the **mean RTT** across all party members. This hides outliers: if one member has 50ms and another has 250ms, the mean is 150ms — which looks acceptable — but the 250ms member will fail pre-join ping validation against the `MaxServerRTT` threshold (default 180ms). The party gets assigned to a server that one member cannot join.

## Fix

`rankEndpointsByAverageLatency` now tracks both mean and max RTT for each endpoint. If **any** entrant's RTT to a given server exceeds the `MaxServerRTT` threshold, the function returns the **max** RTT as the score for that endpoint instead of the mean. This ensures the server is ranked (and potentially excluded by `sortLabelIndexes`) on the basis of the worst-case party member, not the average.

When all members are under the threshold, mean RTT is still used — preserving the existing scoring behavior for well-connected parties.

## Tests

Four new tests in `evr_lobby_builder_test.go` cover:

1. **`TestRankEndpointsByAverageLatency_SymmetricRTT_UsesMean`** — both entrants at 50ms (under threshold): result is mean (50ms).
2. **`TestRankEndpointsByAverageLatency_AsymmetricRTT_OverThreshold_UsesMax`** — entrants at 50ms and 250ms, threshold 180ms: result is max (250ms), not mean (150ms).
3. **`TestRankEndpointsByAverageLatency_AsymmetricRTT_UnderThreshold_UsesMean`** — entrants at 50ms and 150ms, threshold 180ms (both under): result is mean (100ms).
4. **`TestRankEndpointsByAverageLatency_MultipleServers_MixedThresholds`** — two servers, one with both entrants under threshold (uses mean), one with an outlier (uses max).