### PR TITLE
fix(match): drain players before tearing down on shutdown (#439)

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -408,8 +408,8 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 	// at the OpenSlots gate before the reservation lookup is reached.
 	// First try by session ID (fast path). If that misses — e.g. the follower
 	// disconnected and reconnected with a new session — fall back to user ID.
-	var consumedSlotReservation *slotReservation       // the full reservation (with original expiry)
-	var consumedSlotReservationSessionID string        // the map key to restore under
+	var consumedSlotReservation *slotReservation // the full reservation (with original expiry)
+	var consumedSlotReservationSessionID string  // the map key to restore under
 	if r, found := state.LoadAndDeleteReservationRaw(meta.Presence.GetSessionId()); found {
 		consumedSlotReservation = r
 		consumedSlotReservationSessionID = meta.Presence.GetSessionId()
@@ -1187,10 +1187,25 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 		}
 	}
 
-	// If the match is terminating, terminate on the tick.
+	// If the match is terminating, drain it before tearing down (issue #439).
+	//
+	// terminateTick is a BOUNDED FALLBACK deadline, not the primary trigger.
+	// MatchShutdown has already told the game server to remove the players
+	// (entrant reject + CODE_ENDED); as each player leaves, MatchLeave empties
+	// presenceMap. We must terminate as soon as the players are actually gone so
+	// that MatchTerminate does not disconnect the game-server session while
+	// players are still on it (orphaning the server).
+	//
+	// If the game server does not cooperate (players never leave), the deadline
+	// still forces teardown so a match cannot hang forever.
 	if state.terminateTick != 0 {
+		if len(state.presenceMap) == 0 {
+			logger.Debug("Match drained; all players have left. Terminating.")
+			return m.MatchTerminate(ctx, logger, db, nk, dispatcher, tick, state, 0)
+		}
 		if tick >= state.terminateTick {
-			logger.Debug("Match termination tick reached.")
+			logger.WithField("remaining_players", len(state.presenceMap)).
+				Warn("Match drain timed out with players still present; forcing termination.")
 			return m.MatchTerminate(ctx, logger, db, nk, dispatcher, tick, state, 0)
 		}
 		return state

--- a/server/evr_match_shutdown_drain_test.go
+++ b/server/evr_match_shutdown_drain_test.go
@@ -1,0 +1,243 @@
+package server
+
+// Regression tests for issue #439: /shutdown-match orphans the game server.
+//
+// Root cause: MatchShutdown set a fixed terminateTick (tick + grace*tickRate)
+// and the match loop fired MatchTerminate unconditionally once that tick was
+// reached, REGARDLESS of whether players had actually left the game server.
+// MatchTerminate disconnects the game-server session, so the server was torn
+// down while players were still on it ("orphaned").
+//
+// The fix performs an orderly drain:
+//  1. Kick the players (entrant reject + CODE_ENDED) so the game server removes
+//     them and MatchLeave fires for each, emptying presenceMap.
+//  2. Wait — while players remain and the bounded deadline has not elapsed, the
+//     loop must NOT terminate.
+//  3. Terminate as soon as presenceMap is empty (drain complete), OR when the
+//     bounded deadline elapses (timeout fallback for a non-cooperating server).
+//
+// These tests are written RED-first: they fail against the pre-fix behavior
+// (fixed-deadline teardown) and pass once the drain gate is in place.
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap/zapcore"
+)
+
+// drainTestNK is a NakamaModule stub that records SessionDisconnect calls and
+// satisfies the no-op surface MatchShutdown / MatchTerminate touch.
+type drainTestNK struct {
+	runtime.NakamaModule
+	mu               sync.Mutex
+	disconnectedSIDs []string
+}
+
+func (m *drainTestNK) MetricsCounterAdd(_ string, _ map[string]string, _ int64)          {}
+func (m *drainTestNK) MetricsTimerRecord(_ string, _ map[string]string, _ time.Duration) {}
+func (m *drainTestNK) MetricsGaugeSet(_ string, _ map[string]string, _ float64)          {}
+
+func (m *drainTestNK) StorageWrite(_ context.Context, _ []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	return nil, nil
+}
+
+func (m *drainTestNK) StorageRead(_ context.Context, _ []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	return nil, nil
+}
+
+func (m *drainTestNK) SessionDisconnect(_ context.Context, sessionID string, _ ...runtime.PresenceReason) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.disconnectedSIDs = append(m.disconnectedSIDs, sessionID)
+	return nil
+}
+
+// drainTestDispatcher records every BroadcastMessageDeferred so tests can assert
+// that the players were actually told to leave (entrant reject).
+type drainTestDispatcher struct {
+	mu         sync.Mutex
+	broadcasts int
+}
+
+func (d *drainTestDispatcher) BroadcastMessage(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return nil
+}
+
+func (d *drainTestDispatcher) BroadcastMessageDeferred(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.broadcasts++
+	return nil
+}
+
+func (d *drainTestDispatcher) MatchKick(_ []runtime.Presence) error { return nil }
+func (d *drainTestDispatcher) MatchLabelUpdate(_ string) error      { return nil }
+
+func (d *drainTestDispatcher) broadcastCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.broadcasts
+}
+
+func drainTestLogger() runtime.Logger {
+	return NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
+}
+
+func drainTestState(playerCount int) (*MatchLabel, []*EvrMatchPresence) {
+	serverSession := uuid.Must(uuid.NewV4())
+	operatorID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	state := &MatchLabel{
+		ID:        MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"},
+		CreatedAt: time.Now().UTC(),
+		StartTime: time.Now().UTC().Add(-time.Minute),
+		Open:      true,
+		LobbyType: PublicLobby,
+		Mode:      evr.ModeSocialNPE, // not in ValidLeaderboardModes -> no DB leaderboard write
+		Level:     evr.LevelSocial,
+		MaxSize:   16,
+		GroupID:   &groupID,
+		GameServer: &GameServerPresence{
+			SessionID:  serverSession,
+			OperatorID: operatorID,
+			GroupIDs:   []uuid.UUID{groupID},
+		},
+		server: &Presence{
+			ID:     PresenceID{Node: "testnode", SessionID: serverSession},
+			UserID: operatorID,
+		},
+		GameState:             &GameState{},
+		Players:               make([]PlayerInfo, 0, 16),
+		presenceMap:           make(map[string]*EvrMatchPresence, 16),
+		reservationMap:        make(map[string]*slotReservation),
+		reconnectReservations: make(map[string]*reconnectReservation),
+		presenceByEvrID:       make(map[evr.EvrId]*EvrMatchPresence, 16),
+		TeamAlignments:        make(map[string]int, 16),
+		joinTimestamps:        make(map[string]time.Time, 16),
+		joinTimeMilliseconds:  make(map[string]int64, 16),
+		participations:        make(map[string]*PlayerParticipation, 16),
+		tickRate:              10,
+	}
+	state.levelLoaded = true
+
+	players := make([]*EvrMatchPresence, 0, playerCount)
+	for i := 0; i < playerCount; i++ {
+		p := reconnectTestPlayer(string(rune('a'+i)), evr.TeamBlue)
+		state.presenceMap[p.GetSessionId()] = p
+		state.joinTimestamps[p.GetSessionId()] = time.Now()
+		players = append(players, p)
+	}
+	state.rebuildCache()
+	return state, players
+}
+
+// TestMatchShutdown_KicksPlayers proves step (1): MatchShutdown actually tells
+// the game server to remove the players (dispatches the entrant reject).
+func TestMatchShutdown_KicksPlayers(t *testing.T) {
+	t.Parallel()
+
+	state, _ := drainTestState(2)
+	nk := &drainTestNK{}
+	dispatcher := &drainTestDispatcher{}
+	logger := drainTestLogger()
+	m := &EvrMatch{}
+	ctx := context.Background()
+
+	const tick int64 = 100
+	const grace = 30
+
+	out := m.MatchShutdown(ctx, logger, nil, nk, dispatcher, tick, state, grace)
+	if out == nil {
+		t.Fatal("MatchShutdown returned nil; expected the draining match state")
+	}
+
+	if dispatcher.broadcastCount() == 0 {
+		t.Fatal("expected MatchShutdown to dispatch an entrant reject to kick the players, got none")
+	}
+
+	// Match must be closed to new joins and NOT yet terminated.
+	if state.Open {
+		t.Error("expected match to be closed (Open=false) after shutdown")
+	}
+}
+
+// TestMatchShutdown_WaitsForPlayersToLeave proves steps (2)+(3): while players
+// remain (and before the bounded deadline) the loop must NOT terminate, and it
+// must terminate as soon as the presence map is empty — without waiting for the
+// full grace deadline.
+func TestMatchShutdown_WaitsForPlayersToLeave(t *testing.T) {
+	t.Parallel()
+
+	state, players := drainTestState(2)
+	nk := &drainTestNK{}
+	dispatcher := &drainTestDispatcher{}
+	logger := drainTestLogger()
+	m := &EvrMatch{}
+	ctx := context.Background()
+
+	const shutdownTick int64 = 100
+	const grace = 30 // 30s * 10 ticks = 300 ticks fallback deadline
+
+	m.MatchShutdown(ctx, logger, nil, nk, dispatcher, shutdownTick, state, grace)
+
+	// Players are still on the server. The loop must NOT terminate yet, even
+	// several ticks into the drain (well before the 300-tick deadline).
+	for _, tick := range []int64{shutdownTick + 1, shutdownTick + 10, shutdownTick + 100} {
+		out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, tick, state, nil)
+		if out == nil {
+			t.Fatalf("tick %d: match terminated while players remained (orphans the game server)", tick)
+		}
+	}
+
+	// Now the players leave (game server removed them; MatchLeave emptied the map).
+	for _, p := range players {
+		delete(state.presenceMap, p.GetSessionId())
+	}
+	state.rebuildCache()
+
+	// The very next tick — still far before the deadline — must terminate.
+	out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, shutdownTick+101, state, nil)
+	if out != nil {
+		t.Fatal("expected match to terminate immediately once all players had left, but it did not")
+	}
+}
+
+// TestMatchShutdown_TimeoutFallback proves the bounded fallback: a
+// non-cooperating game server that never removes its players must still be torn
+// down once the deadline elapses, so a match cannot hang forever.
+func TestMatchShutdown_TimeoutFallback(t *testing.T) {
+	t.Parallel()
+
+	state, _ := drainTestState(2)
+	nk := &drainTestNK{}
+	dispatcher := &drainTestDispatcher{}
+	logger := drainTestLogger()
+	m := &EvrMatch{}
+	ctx := context.Background()
+
+	const shutdownTick int64 = 100
+	const grace = 5 // 5s * 10 ticks = 50 ticks fallback deadline
+
+	m.MatchShutdown(ctx, logger, nil, nk, dispatcher, shutdownTick, state, grace)
+
+	// Players never leave. Before the deadline, no termination.
+	if out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, shutdownTick+10, state, nil); out == nil {
+		t.Fatal("terminated before the fallback deadline with players still present")
+	}
+
+	// At/after the deadline, the match must terminate anyway despite the
+	// players still being present.
+	deadlineTick := shutdownTick + int64(grace)*state.tickRate
+	if out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, deadlineTick, state, nil); out != nil {
+		t.Fatal("expected timeout fallback to terminate the match at the deadline, but it did not")
+	}
+}


### PR DESCRIPTION
## Summary

`/shutdown-match` was **orphaning the game server while players were still on it**. Nakama kicked players and set a termination tick, but the match loop fired `MatchTerminate` *unconditionally* once `tick >= terminateTick` — disconnecting the game-server session regardless of whether players had actually left.

This makes shutdown **drain players first, then tear down**.

Fixes #439.

## Root cause

`MatchShutdown` already kicks (entrant reject + `CODE_ENDED`) and sets `terminateTick = tick + grace*tickRate`. But the loop treated `terminateTick` as the *primary* trigger and terminated even if `presenceMap` was non-empty → orphaned players.

## Fix

Reframe `terminateTick` as a **bounded fallback deadline**, not the primary trigger. The loop now:
1. Terminates immediately when `len(state.presenceMap) == 0` (drain complete). `MatchLeave` empties the map as players exit, so this fits the existing tick model — no blocking.
2. Falls back to terminating at the deadline if players never leave (non-cooperating server), logged at **warn**.

Kick step preserved; no logging downgraded (old `Debug "termination tick reached"` → `Warn` on the timeout path — a stronger signal).

## Tests (TDD, red-first) — integration-style per AGENTS.md

- `TestMatchShutdown_WaitsForPlayersToLeave` (the meaningful red→green: terminates once drained)
- `TestMatchShutdown_KicksPlayers`, `TestMatchShutdown_TimeoutFallback`

`go test -race` green; `go vet ./server/` clean; `gofmt` clean.

## Design decisions

1. **Reused `terminateTick` as the deadline** (no new field) — preserves its other consumer (`MatchJoinAttempt` rejecting joins into a terminating match).
2. **Empty-match shutdowns terminate next tick** instead of waiting out full grace (nobody to drain).
3. **Timeout logged `warn`** — a server that won't release players is an anomaly.

## ⚠️ Open questions for reviewer

1. **`graceSeconds` is now a max, not a fixed wait.** If any caller relied on the full grace window elapsing for *empty* matches (e.g. a settle delay before recycle), that changed. Judged safe (grace existed to allow drain) — please confirm.
2. Drain observes `presenceMap` (emptied by `MatchLeave`). Did not add an independent `StreamUserList` poll (would duplicate). Flag if a stricter cross-check is wanted.
3. **Unrelated pre-existing test failures** (`TestEvrMatch_MatchJoinAttempt`, `TestMatchLoop_AllocatePostMatchSocialLobby_*`) fail on clean `main` too — **independently confirmed**, NOT caused by this change. Worth a separate issue.
4. `golangci-lint`/`go mod tidy`/`govulncheck` not run (no dependency/API-surface changes); `gofmt`+`vet`+`-race` tests green. Pre-push hook will gate the rest.

---
*Root-caused via automated read-only inspection; "kick → wait for exit → teardown" direction from the maintainer. Implemented TDD-first; diff + tests + the pre-existing-failure claim all independently re-verified before opening.*