### PR TITLE
fix(party): do not pull players out of active arena matches for party follow

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -33,6 +33,14 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 	startTime := time.Now()
 	entrantSessionIDs := []uuid.UUID{session.id}
 
+	// if this player is currently playing in a match,
+	// do not process the party follow request, it would pull them out
+	// mid-game. Wait for the match to end naturally.
+	if lc := getMatchLifecycle(session); lc != nil && lc.State() == StateInMatch {
+		logger.Info("Player is mid-match in Arena/Combat, ignoring LobbyFindSessionRequest (party follow gate)")
+		return nil
+	}
+
 	var lobbyGroup *LobbyGroup
 	var memberSessionIDs []uuid.UUID
 	var isLeader bool


### PR DESCRIPTION
Added a state check before processing a party
follow. If the player is currently in a match,
ignore the party follow path.

Fixes: #460 