### PR TITLE
fix(lobby): make social-lobby no-op guard target-aware (#462)

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -160,7 +160,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 				if err != nil {
 					return NewLobbyError(InternalError, fmt.Sprintf("failed to prepare follower entrant: %s", err))
 				}
-				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
+				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, lobbyGroup, followerEntrants...)
 			}
 
 			if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
@@ -200,7 +200,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 				if err != nil {
 					return NewLobbyError(InternalError, fmt.Sprintf("failed to prepare follower entrant: %s", err))
 				}
-				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, followerEntrants...)
+				return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, lobbyGroup, followerEntrants...)
 			} else {
 				// Still a non-leader in a non-social mode. Poll for the leader
 				// to settle into a match that can be joined. This covers followers at
@@ -372,7 +372,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 				}
 			}
 		}
-		return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, entrants...)
+		return p.lobbyFindOrCreateSocial(ctx, logger, session, lobbyParams, lobbyGroup, entrants...)
 	}
 
 	// Arena and Combat lobbies use the matchmaker (backfill is handled by the matchmaker process)
@@ -668,13 +668,16 @@ func filterBlacklistedSocialMatches(matches []*MatchLabelMeta, blacklistedIPs ma
 	return filtered
 }
 
-func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters, entrants ...*EvrMatchPresence) error {
-	// Fast path: if the player is already in a social lobby that matches
-	// the search criteria (same group, social mode), treat as no-op.
-	// This prevents the party follow path from producing an error when it
-	// directs a player to a social lobby they are already in. (#462)
-	if currentMatchID := p.currentSocialLobbyForSession(ctx, logger, session, lobbyParams); !currentMatchID.IsNil() {
-		logger.Debug("Player already in a matching social lobby, treating as no-op",
+func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup, entrants ...*EvrMatchPresence) error {
+	// Fast path: if the player is already in the social lobby we intend to
+	// send them to, treat as no-op. The guard is target-aware — it only
+	// short-circuits when the player's current social lobby equals the
+	// intended target (the party leader's lobby in a follow, or the
+	// player's own CurrentMatchID otherwise). A same-guild move to a
+	// *different* social lobby, and a forced relocation (cleared
+	// CurrentMatchID), are NOT no-ops. (#462)
+	if currentMatchID := p.currentSocialLobbyForSession(ctx, logger, session, lobbyParams, lobbyGroup); !currentMatchID.IsNil() {
+		logger.Debug("Player already in the intended social lobby, treating as no-op",
 			zap.String("mid", currentMatchID.String()))
 		return nil
 	}
@@ -1089,14 +1092,31 @@ func (p *EvrPipeline) isFollowerInActiveMatch(ctx context.Context, logger *zap.L
 }
 
 // currentSocialLobbyForSession returns the match ID of the social lobby that
-// the player is currently in, if it matches the search criteria (same group ID
-// and social mode). Returns a nil MatchID when the player is not in a matching
-// social lobby.
+// the player is currently in, but ONLY when that lobby is the one we intend to
+// send them to. Returns a nil MatchID otherwise, so the normal
+// find-or-create flow proceeds.
+//
+// The guard is TARGET-AWARE (#462). It is not enough for the player's current
+// lobby to be a social lobby of the same guild; it must be the *intended
+// target*:
+//
+//   - In a party-follow context (PartyGroupName set, follower is not the
+//     leader, and the leader is resolvable to a current match), the target is
+//     the leader's match. This lets a player in social lobby X of guild G be
+//     correctly moved to a DIFFERENT social lobby Y of the same guild G
+//     (GAP 1) instead of being short-circuited on a mere group-ID match.
+//   - Otherwise the target is lobbyParams.CurrentMatchID. A cleared
+//     CurrentMatchID (the relocate path at lobbyFind nils it to force a move
+//     to a larger lobby) yields a nil target, so the requested relocation is
+//     NOT short-circuited (GAP 2).
+//
+// Guild isolation is preserved: a current lobby in a different guild never
+// matches the search group and is rejected before the target comparison.
 //
 // Used as a fast-path guard in lobbyFindOrCreateSocial to avoid rejoining a
 // lobby the player is already in — the party follow path can direct a player
-// to a social lobby they never left. (#462)
-func (p *EvrPipeline) currentSocialLobbyForSession(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters) MatchID {
+// to a social lobby they never left.
+func (p *EvrPipeline) currentSocialLobbyForSession(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup) MatchID {
 	matchStream := PresenceStream{
 		Mode:    StreamModeService,
 		Subject: session.ID(),
@@ -1127,11 +1147,63 @@ func (p *EvrPipeline) currentSocialLobbyForSession(ctx context.Context, logger *
 		return MatchID{}
 	}
 
+	// Guild isolation: a current lobby in a different guild is never the
+	// target of a search scoped to lobbyParams.GroupID.
 	if label.GetGroupID() != lobbyParams.GroupID {
 		return MatchID{}
 	}
 
+	// Resolve the intended target match. Only no-op when the player's current
+	// social lobby IS that target.
+	target := p.intendedSocialTargetMatchID(ws, lobbyParams, lobbyGroup)
+	if target.IsNil() {
+		// No concrete target (forced relocation cleared CurrentMatchID, or no
+		// follow leader to align with): do not short-circuit the requested move.
+		logger.Debug("Social lobby guard: no intended target, not treating as no-op",
+			zap.String("current_mid", currentMatchID.String()))
+		return MatchID{}
+	}
+
+	if target != currentMatchID {
+		// Player is in a different social lobby of the same guild than the one
+		// we intend to send them to (GAP 1): this is a real move, not a no-op.
+		logger.Debug("Social lobby guard: current lobby differs from intended target, not a no-op",
+			zap.String("current_mid", currentMatchID.String()),
+			zap.String("target_mid", target.String()))
+		return MatchID{}
+	}
+
 	return currentMatchID
+}
+
+// intendedSocialTargetMatchID resolves the social lobby that the caller intends
+// to place this session into. In a party-follow context (PartyGroupName set,
+// session is not the leader, leader resolvable to a current match) the target
+// is the leader's match, resolved via the tracker. Otherwise the target is the
+// session's own lobbyParams.CurrentMatchID, which is nil when a relocation was
+// requested. Returns a nil MatchID when no concrete target can be resolved.
+func (p *EvrPipeline) intendedSocialTargetMatchID(session *sessionWS, lobbyParams *LobbySessionParameters, lobbyGroup *LobbyGroup) MatchID {
+	if lobbyGroup != nil && lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
+		leader := lobbyGroup.GetLeader()
+		if leader != nil && leader.SessionId != session.ID().String() {
+			leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
+			leaderUserID := uuid.FromStringOrNil(leader.UserId)
+
+			leaderStream := PresenceStream{
+				Mode:    StreamModeService,
+				Subject: leaderSessionID,
+				Label:   StreamLabelMatchService,
+			}
+			leaderPresence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+			if leaderPresence != nil {
+				if leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus()); !leaderMatchID.IsNil() {
+					return leaderMatchID
+				}
+			}
+		}
+	}
+
+	return lobbyParams.CurrentMatchID
 }
 
 // isFollowerAlreadyInLeaderMatch checks whether the follower is already in

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -2628,10 +2628,14 @@ func TestCurrentSocialLobby_AlreadyInMatchingSocialLobby(t *testing.T) {
 	env.withMockNK(registry)
 	env.setFollowerMatch(socialMatchID)
 	env.params.GroupID = groupID
+	// No relocation requested and no party-follow context: the intended target
+	// is the player's CurrentMatchID, which equals the lobby they are in. This
+	// is the originally-reported rejoin-same-lobby case (#462) — must stay a no-op.
+	env.params.CurrentMatchID = socialMatchID
 
 	logger := loggerForTest(t)
 	result := env.pipeline.currentSocialLobbyForSession(
-		context.Background(), logger, env.session, env.params)
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
 
 	if result.IsNil() {
 		t.Error("currentSocialLobbyForSession should return the match ID when player is already in a matching social lobby")
@@ -2666,7 +2670,7 @@ func TestCurrentSocialLobby_DifferentLobby_ReturnsNil(t *testing.T) {
 
 	logger := loggerForTest(t)
 	result := env.pipeline.currentSocialLobbyForSession(
-		context.Background(), logger, env.session, env.params)
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
 
 	if !result.IsNil() {
 		t.Error("currentSocialLobbyForSession should return nil when player is in a lobby with a different group ID")
@@ -2696,7 +2700,7 @@ func TestCurrentSocialLobby_InArenaMatch_ReturnsNil(t *testing.T) {
 
 	logger := loggerForTest(t)
 	result := env.pipeline.currentSocialLobbyForSession(
-		context.Background(), logger, env.session, env.params)
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
 
 	if !result.IsNil() {
 		t.Error("currentSocialLobbyForSession should return nil when player is in an arena match")
@@ -2716,9 +2720,137 @@ func TestCurrentSocialLobby_NotInAnyMatch_ReturnsNil(t *testing.T) {
 
 	logger := loggerForTest(t)
 	result := env.pipeline.currentSocialLobbyForSession(
-		context.Background(), logger, env.session, env.params)
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
 
 	if !result.IsNil() {
 		t.Error("currentSocialLobbyForSession should return nil when player is not in any match")
+	}
+}
+
+// TestCurrentSocialLobby_MoveToDifferentLobbySameGuild_ReturnsNil covers GAP 1
+// (#462): a player already in social lobby X of guild G who is being directed
+// (via the party-follow path) to a DIFFERENT social lobby Y of the SAME guild G
+// must NOT be treated as a no-op. The guard must be target-aware: it may only
+// short-circuit when the player's current social lobby equals the intended
+// target (here, the leader's lobby Y), not merely when the group IDs match.
+func TestCurrentSocialLobby_MoveToDifferentLobbySameGuild_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	groupID := env.groupID
+
+	// Player (follower) is currently in social lobby X of guild G.
+	lobbyX := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	// Party leader is in a DIFFERENT social lobby Y of the SAME guild G —
+	// this is the intended target.
+	lobbyY := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(lobbyX, &MatchLabel{
+		ID:          lobbyX,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	registry.SetMatch(lobbyY, &MatchLabel{
+		ID:          lobbyY,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+
+	env.setFollowerMatch(lobbyX)
+	env.setLeaderMatch(lobbyY)
+	env.params.GroupID = groupID
+	env.params.PartyGroupName = "squad" // party-follow context
+	// Follower's CurrentMatchID is their current lobby X; the intended target
+	// is the leader's lobby Y. These differ, so this is a real move, not a no-op.
+	env.params.CurrentMatchID = lobbyX
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
+
+	if !result.IsNil() {
+		t.Errorf("GAP 1: moving from social lobby X to a DIFFERENT social lobby Y of the same guild must NOT be a no-op; got match %s", result)
+	}
+}
+
+// TestCurrentSocialLobby_ForcedRelocation_ReturnsNil covers GAP 2 (#462): the
+// relocate path clears lobbyParams.CurrentMatchID to force a move to a larger
+// social lobby. The guard must respect that relocation intent and NOT no-op the
+// requested move, even though the player is still tracked in their old social
+// lobby of the same guild.
+func TestCurrentSocialLobby_ForcedRelocation_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	groupID := env.groupID
+
+	// Player is still in their (too-small) social lobby of guild G.
+	oldLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(oldLobby, &MatchLabel{
+		ID:          oldLobby,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+
+	env.setFollowerMatch(oldLobby)
+	env.params.GroupID = groupID
+	// Relocate path (evr_lobby_find.go:371) cleared CurrentMatchID to signal
+	// "find/create a different, larger lobby". No party-follow leader target.
+	env.params.CurrentMatchID = MatchID{}
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
+
+	if !result.IsNil() {
+		t.Errorf("GAP 2: a forced relocation (cleared CurrentMatchID) must NOT be short-circuited as a no-op; got match %s", result)
+	}
+}
+
+// TestCurrentSocialLobby_FollowToLeaderSameLobby_IsNoop verifies the
+// originally-reported case in the party-follow context: the follower is
+// directed to the leader's social lobby, which is the SAME lobby the follower
+// is already in. This must stay a no-op (return the current match ID).
+func TestCurrentSocialLobby_FollowToLeaderSameLobby_IsNoop(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	groupID := env.groupID
+
+	sharedLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(sharedLobby, &MatchLabel{
+		ID:          sharedLobby,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+
+	env.setFollowerMatch(sharedLobby)
+	env.setLeaderMatch(sharedLobby)
+	env.params.GroupID = groupID
+	env.params.PartyGroupName = "squad"
+	env.params.CurrentMatchID = sharedLobby
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params, env.lobbyGroup)
+
+	if result != sharedLobby {
+		t.Errorf("rejoin of the leader's (same) social lobby must remain a no-op; expected %s, got %s", sharedLobby, result)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the **two remaining gaps** in the social-lobby rejoin no-op guard added by `234dac5f2`. That guard returned a no-op whenever the player's current social lobby merely shared the **GroupID** of the requested lobby — too broad. It now compares against the **intended target match**.

Fixes #462.

## The two gaps

1. **Not target-aware:** a player already in social lobby X of guild G was wrongly no-op'd when asked to move to a *different* social lobby Y of the same guild G.
2. **Ignored relocation intent:** the relocate path clears `lobbyParams.CurrentMatchID` to force a move to a larger lobby; the group-only guard overrode that and no-op'd the relocation.

## Fix

`currentSocialLobbyForSession` is now **target-aware** — no-op only when the player's current social lobby IS the intended target:
- **Party-follow context** → target is the **leader's match**, resolved tracker-only (mirrors `isFollowerAlreadyInLeaderMatch`, no party-registry side effects).
- **Otherwise** → target is `lobbyParams.CurrentMatchID`; a cleared `CurrentMatchID` (relocate) → nil target → **no** no-op (gap 2).

Plumbed `lobbyGroup` through `lobbyFindOrCreateSocial` from its three call sites (all already had it in scope). **Guild isolation preserved** — the `GetGroupID() != lobbyParams.GroupID` rejection still runs first.

## Tests (TDD, red-first)

- `TestCurrentSocialLobby_MoveToDifferentLobbySameGuild_ReturnsNil` (gap 1)
- `TestCurrentSocialLobby_ForcedRelocation_ReturnsNil` (gap 2)
- Rejoin-same-lobby still a no-op.

Full follow + lobby-find suite under `-race`: **41 pass, 0 fail** — the 30+ existing party-follow tests are unbroken. `go vet` clean, `gofmt` clean.

## Design decisions

- **Plumbed `lobbyGroup`** rather than calling `JoinPartyGroup` inside the guard — avoids party-registry side effects + multi-subsystem coupling (AGENTS.md). Leader resolved tracker-only.
- Followed the existing `CurrentMatchID`-as-target convention from `pollFollowPartyLeader`.

## ⚠️ Open questions / flags

1. **Separate pre-existing failure:** `TestConfigureParty_FollowerNotOnMatchmakingStream_NotKicked` panics (nil deref `configureParty`, `evr_lobby_find.go:511`) — **confirmed on base `234dac5f2`**, not caused by this change. Being fixed separately.
2. `golangci-lint`/`go mod tidy`/`govulncheck` not run (no dep changes); `gofmt`+`vet`+`-race` tests green.

---
*Root-caused via automated read-only inspection; implemented TDD-first in an isolated worktree; diff + tests independently re-verified before opening.*