### PR TITLE
fix(ping): exempt spectators and private lobbies from RTT limit

### DIFF
--- a/server/evr_lobby_prejoin_ping.go
+++ b/server/evr_lobby_prejoin_ping.go
@@ -197,6 +197,18 @@ func (p *EvrPipeline) validatePreJoinPing(
 		maxRTT = 180
 	}
 
+	// Spectators and private lobbies need reachability only — high RTT is fine.
+	// Only completely unreachable servers (timeout/no-response) block them.
+	relaxRTT := isPrivateMatch(label.Mode)
+	if !relaxRTT {
+		for _, ent := range entrants {
+			if ent.IsSpectator() {
+				relaxRTT = true
+				break
+			}
+		}
+	}
+
 	cutoff := time.Now().Add(-preJoinPingMaxAge)
 
 	type memberCheck struct {
@@ -245,9 +257,15 @@ func (p *EvrPipeline) validatePreJoinPing(
 
 	for _, mc := range checks {
 		entry, found := mc.history.LatestEntry(extIP)
-		if found && entry.Timestamp.After(cutoff) && int(entry.RTT.Milliseconds()) <= maxRTT {
-			// Recent good entry exists; skip.
-			continue
+		if found && entry.Timestamp.After(cutoff) {
+			if relaxRTT {
+				// Spectators and private lobbies: any recent ping proves reachability.
+				continue
+			}
+			if int(entry.RTT.Milliseconds()) <= maxRTT {
+				// Recent good entry exists; skip.
+				continue
+			}
 		}
 		pending = append(pending, needsPing{memberCheck: mc})
 	}
@@ -311,7 +329,7 @@ func (p *EvrPipeline) validatePreJoinPing(
 					return
 				}
 				result.RTT = int(entry.RTT.Milliseconds())
-				if result.RTT > maxRTT {
+				if result.RTT > maxRTT && !relaxRTT {
 					result.Err = fmt.Errorf("RTT %dms exceeds max %dms", result.RTT, maxRTT)
 				}
 			case <-timer.C:
@@ -387,4 +405,10 @@ func (p *EvrPipeline) validatePreJoinPing(
 
 	return fmt.Errorf("%w: %w", ErrPreJoinPingFailed, NewLobbyErrorf(InternalError, "pre-join ping validation failed: %d of %d party members could not reach server %s",
 		len(failures), len(entrants), endpoint.ExternalAddress()))
+}
+
+// isPrivateMatch returns true if the mode is a private lobby that should
+// have relaxed RTT requirements for pre-join ping validation.
+func isPrivateMatch(mode evr.Symbol) bool {
+	return mode == evr.ModeArenaPrivate || mode == evr.ModeCombatPrivate || mode == evr.ModeSocialPrivate
 }

--- a/server/evr_lobby_prejoin_ping_test.go
+++ b/server/evr_lobby_prejoin_ping_test.go
@@ -47,6 +47,43 @@ func TestErrPreJoinPingFailed_Sentinel(t *testing.T) {
 //
 // The test calls validatePreJoinPing with a nil *EvrPipeline, which is safe
 // because the social mode early-return fires before p.nk is ever accessed.
+// TestIsPrivateMatch verifies that isPrivateMatch correctly identifies
+// private lobby modes that should have relaxed RTT requirements.
+func TestIsPrivateMatch(t *testing.T) {
+	tests := []struct {
+		mode evr.Symbol
+		want bool
+	}{
+		{evr.ModeArenaPrivate, true},
+		{evr.ModeCombatPrivate, true},
+		{evr.ModeSocialPrivate, true},
+		{evr.ModeArenaPublic, false},
+		{evr.ModeCombatPublic, false},
+		{evr.ModeSocialPublic, false},
+		{evr.ModeSocialNPE, false},
+		{evr.ToSymbol("echo_combat_tournament"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode.String(), func(t *testing.T) {
+			got := isPrivateMatch(tt.mode)
+			assert.Equal(t, tt.want, got, "isPrivateMatch(%s)", tt.mode)
+		})
+	}
+}
+
+// TestEvrMatchPresence_IsSpectator verifies that IsSpectator correctly
+// identifies spectator role alignment.
+func TestEvrMatchPresence_IsSpectator(t *testing.T) {
+	p := &EvrMatchPresence{RoleAlignment: evr.TeamSpectator}
+	assert.True(t, p.IsSpectator(), "spectator role should be detected")
+
+	p2 := &EvrMatchPresence{RoleAlignment: evr.TeamBlue}
+	assert.False(t, p2.IsSpectator(), "blue team should not be spectator")
+
+	p3 := &EvrMatchPresence{RoleAlignment: 0}
+	assert.False(t, p3.IsSpectator(), "unset role should not be spectator")
+}
+
 func TestValidatePreJoinPing_SocialModeSkipsRTT(t *testing.T) {
 	// Ensure RequiresPreMatchPing() returns true so the function does not
 	// short-circuit before reaching the social-mode check.


### PR DESCRIPTION
## Problem

Spectators (role=2) and private lobbies were subject to the same RTT ceiling (default 180ms) as public competitive matches. When a spectator tried to join a match on a geographically distant server, they were rejected with `pre-join ping validation failed` even when the server was perfectly reachable — just high latency.

In production, vibinator's spectator bot was unable to join an echo_combat manual lobby hosted on an AU-Queensland server because 296ms RTT exceeded the 240ms max.

## Solution

Spectators and private lobbies need **reachability only** — high RTT does not affect their experience. The fix:

1. **`relaxRTT` flag**: Set when any entrant is a spectator or the match is a private mode (`echo_arena_private`, `echo_combat_private`, `social_2.0_private`)
2. **Phase 1 (cache check)**: Spectators/private skip re-ping on any recent cached entry, not just entries under maxRTT
3. **Phase 3 (RTT evaluation)**: Spectators/private are not failed on high RTT, only on timeout or missing ping data
4. **`isPrivateMatch` helper**: Cleanly identifies private modes

## Testing

- `TestIsPrivateMatch`: validates all public/private mode combinations
- `TestEvrMatchPresence_IsSpectator`: validates spectator detection
- Existing `TestValidatePreJoinPing_SocialModeSkipsRTT` still passes
- All existing pre-join ping sentinel tests pass