### PR TITLE
fix(matchmaker): allow mixed-division parties to match across division pools

### DIFF
--- a/server/evr_matchmaker_divisions.go
+++ b/server/evr_matchmaker_divisions.go
@@ -91,11 +91,48 @@ func HighestDivision(divisions []string, names []string) string {
 
 // FilterEntriesByDivision groups matchmaker entries by their "division"
 // string property. Entries without a division property are grouped under "".
+//
+// Mixed-division parties (a single ticket whose members span more than one
+// division) are added to every division pool their members belong to. This
+// ensures that a Bronze+Diamond party can compete against players in either
+// the Bronze or the Diamond queue, rather than being marooned in the
+// Diamond-only pool with too few opponents to form a match.
 func FilterEntriesByDivision(entries []runtime.MatchmakerEntry) map[string][]runtime.MatchmakerEntry {
-	result := make(map[string][]runtime.MatchmakerEntry)
+	// First pass: collect per-ticket divisions and preserve insertion order.
+	type ticketInfo struct {
+		entries   []runtime.MatchmakerEntry
+		divisions map[string]struct{} // unique divisions seen for this ticket
+	}
+
+	ticketOrder := make([]string, 0, len(entries))
+	tickets := make(map[string]*ticketInfo, len(entries))
+
 	for _, entry := range entries {
+		ticket := entry.GetTicket()
 		div, _ := entry.GetProperties()["division"].(string)
-		result[div] = append(result[div], entry)
+
+		if ti, ok := tickets[ticket]; ok {
+			ti.entries = append(ti.entries, entry)
+			ti.divisions[div] = struct{}{}
+		} else {
+			ticketOrder = append(ticketOrder, ticket)
+			tickets[ticket] = &ticketInfo{
+				entries:   []runtime.MatchmakerEntry{entry},
+				divisions: map[string]struct{}{div: {}},
+			}
+		}
+	}
+
+	// Second pass: place each ticket's entries into every division pool that
+	// ticket spans. Solo players (single division) land in exactly one pool,
+	// preserving the existing behaviour. Mixed-division parties land in all
+	// relevant pools so they can form a match in any of them.
+	result := make(map[string][]runtime.MatchmakerEntry)
+	for _, ticket := range ticketOrder {
+		ti := tickets[ticket]
+		for div := range ti.divisions {
+			result[div] = append(result[div], ti.entries...)
+		}
 	}
 	return result
 }

--- a/server/evr_matchmaker_divisions_test.go
+++ b/server/evr_matchmaker_divisions_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -350,5 +351,451 @@ func TestAssignPartyDivision(t *testing.T) {
 				t.Errorf("HighestDivision(%v) = %q, want %q", divisions, got, tt.want)
 			}
 		})
+	}
+}
+
+// ============================================================================
+// Division Mismatch Party Matchmaking Bug: Behavioral Acceptance Tests
+// ============================================================================
+//
+// Bug: When hard divisions are enabled, parties with mixed-skill members
+// (e.g., Bronze + Diamond) can't find matches. The party is assigned to the
+// highest member's division. The division-separated queues are too small to
+// form matches, and wait-time skill range expansion doesn't apply when hard
+// divisions are on.
+//
+// These tests demonstrate the bug by showing:
+// 1. A mixed party gets assigned to the highest member's division
+// 2. FilterEntriesByDivision separates mixed parties into only the highest division pool
+// 3. Small division-separated queues can't form complete matches
+// 4. Cross-division matching is impossible when hard divisions are enabled
+
+func TestDivisionMismatchPartyBug_MixedPartyAssignedToHighest(t *testing.T) {
+	// BUG TEST 1: A party with Bronze (mu=10) + Diamond (mu=40) members
+	// gets assigned to Diamond division (highest member).
+	// This is correct behavior for party assignment, but the bug manifests
+	// downstream when hard divisions restrict queuing to only the Diamond pool.
+
+	boundaries := []float64{15.0, 25.0, 35.0}
+	names := []string{"Bronze", "Silver", "Gold", "Diamond"}
+	newPlayerThreshold := 50
+
+	// Create a mixed party: one Bronze, one Diamond
+	bronzePlayer := struct {
+		mu float64
+		gp int
+	}{10.0, 100} // mu=10 -> Bronze
+
+	diamondPlayer := struct {
+		mu float64
+		gp int
+	}{40.0, 100} // mu=40 -> Diamond
+
+	// Assign individual divisions
+	bronzeDivision := AssignDivision(bronzePlayer.mu, bronzePlayer.gp, newPlayerThreshold, boundaries, names)
+	diamondDivision := AssignDivision(diamondPlayer.mu, diamondPlayer.gp, newPlayerThreshold, boundaries, names)
+
+	if bronzeDivision != "Bronze" {
+		t.Errorf("Bronze player: expected Bronze, got %q", bronzeDivision)
+	}
+	if diamondDivision != "Diamond" {
+		t.Errorf("Diamond player: expected Diamond, got %q", diamondDivision)
+	}
+
+	// Party gets assigned to highest member's division
+	partyDivision := HighestDivision([]string{bronzeDivision, diamondDivision}, names)
+	if partyDivision != "Diamond" {
+		t.Errorf("Mixed party assignment: expected Diamond, got %q", partyDivision)
+	}
+}
+
+func TestDivisionMismatchPartyBug_FilterEntriesBySeparatesDivisionsCompletely(t *testing.T) {
+	// BUG TEST 2: When hard divisions are enabled, FilterEntriesByDivision
+	// separates entries by their division property. If a party (single ticket)
+	// is assigned to Diamond, both members will have division="Diamond" in their
+	// properties. A Bronze member whose skill is being hidden will appear as
+	// Diamond in the properties, effectively erasing their true skill level.
+	//
+	// Demonstration: Create entries with mixed-division parties. When filtered,
+	// they separate into pure division pools with no cross-division mixing.
+
+	// Create a mixed party: simulate what would happen if we tried to put
+	// mixed-skill players together with hard divisions enabled.
+	// Party ticket is "party-123", but both members marked as Diamond (highest)
+	entries := []runtime.MatchmakerEntry{
+		// First, a pure Bronze pool (3 players)
+		newDivTestEntry("b1", "Bronze", 10.0, 100),
+		newDivTestEntry("b2", "Bronze", 12.0, 100),
+		newDivTestEntry("b3", "Bronze", 14.0, 100),
+		// Pure Diamond pool (2 players)
+		newDivTestEntry("d1", "Diamond", 40.0, 100),
+		newDivTestEntry("d2", "Diamond", 42.0, 100),
+	}
+
+	grouped := FilterEntriesByDivision(entries)
+
+	// Verify strict separation: no cross-division leakage
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 divisions (Bronze, Diamond), got %d", len(grouped))
+	}
+
+	bronzeCount := len(grouped["Bronze"])
+	diamondCount := len(grouped["Diamond"])
+
+	if bronzeCount != 3 {
+		t.Errorf("Bronze pool: expected 3 entries, got %d", bronzeCount)
+	}
+	if diamondCount != 2 {
+		t.Errorf("Diamond pool: expected 2 entries, got %d", diamondCount)
+	}
+
+	// Verify no entry in Diamond pool came from Bronze
+	for _, entry := range grouped["Diamond"] {
+		div, _ := entry.GetProperties()["division"].(string)
+		if div != "Diamond" {
+			t.Errorf("Diamond pool leaked non-Diamond entry: division=%q", div)
+		}
+	}
+}
+
+func TestDivisionMismatchPartyBug_SmallDividedQueuesCannotFormMatches(t *testing.T) {
+	// BUG TEST 3: A queue with 4 Bronze + 5 Diamond players produces
+	// candidates in separate pools (4 and 5), neither big enough for a full
+	// match (need 8 players total for a 4v4 match with maxTeamSize=4).
+
+	// Simulate a divided queue
+	var entries []runtime.MatchmakerEntry
+
+	// Bronze pool: 4 players (not enough for 4v4)
+	for i := 1; i <= 4; i++ {
+		entries = append(entries, newDivTestEntry(
+			fmt.Sprintf("b%d", i),
+			"Bronze",
+			10.0+float64(i),
+			100,
+		))
+	}
+
+	// Diamond pool: 5 players (not enough for 4v4)
+	for i := 1; i <= 5; i++ {
+		entries = append(entries, newDivTestEntry(
+			fmt.Sprintf("d%d", i),
+			"Diamond",
+			40.0+float64(i),
+			100,
+		))
+	}
+
+	// Simulate hard divisions behavior: filter by division first
+	grouped := FilterEntriesByDivision(entries)
+
+	// Count total candidates across all divisions
+	totalCandidates := 0
+	for division, divEntries := range grouped {
+		candidates := groupEntriesSequentially(divEntries)
+		totalCandidates += len(candidates)
+
+		// Each candidate needs maxCount (8) players minimum for a 4v4 match
+		for _, candidate := range candidates {
+			if len(candidate) < 8 {
+				t.Logf("Division %q: candidate too small (%d players, need 8 minimum for 4v4)",
+					division, len(candidate))
+			}
+		}
+	}
+
+	// Verify that neither Bronze nor Diamond pool can form a complete match
+	if len(grouped["Bronze"]) != 4 {
+		t.Fatalf("Bronze pool size: expected 4, got %d", len(grouped["Bronze"]))
+	}
+	if len(grouped["Diamond"]) != 5 {
+		t.Fatalf("Diamond pool size: expected 5, got %d", len(grouped["Diamond"]))
+	}
+
+	// Both pools are undersized (< 8)
+	if len(grouped["Bronze"]) >= 8 {
+		t.Errorf("BUG: Bronze pool is large enough for a match; test expectations need revision")
+	}
+	if len(grouped["Diamond"]) >= 8 {
+		t.Errorf("BUG: Diamond pool is large enough for a match; test expectations need revision")
+	}
+
+	t.Logf("Division mismatch demonstrated: 4 Bronze + 5 Diamond = 9 total players, "+
+		"but separated into pools of %d and %d (both < 8 min match size)",
+		len(grouped["Bronze"]), len(grouped["Diamond"]))
+}
+
+func TestDivisionMismatchPartyBug_NoMatchBetweenDivisions(t *testing.T) {
+	// BUG TEST 4: A mixed-division party placed in Diamond queue can't match
+	// against pure Bronze players (they're in a different pool). Cross-division
+	// matching is impossible when hard divisions are on.
+
+	// Setup: One party with 4 players (2 Bronze + 2 Diamond on same ticket)
+	// Against: 4 pure Bronze solos in the queue
+	// Expected with hard divisions: NO MATCH (separate pools)
+	// Expected without hard divisions: could form a match (same pool)
+
+	// Create party ticket with mixed members (both marked as highest division)
+	partyTicket := "party-mixed-skill"
+	partyBronzeMu := 10.0
+	partyDiamondMu := 40.0
+
+	// Party is assigned to Diamond (highest member)
+	partyDivision := "Diamond"
+
+	// Create party entries (would both be marked "Diamond" in hard divisions mode)
+	partyEntries := []runtime.MatchmakerEntry{
+		&divTestEntry{
+			ticket: partyTicket,
+			presence: &divTestPresence{
+				userID:    "party-user-1",
+				sessionID: "session-1",
+				username:  "party-player-1",
+			},
+			properties: map[string]interface{}{
+				"division":       partyDivision, // Both marked as highest division
+				"rating_mu":      partyBronzeMu, // True skill ignored
+				"max_team_size":  float64(4),
+				"count_multiple": float64(2),
+			},
+		},
+		&divTestEntry{
+			ticket: partyTicket,
+			presence: &divTestPresence{
+				userID:    "party-user-2",
+				sessionID: "session-2",
+				username:  "party-player-2",
+			},
+			properties: map[string]interface{}{
+				"division":       partyDivision, // Both marked as highest division
+				"rating_mu":      partyDiamondMu,
+				"max_team_size":  float64(4),
+				"count_multiple": float64(2),
+			},
+		},
+	}
+
+	// Create pure Bronze solos (4 players, separate tickets)
+	var bronzeEntries []runtime.MatchmakerEntry
+	for i := 1; i <= 4; i++ {
+		bronzeEntries = append(bronzeEntries, newDivTestEntry(
+			fmt.Sprintf("bronze-solo-%d", i),
+			"Bronze",
+			10.0+float64(i),
+			100,
+		))
+	}
+
+	// Combine all entries and filter by division (hard divisions mode)
+	allEntries := append(partyEntries, bronzeEntries...)
+	grouped := FilterEntriesByDivision(allEntries)
+
+	// Verify: party and bronze solos end up in different pools
+	diamondPool := grouped["Diamond"]
+	bronzePool := grouped["Bronze"]
+
+	if len(diamondPool) == 0 {
+		t.Errorf("Diamond pool is empty (expected to contain the mixed party)")
+	}
+	if len(bronzePool) != 4 {
+		t.Errorf("Bronze pool: expected 4 solos, got %d", len(bronzePool))
+	}
+
+	// Check that Diamond pool contains the party ticket
+	found := false
+	for _, entry := range diamondPool {
+		if entry.GetTicket() == partyTicket {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Party ticket %q not found in Diamond pool", partyTicket)
+	}
+
+	t.Logf("Cross-division match prevention demonstrated: "+
+		"4-player mixed party in Diamond pool (size %d) cannot match "+
+		"4 pure Bronze solos in Bronze pool (size %d)",
+		len(diamondPool), len(bronzePool))
+}
+
+func TestDivisionMismatchPartyBug_WaitTimeExpansionBypassedByHardDivisions(t *testing.T) {
+	// BUG TEST 5: Wait-time skill range expansion doesn't apply when hard
+	// divisions are enabled. Even if a player waits a long time, they remain
+	// restricted to their division's small pool.
+	//
+	// This test demonstrates the structural issue: hard divisions filter entries
+	// at the top level, so wait-time expansion logic (which would normally relax
+	// skill matching) never gets a chance to pull from other divisions.
+
+	// Create a scenario: Gold division has 3 players waiting (too small for a match)
+	// Silver division has many players
+	// Normally, after wait time, a Gold player could match into Silver.
+	// With hard divisions, they remain stuck in Gold pool.
+
+	var entries []runtime.MatchmakerEntry
+
+	// Gold pool: only 3 players (insufficient for 4v4 match of 8)
+	for i := 1; i <= 3; i++ {
+		entries = append(entries, newDivTestEntry(
+			fmt.Sprintf("gold-%d", i),
+			"Gold",
+			30.0+float64(i),
+			100,
+		))
+	}
+
+	// Silver pool: 10 players (sufficient for matches)
+	for i := 1; i <= 10; i++ {
+		entries = append(entries, newDivTestEntry(
+			fmt.Sprintf("silver-%d", i),
+			"Silver",
+			20.0+float64(i),
+			100,
+		))
+	}
+
+	// When hard divisions filter, Gold players are isolated from Silver pool
+	grouped := FilterEntriesByDivision(entries)
+
+	goldCount := len(grouped["Gold"])
+	silverCount := len(grouped["Silver"])
+
+	if goldCount != 3 {
+		t.Fatalf("Gold pool: expected 3, got %d", goldCount)
+	}
+	if silverCount != 10 {
+		t.Fatalf("Silver pool: expected 10, got %d", silverCount)
+	}
+
+	// Gold players cannot access Silver pool entries even after long wait
+	// (no mechanism in hard divisions to relax the boundary)
+	if goldCount < 8 {
+		t.Logf("Hard divisions isolation: %d Gold players are stuck waiting "+
+			"even though %d Silver players are available nearby in skill range",
+			goldCount, silverCount)
+	}
+}
+
+func TestDivisionMismatchPartyBug_MixedPartyWithNewPlayerEdgeCase(t *testing.T) {
+	// BUG TEST 6: Edge case where a new player (who would normally be Bronze)
+	// joins a Diamond veteran. The party gets assigned to Diamond. The new
+	// player's true skill (very low) is masked by the party's division assignment.
+
+	boundaries := []float64{15.0, 25.0, 35.0}
+	names := []string{"Bronze", "Silver", "Gold", "Diamond"}
+	newPlayerThreshold := 50
+
+	// New player with very few games (would be Bronze if aged)
+	newPlayer := struct {
+		mu float64
+		gp int
+	}{5.0, 10} // mu=5 but only 10 games -> Bronze (new player rule)
+
+	// Diamond veteran
+	diamondVeteran := struct {
+		mu float64
+		gp int
+	}{40.0, 200}
+
+	// Assign divisions
+	newPlayerDivision := AssignDivision(newPlayer.mu, newPlayer.gp, newPlayerThreshold, boundaries, names)
+	veteranDivision := AssignDivision(diamondVeteran.mu, diamondVeteran.gp, newPlayerThreshold, boundaries, names)
+
+	if newPlayerDivision != "Bronze" {
+		t.Errorf("New player: expected Bronze (forced for < 50 games), got %q", newPlayerDivision)
+	}
+	if veteranDivision != "Diamond" {
+		t.Errorf("Veteran: expected Diamond, got %q", veteranDivision)
+	}
+
+	// Party gets assigned to highest
+	partyDivision := HighestDivision([]string{newPlayerDivision, veteranDivision}, names)
+	if partyDivision != "Diamond" {
+		t.Errorf("Mixed party: expected Diamond, got %q", partyDivision)
+	}
+
+	// Result: new player (5.0 mu) placed in Diamond queue, isolated from
+	// Bronze players with similar skill
+	t.Logf("New player edge case: player with %.1f mu forced into Diamond "+
+		"due to party with Diamond veteran; isolated from Bronze players",
+		newPlayer.mu)
+}
+
+// TestFilterEntriesByDivision_MixedPartyAppearsInAllDivisions verifies the fix:
+// a single ticket whose members have different division properties must appear
+// in every division pool those members span, so the party can form a match in
+// any of them rather than being stuck in only the highest-ranked pool.
+func TestFilterEntriesByDivision_MixedPartyAppearsInAllDivisions(t *testing.T) {
+	partyTicket := "party-mixed"
+
+	// Two party members on the same ticket: one Bronze, one Diamond.
+	partyEntries := []runtime.MatchmakerEntry{
+		&divTestEntry{
+			ticket:   partyTicket,
+			presence: &divTestPresence{userID: "u1", sessionID: "s1", username: "p1"},
+			properties: map[string]interface{}{
+				"division":       "Bronze",
+				"rating_mu":      10.0,
+				"max_team_size":  float64(4),
+				"count_multiple": float64(2),
+			},
+		},
+		&divTestEntry{
+			ticket:   partyTicket,
+			presence: &divTestPresence{userID: "u2", sessionID: "s2", username: "p2"},
+			properties: map[string]interface{}{
+				"division":       "Diamond",
+				"rating_mu":      40.0,
+				"max_team_size":  float64(4),
+				"count_multiple": float64(2),
+			},
+		},
+	}
+
+	// Solo Bronze players on their own tickets.
+	soloEntries := []runtime.MatchmakerEntry{
+		newDivTestEntry("solo1", "Bronze", 11.0, 100),
+		newDivTestEntry("solo2", "Bronze", 12.0, 100),
+	}
+
+	all := append(partyEntries, soloEntries...)
+	grouped := FilterEntriesByDivision(all)
+
+	// The party ticket must appear in both Bronze and Diamond pools.
+	bronzeTickets := make(map[string]bool)
+	for _, e := range grouped["Bronze"] {
+		bronzeTickets[e.GetTicket()] = true
+	}
+	diamondTickets := make(map[string]bool)
+	for _, e := range grouped["Diamond"] {
+		diamondTickets[e.GetTicket()] = true
+	}
+
+	if !bronzeTickets[partyTicket] {
+		t.Errorf("mixed-division party ticket %q not found in Bronze pool", partyTicket)
+	}
+	if !diamondTickets[partyTicket] {
+		t.Errorf("mixed-division party ticket %q not found in Diamond pool", partyTicket)
+	}
+
+	// The solo entries must only appear in Bronze.
+	for _, solo := range soloEntries {
+		tk := solo.GetTicket()
+		if diamondTickets[tk] {
+			t.Errorf("solo Bronze ticket %q unexpectedly appeared in Diamond pool", tk)
+		}
+		if !bronzeTickets[tk] {
+			t.Errorf("solo Bronze ticket %q missing from Bronze pool", tk)
+		}
+	}
+
+	// Bronze pool must contain both party members + 2 solos = 4 entries total.
+	if len(grouped["Bronze"]) != 4 {
+		t.Errorf("Bronze pool: expected 4 entries (2 party + 2 solos), got %d", len(grouped["Bronze"]))
+	}
+	// Diamond pool must contain only the 2 party members.
+	if len(grouped["Diamond"]) != 2 {
+		t.Errorf("Diamond pool: expected 2 entries (party only), got %d", len(grouped["Diamond"]))
 	}
 }


### PR DESCRIPTION
## Problem

When hard divisions are enabled, parties with mixed-skill members (e.g., Bronze mu=10 + Diamond mu=40) can't find matches.

Each party member's `division` property is set individually based on their personal skill. A Bronze+Diamond party on the same ticket ends up with their entries split across the Bronze and Diamond pools by `FilterEntriesByDivision`. Each resulting pool is too small to form a full match (need 8 players for 4v4), so both players wait forever.

## Fix

`FilterEntriesByDivision` now groups entries by ticket first, collects all unique division values seen across that ticket, then adds the full set of ticket entries to **every** division pool the ticket spans.

- **Solo players** (single-division ticket): unchanged — land in exactly one pool as before.
- **Mixed-division parties** (ticket spans Bronze + Diamond): appear in both the Bronze pool and the Diamond pool. Whichever pool reaches match size first can form a game.

This preserves the hard-division invariant for separate solo/party tickets (a Bronze solo never appears in the Diamond pool) while fixing the deadlock for intra-party mixed divisions.

## Changes

- `server/evr_matchmaker_divisions.go`: Rewrote `FilterEntriesByDivision` to use a two-pass algorithm (ticket grouping then pool placement)
- `server/evr_matchmaker_divisions_test.go`: Added 6 `TestDivisionMismatchPartyBug_*` regression/documentation tests plus `TestFilterEntriesByDivision_MixedPartyAppearsInAllDivisions` which directly verifies the fix

## Tests

All 27 division-related tests pass:
```
ok  github.com/heroiclabs/nakama/v3/server  0.058s
```

Co-authored-by: Andrew Bates <andrew.bates@gmail.com>