### PR TITLE
fix: exempt Combat from matchmaker quality floor (#479)

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -63,6 +63,17 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 			}()
 		}
 
+		// Fast path: if the follower is already in the leader's match,
+		// skip all heavyweight operations (authorization, matchmaking
+		// stream, monitor goroutine, TryFollowPartyLeader). This
+		// prevents repeated "Joined party group" / "Already in
+		// leader's match" churn when the client re-sends
+		// LobbyFindSessionRequest on its normal message cycle.
+		if !isLeader && p.isFollowerAlreadyInLeaderMatch(logger, session, lobbyGroup) {
+			logger.Debug("Follower already in leader's match, skipping follow path")
+			return nil
+		}
+
 		// Synchronize mode if the leader is heading to Social.
 		// Cache the result to avoid a TOCTOU double-read later (line 111).
 		headingToSocial = !isLeader && p.isLeaderHeadingToSocial(ctx, logger, session, lobbyParams, lobbyGroup)
@@ -99,6 +110,15 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 
 	if lobbyGroup != nil {
 		if !isLeader {
+			// Guard: if the follower is in an active Arena/Combat match,
+			// do not process the party follow. Let them finish their match.
+			// The party will pick them up when they return to social.
+			// Fixes #460: player mid-match yanked back to social by party follow.
+			if p.isFollowerInActiveMatch(ctx, logger, session) {
+				logger.Info("Follower is in an active arena/combat match, skipping party follow")
+				return nil
+			}
+
 			// Observer: non-leader entering holding pattern, waiting for leader's ticket.
 			if lc := getMatchLifecycle(session); lc != nil {
 				lc.Transition(StateHolding, "waiting for leader's ticket")
@@ -994,6 +1014,86 @@ func (p *EvrPipeline) isLeaderHeadingToSocial(ctx context.Context, logger *zap.L
 	}
 
 	return false
+}
+
+// isFollowerInActiveMatch reports whether the follower (session) is currently
+// in an Arena or Combat match (public or private). When this returns true,
+// the party follow system must not process the LobbyFindSessionRequest —
+// doing so would yank the player out of their active match.
+//
+// Returns false when the session has no match presence, the match label
+// cannot be resolved, or the match is a social lobby.
+//
+// Fixes #460: player mid-match was pulled back to social when party leader
+// hit matchmaking.
+func (p *EvrPipeline) isFollowerInActiveMatch(ctx context.Context, logger *zap.Logger, session *sessionWS) bool {
+	matchStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: session.id,
+		Label:   StreamLabelMatchService,
+	}
+	presence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(session.id, matchStream, session.userID)
+	if presence == nil {
+		return false
+	}
+
+	followerMatchID := MatchIDFromStringOrNil(presence.GetStatus())
+	if followerMatchID.IsNil() {
+		return false
+	}
+
+	label, err := MatchLabelByID(ctx, p.nk, followerMatchID)
+	if err != nil || label == nil {
+		return false
+	}
+
+	return label.IsArena() || label.IsCombat()
+}
+
+// isFollowerAlreadyInLeaderMatch checks whether the follower is already in
+// the same match as the party leader. This is a lightweight tracker-only
+// check (no match registry calls) used as a fast path at the top of
+// lobbyFind to avoid redundant configureParty / authorization / matchmaking
+// stream / TryFollowPartyLeader work when the client re-sends
+// LobbyFindSessionRequest on its normal message cycle.
+//
+// Returns false when the leader cannot be found, either player is not in a
+// match, or their match IDs differ.
+func (p *EvrPipeline) isFollowerAlreadyInLeaderMatch(logger *zap.Logger, session *sessionWS, lobbyGroup *LobbyGroup) bool {
+	leader := lobbyGroup.GetLeader()
+	if leader == nil || leader.SessionId == session.id.String() {
+		return false
+	}
+
+	leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
+	leaderUserID := uuid.FromStringOrNil(leader.UserId)
+
+	leaderStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: leaderSessionID,
+		Label:   StreamLabelMatchService,
+	}
+	leaderPresence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+	if leaderPresence == nil {
+		return false
+	}
+	leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus())
+	if leaderMatchID.IsNil() {
+		return false
+	}
+
+	followerStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: session.id,
+		Label:   StreamLabelMatchService,
+	}
+	followerPresence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(session.id, followerStream, session.userID)
+	if followerPresence == nil {
+		return false
+	}
+	followerMatchID := MatchIDFromStringOrNil(followerPresence.GetStatus())
+
+	return followerMatchID == leaderMatchID
 }
 
 // isLeaderInArenaCombatMatch reports whether the party leader is currently

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -1086,11 +1086,25 @@ func (p *EvrPipeline) cancelTicketForLateArrival(_ context.Context, logger *zap.
 		zap.String("party_id", lobbyGroup.IDStr()),
 		zap.Int("party_size", lobbyGroup.Size()))
 
+	// Remove party-scoped tickets first.
 	if err := lobbyGroup.MatchmakerRemoveAll(); err != nil {
-		logger.Warn("Failed to cancel matchmaking tickets for late arrival",
+		logger.Warn("Failed to cancel party matchmaking tickets for late arrival",
 			zap.Error(err))
-		return
 	}
+
+	// Also remove any solo ticket the leader submitted before the late
+	// arrival joined. When the leader initially had a party of 1, addTicket
+	// takes the solo path and creates a ticket with an empty party ID.
+	// MatchmakerRemoveAll only removes tickets keyed by the party ID, so
+	// the solo ticket survives. RemoveSessionAll catches it.
+	if err := lobbyGroup.MatchmakerRemoveSessionAll(leader.SessionId); err != nil {
+		logger.Warn("Failed to cancel leader session tickets for late arrival",
+			zap.Error(err))
+	}
+
+	// Signal the leader's matchmaking loop to rebuild the ticket
+	// immediately instead of waiting for the fallback timer.
+	lobbyGroup.SignalTicketRebuild()
 
 	// Observer: ticket cancelled due to late arrival.
 	if lc := getMatchLifecycle(session); lc != nil {

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -647,6 +647,16 @@ func flushMatchRegistryLabelUpdates(nk runtime.NakamaModule) {
 }
 
 func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters, entrants ...*EvrMatchPresence) error {
+	// Fast path: if the player is already in a social lobby that matches
+	// the search criteria (same group, social mode), treat as no-op.
+	// This prevents the party follow path from producing an error when it
+	// directs a player to a social lobby they are already in. (#462)
+	if currentMatchID := p.currentSocialLobbyForSession(ctx, logger, session, lobbyParams); !currentMatchID.IsNil() {
+		logger.Debug("Player already in a matching social lobby, treating as no-op",
+			zap.String("mid", currentMatchID.String()))
+		return nil
+	}
+
 	// First attempt runs immediately — no pre-wait. The old 1s pre-query wait
 	// was a workaround for the Bluge label-flush lag; newLobby now flushes
 	// synchronously, so the first query sees fresh state. Subsequent attempts
@@ -1048,6 +1058,52 @@ func (p *EvrPipeline) isFollowerInActiveMatch(ctx context.Context, logger *zap.L
 	}
 
 	return label.IsArena() || label.IsCombat()
+}
+
+// currentSocialLobbyForSession returns the match ID of the social lobby that
+// the player is currently in, if it matches the search criteria (same group ID
+// and social mode). Returns a nil MatchID when the player is not in a matching
+// social lobby.
+//
+// Used as a fast-path guard in lobbyFindOrCreateSocial to avoid rejoining a
+// lobby the player is already in — the party follow path can direct a player
+// to a social lobby they never left. (#462)
+func (p *EvrPipeline) currentSocialLobbyForSession(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters) MatchID {
+	matchStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: session.ID(),
+		Label:   StreamLabelMatchService,
+	}
+
+	ws, ok := session.(*sessionWS)
+	if !ok {
+		return MatchID{}
+	}
+
+	presence := ws.pipeline.tracker.GetLocalBySessionIDStreamUserID(session.ID(), matchStream, session.UserID())
+	if presence == nil {
+		return MatchID{}
+	}
+
+	currentMatchID := MatchIDFromStringOrNil(presence.GetStatus())
+	if currentMatchID.IsNil() {
+		return MatchID{}
+	}
+
+	label, err := MatchLabelByID(ctx, p.nk, currentMatchID)
+	if err != nil || label == nil {
+		return MatchID{}
+	}
+
+	if !label.IsSocial() {
+		return MatchID{}
+	}
+
+	if label.GetGroupID() != lobbyParams.GroupID {
+		return MatchID{}
+	}
+
+	return currentMatchID
 }
 
 // isFollowerAlreadyInLeaderMatch checks whether the follower is already in

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -2265,6 +2265,156 @@ func TestPoll_LeaderInCombatMatch_ReturnsFalseImmediately(t *testing.T) {
 // short-circuit — it defers to context cancellation for loop termination.
 // ---------------------------------------------------------------------------
 
+// ===========================================================================
+// Issue #460: Party follow must not pull a follower out of an active match.
+//
+// When a follower is in an active Arena or Combat match, the party follow
+// system must not process a LobbyFindSessionRequest that would yank them
+// back to the social lobby. isFollowerInActiveMatch returns true for
+// Arena/Combat, false for Social, and false when the follower has no match.
+// ===========================================================================
+
+// TestIsFollowerInActiveMatch_ArenaPublic verifies that a follower in an
+// active ModeArenaPublic match is detected as being in an active match.
+func TestIsFollowerInActiveMatch_ArenaPublic(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(arenaMatchID, &MatchLabel{
+		ID:          arenaMatchID,
+		Mode:        evr.ModeArenaPublic,
+		Open:        true,
+		PlayerLimit: 8,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(arenaMatchID)
+
+	logger := loggerForTest(t)
+	result := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), logger, env.session)
+
+	if !result {
+		t.Error("Expected true when follower is in ModeArenaPublic match")
+	}
+}
+
+// TestIsFollowerInActiveMatch_CombatPublic verifies that a follower in an
+// active ModeCombatPublic match is detected as being in an active match.
+func TestIsFollowerInActiveMatch_CombatPublic(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	combatMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(combatMatchID, &MatchLabel{
+		ID:          combatMatchID,
+		Mode:        evr.ModeCombatPublic,
+		Open:        true,
+		PlayerLimit: 8,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(combatMatchID)
+
+	logger := loggerForTest(t)
+	result := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), logger, env.session)
+
+	if !result {
+		t.Error("Expected true when follower is in ModeCombatPublic match")
+	}
+}
+
+// TestIsFollowerInActiveMatch_SocialPublic verifies that a follower in a
+// ModeSocialPublic lobby is NOT treated as being in an active match. The
+// party follow system should proceed normally for social lobbies.
+func TestIsFollowerInActiveMatch_SocialPublic(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(socialMatchID, &MatchLabel{
+		ID:          socialMatchID,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(socialMatchID)
+
+	logger := loggerForTest(t)
+	result := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), logger, env.session)
+
+	if result {
+		t.Error("Expected false when follower is in ModeSocialPublic — party follow should proceed")
+	}
+}
+
+// TestIsFollowerInActiveMatch_NoMatch verifies that a follower with no
+// current match (e.g. at the main menu) is NOT treated as being in an
+// active match. The party follow system should proceed normally.
+func TestIsFollowerInActiveMatch_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	// No follower match set — follower is not in any match.
+
+	logger := loggerForTest(t)
+	result := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), logger, env.session)
+
+	if result {
+		t.Error("Expected false when follower has no match presence")
+	}
+}
+
+// TestIsFollowerInActiveMatch_PrivateArenaCombat verifies that private
+// arena/combat modes are also treated as active matches.
+func TestIsFollowerInActiveMatch_PrivateArenaCombat(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []evr.Symbol{evr.ModeArenaPrivate, evr.ModeCombatPrivate} {
+		t.Run(mode.String(), func(t *testing.T) {
+			t.Parallel()
+
+			env := newFollowTestEnv(t)
+			matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+			registry := newMockFollowMatchRegistry()
+			groupID := env.groupID
+			registry.SetMatch(matchID, &MatchLabel{
+				ID:          matchID,
+				Mode:        mode,
+				Open:        true,
+				PlayerLimit: 8,
+				GroupID:     &groupID,
+			})
+			env.withMockNK(registry)
+			env.setFollowerMatch(matchID)
+
+			logger := loggerForTest(t)
+			result := env.pipeline.isFollowerInActiveMatch(
+				context.Background(), logger, env.session)
+
+			if !result {
+				t.Errorf("Expected true when follower is in %s match", mode.String())
+			}
+		})
+	}
+}
+
 func TestPoll_NilNK_FollowerNotInLeaderMatch_LoopsUntilContextExpiry(t *testing.T) {
 	t.Parallel()
 
@@ -2293,5 +2443,162 @@ func TestPoll_NilNK_FollowerNotInLeaderMatch_LoopsUntilContextExpiry(t *testing.
 	if elapsed < 1*time.Second {
 		t.Errorf("pollFollowPartyLeader returned in %v — expected it to loop until context expiry (~3s). "+
 			"This suggests a fast-fail path was triggered instead of polling.", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// isFollowerAlreadyInLeaderMatch — issue #461 regression tests
+// ---------------------------------------------------------------------------
+
+// TestIsFollowerAlreadyInLeaderMatch_SameMatch verifies that when the follower
+// and leader are in the same match, isFollowerAlreadyInLeaderMatch returns true.
+// This is the fast path that prevents repeated "Joined party group" /
+// "Already in leader's match" churn when the client re-sends
+// LobbyFindSessionRequest on its normal message cycle.
+func TestIsFollowerAlreadyInLeaderMatch_SameMatch(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	env.setLeaderMatch(matchID)
+	env.setFollowerMatch(matchID)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if !result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return true when both are in the same match")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_DifferentMatches verifies that when the
+// follower and leader are in different matches, the function returns false.
+func TestIsFollowerAlreadyInLeaderMatch_DifferentMatches(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	matchA := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	matchB := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	env.setLeaderMatch(matchA)
+	env.setFollowerMatch(matchB)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return false when in different matches")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_LeaderNotInMatch verifies that when the
+// leader is not in any match, the function returns false.
+func TestIsFollowerAlreadyInLeaderMatch_LeaderNotInMatch(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	// Only follower is in a match; leader is not.
+	env.setFollowerMatch(matchID)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return false when leader has no match")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_FollowerNotInMatch verifies that when the
+// follower is not in any match, the function returns false.
+func TestIsFollowerAlreadyInLeaderMatch_FollowerNotInMatch(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	// Only leader is in a match; follower is not.
+	env.setLeaderMatch(matchID)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return false when follower has no match")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_NoLeader verifies that when the party has
+// no leader, the function returns false gracefully.
+func TestIsFollowerAlreadyInLeaderMatch_NoLeader(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	logger := loggerForTest(t)
+
+	env.clearLeader()
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return false when there is no leader")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_FollowerIsLeader verifies that when the
+// follower is the leader (same session), the function returns false.
+func TestIsFollowerAlreadyInLeaderMatch_FollowerIsLeader(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	// Promote the follower to leader.
+	env.setLeader(env.followerSID, env.followerUID, "follower")
+	env.setFollowerMatch(matchID)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup)
+	if result {
+		t.Error("isFollowerAlreadyInLeaderMatch should return false when follower is the leader")
+	}
+}
+
+// TestIsFollowerAlreadyInLeaderMatch_HeartbeatDoesNotTriggerFollow verifies
+// that non-LobbyFindSessionRequest messages (heartbeats, profile updates)
+// do not reach the party follow path. This is a structural test that confirms
+// the ProcessRequestEVR dispatch table only routes LobbyFindSessionRequest,
+// LobbyCreateSessionRequest, and LobbyJoinSessionRequest to lobbySessionRequest.
+func TestIsFollowerAlreadyInLeaderMatch_HeartbeatDoesNotTriggerFollow(t *testing.T) {
+	t.Parallel()
+
+	// Verify that non-lobby message types are NOT routed to lobbySessionRequest.
+	// The dispatch table in ProcessRequestEVR maps message types to handler
+	// functions. Only LobbyFindSessionRequest, LobbyCreateSessionRequest, and
+	// LobbyJoinSessionRequest should reach lobbySessionRequest (and from there,
+	// lobbyFind). Other message types like GenericMessage, UpdateClientProfile,
+	// RemoteLogSet, etc. are routed to their own handlers that do not call
+	// lobbyFind or any party follow logic.
+
+	// This test validates the contract by checking that the message types that
+	// could be confused as "heartbeat" or "routine client traffic" do not
+	// implement the LobbySessionRequest interface, which is the gate in
+	// lobbySessionRequest (line 38 of evr_pipeline_matchmaker.go).
+	nonLobbyMessages := []evr.Message{
+		&evr.GenericMessage{},
+		&evr.UpdateClientProfile{},
+		&evr.RemoteLogSet{},
+		&evr.ConfigRequest{},
+		&evr.DocumentRequest{},
+		&evr.LoggedInUserProfileRequest{},
+		&evr.ChannelInfoRequest{},
+		&evr.OtherUserProfileRequest{},
+		&evr.LobbyMatchmakerStatusRequest{},
+		&evr.LobbyPingResponse{},
+		&evr.LobbyPendingSessionCancel{},
+	}
+
+	for _, msg := range nonLobbyMessages {
+		if _, ok := msg.(evr.LobbySessionRequest); ok {
+			t.Errorf("%T implements LobbySessionRequest — it would reach "+
+				"lobbySessionRequest and potentially trigger the follow path", msg)
+		}
 	}
 }

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -2602,3 +2602,123 @@ func TestIsFollowerAlreadyInLeaderMatch_HeartbeatDoesNotTriggerFollow(t *testing
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for currentSocialLobbyForSession (#462)
+// ---------------------------------------------------------------------------
+
+// TestCurrentSocialLobby_AlreadyInMatchingSocialLobby verifies that when a
+// player is in a social lobby with the same group ID, the function returns
+// the current match ID (no-op fast path).
+func TestCurrentSocialLobby_AlreadyInMatchingSocialLobby(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(socialMatchID, &MatchLabel{
+		ID:          socialMatchID,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(socialMatchID)
+	env.params.GroupID = groupID
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params)
+
+	if result.IsNil() {
+		t.Error("currentSocialLobbyForSession should return the match ID when player is already in a matching social lobby")
+	}
+	if result != socialMatchID {
+		t.Errorf("expected match ID %s, got %s", socialMatchID, result)
+	}
+}
+
+// TestCurrentSocialLobby_DifferentLobby_ReturnsNil verifies that when a
+// player needs to join a different lobby (different group), the function
+// returns nil so the normal find-or-create proceeds.
+func TestCurrentSocialLobby_DifferentLobby_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	differentGroupID := uuid.Must(uuid.NewV4())
+	registry.SetMatch(socialMatchID, &MatchLabel{
+		ID:          socialMatchID,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		GroupID:     &differentGroupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(socialMatchID)
+	// Searching for a different group.
+	env.params.GroupID = uuid.Must(uuid.NewV4())
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params)
+
+	if !result.IsNil() {
+		t.Error("currentSocialLobbyForSession should return nil when player is in a lobby with a different group ID")
+	}
+}
+
+// TestCurrentSocialLobby_InArenaMatch_ReturnsNil verifies that a player
+// in an arena match is not treated as already in a social lobby.
+func TestCurrentSocialLobby_InArenaMatch_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(arenaMatchID, &MatchLabel{
+		ID:          arenaMatchID,
+		Mode:        evr.ModeArenaPublic,
+		Open:        true,
+		PlayerLimit: 8,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(arenaMatchID)
+	env.params.GroupID = groupID
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params)
+
+	if !result.IsNil() {
+		t.Error("currentSocialLobbyForSession should return nil when player is in an arena match")
+	}
+}
+
+// TestCurrentSocialLobby_NotInAnyMatch_ReturnsNil verifies that a player
+// who is not in any match gets nil (proceed with find-or-create).
+func TestCurrentSocialLobby_NotInAnyMatch_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	registry := newMockFollowMatchRegistry()
+	env.withMockNK(registry)
+	// Do NOT call setFollowerMatch — player has no match presence.
+	env.params.GroupID = env.groupID
+
+	logger := loggerForTest(t)
+	result := env.pipeline.currentSocialLobbyForSession(
+		context.Background(), logger, env.session, env.params)
+
+	if !result.IsNil() {
+		t.Error("currentSocialLobbyForSession should return nil when player is not in any match")
+	}
+}

--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -83,6 +83,41 @@ func (g *LobbyGroup) HasSessionOnTicket(sessionID string) bool {
 	return g.ph.matchmaker.HasSessionOnPartyTicket(g.ph.IDStr, sessionID)
 }
 
+// TicketRebuildCh returns a channel that is signalled when party membership
+// changes require the active matchmaking ticket to be rebuilt. Returns nil
+// when the LobbyGroup or party handler is nil.
+func (g *LobbyGroup) TicketRebuildCh() <-chan struct{} {
+	if g == nil || g.ph == nil {
+		return nil
+	}
+	return g.ph.ticketRebuildCh
+}
+
+// SignalTicketRebuild sends a non-blocking signal on the ticket rebuild
+// channel, notifying the leader's matchmaking loop that the party
+// membership has changed and the ticket must be rebuilt.
+func (g *LobbyGroup) SignalTicketRebuild() {
+	if g == nil || g.ph == nil {
+		return
+	}
+	select {
+	case g.ph.ticketRebuildCh <- struct{}{}:
+	default:
+		// Already signalled; the leader will pick it up.
+	}
+}
+
+// MatchmakerRemoveSessionAll removes all matchmaking tickets associated
+// with the given sessionID, regardless of party affiliation. This is
+// necessary when the leader submitted a solo ticket (no party ID) and a
+// late arrival needs to cancel it.
+func (g *LobbyGroup) MatchmakerRemoveSessionAll(sessionID string) error {
+	if g == nil || g.ph == nil {
+		return nil
+	}
+	return g.ph.matchmaker.RemoveSessionAll(sessionID)
+}
+
 func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID) (*LobbyGroup, bool, error) {
 
 	userPresence := &rtapi.UserPresence{

--- a/server/evr_lobby_matchmake.go
+++ b/server/evr_lobby_matchmake.go
@@ -206,6 +206,14 @@ func (p *EvrPipeline) lobbyMatchMakeWithFallback(ctx context.Context, logger *za
 		return err
 	}
 
+	// rebuildCh is signalled by cancelTicketForLateArrival when a late
+	// party member arrives and the current ticket must be rebuilt with the
+	// full party. May be nil when there is no party.
+	var rebuildCh <-chan struct{}
+	if lobbyGroup != nil {
+		rebuildCh = lobbyGroup.TicketRebuildCh()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -213,6 +221,17 @@ func (p *EvrPipeline) lobbyMatchMakeWithFallback(ctx context.Context, logger *za
 		case <-timeoutTimer.C:
 			logger.Debug("Matchmaking timeout")
 			return ErrMatchmakingTimeout
+
+		case <-rebuildCh:
+			// A late party member arrived and cancelled the current
+			// ticket. Rebuild immediately with the full party.
+			logger.Info("Ticket rebuild triggered by late party arrival",
+				zap.Int("party_size", lobbyGroup.Size()))
+			currentTicket = "" // Already removed by cancelTicketForLateArrival.
+			if err := replaceTicket(ticketConfig); err != nil {
+				return err
+			}
+
 		case <-fallbackTimer.C:
 			fallbackCount++
 

--- a/server/evr_lobby_matchmake_test.go
+++ b/server/evr_lobby_matchmake_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/rtapi"
 	"github.com/heroiclabs/nakama/v3/server/evr"
+	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/stretchr/testify/require"
 	uatomic "go.uber.org/atomic"
-	_ "github.com/jackc/pgx/v5/stdlib"
 )
 
 // stubDB returns a non-nil *sql.DB that will fail gracefully (with an error,
@@ -66,9 +66,10 @@ func makeMatchmakeTestParty(leaderSID, leaderUID, followerSID, followerUID uuid.
 	}
 
 	ph := &PartyHandler{
-		members:    NewPartyPresenceList(8),
-		matchmaker: mm,
-		ctx:        context.Background(),
+		members:         NewPartyPresenceList(8),
+		matchmaker:      mm,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
 	}
 	ph.leader = &PartyLeader{
 		UserPresence: leaderPresence,

--- a/server/evr_lobby_ticket_rebuild_test.go
+++ b/server/evr_lobby_ticket_rebuild_test.go
@@ -1,0 +1,602 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/require"
+	uatomic "go.uber.org/atomic"
+)
+
+// makeTicketRebuildParty creates a PartyHandler with a real matchmaker,
+// joining N members. Returns the LobbyGroup, the leader's sessionID, and
+// all member sessionIDs (leader first). The matchmaker is needed for
+// MatchmakerAdd/Remove to work.
+func makeTicketRebuildParty(t *testing.T, n int) (*LobbyGroup, *LocalMatchmaker, []uuid.UUID, func()) {
+	t.Helper()
+
+	logger := loggerForTest(t)
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+
+	sessionIDs := make([]uuid.UUID, 0, n)
+	for i := 0; i < n; i++ {
+		sid := uuid.Must(uuid.NewV4())
+		uid := uuid.Must(uuid.NewV4())
+		p := &Presence{
+			ID:     PresenceID{SessionID: sid, Node: partyTestNode},
+			UserID: uid,
+			Meta:   PresenceMeta{Username: "user-" + sid.String()[:8]},
+		}
+		ph.Join([]*Presence{p})
+		sessionIDs = append(sessionIDs, sid)
+	}
+
+	lg := &LobbyGroup{name: "test_rebuild_group", ph: ph}
+	return lg, mm, sessionIDs, mmCleanup
+}
+
+// submitLeaderTicket submits a ticket via the party handler's MatchmakerAdd.
+// Returns the ticket string.
+func submitLeaderTicket(t *testing.T, lg *LobbyGroup, leaderSID uuid.UUID) string {
+	t.Helper()
+	ticket, _, err := lg.MatchmakerAdd(
+		leaderSID.String(), partyTestNode, "",
+		2, 8, 2, nil, nil,
+	)
+	require.NoError(t, err, "MatchmakerAdd")
+	require.NotEmpty(t, ticket, "expected non-empty ticket")
+	return ticket
+}
+
+// submitSoloTicket submits a solo ticket via the matchmaker directly (not
+// through the party handler). This simulates what addTicket does when
+// lobbyGroup.Size() == 1.
+func submitSoloTicket(t *testing.T, mm Matchmaker, leaderSID, leaderUID uuid.UUID) string {
+	t.Helper()
+	presences := []*MatchmakerPresence{{
+		UserId:    leaderUID.String(),
+		SessionId: leaderSID.String(),
+		Username:  "leader",
+		Node:      partyTestNode,
+		SessionID: leaderSID,
+	}}
+	ticket, _, err := mm.Add(
+		context.Background(), presences,
+		leaderSID.String(), "", // empty party ID = solo ticket
+		"", 2, 8, 2, nil, nil,
+	)
+	require.NoError(t, err, "solo matchmaker.Add")
+	require.NotEmpty(t, ticket, "expected non-empty solo ticket")
+	return ticket
+}
+
+// ticketPresenceCount returns the number of presences (entries) on a ticket.
+func ticketPresenceCount(t *testing.T, mm *LocalMatchmaker, ticket string) int {
+	t.Helper()
+	mm.Lock()
+	defer mm.Unlock()
+	idx, ok := mm.indexes[ticket]
+	if !ok {
+		t.Fatalf("ticket %s not found in matchmaker indexes", ticket)
+	}
+	return idx.Count
+}
+
+// TestTicketRebuild_LateArrivalIncluded verifies the core fix: when a late
+// party member arrives after the leader submitted a solo ticket, the solo
+// ticket is cancelled and the rebuilt ticket includes both members.
+//
+// Scenario:
+//  1. Leader creates party alone (size=1), submits solo ticket (no party ID)
+//  2. Follower joins party (size=2)
+//  3. cancelTicketForLateArrival fires — must cancel the solo ticket
+//  4. Rebuild signal fires — leader rebuilds via MatchmakerAdd
+//  5. New ticket has presences=2
+func TestTicketRebuild_LateArrivalIncluded(t *testing.T) {
+	t.Parallel()
+
+	logger := loggerForTest(t)
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	// Step 1: Leader creates party alone.
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+	leaderPresence := &Presence{
+		ID:     PresenceID{SessionID: leaderSID, Node: partyTestNode},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}
+	ph.Join([]*Presence{leaderPresence})
+
+	lg := &LobbyGroup{name: "dumpsterfire", ph: ph}
+	require.Equal(t, 1, lg.Size(), "party should start with leader only")
+
+	// Leader submits a solo ticket (simulating addTicket's solo path).
+	soloTicket := submitSoloTicket(t, mm, leaderSID, leaderUID)
+	require.Equal(t, 1, ticketPresenceCount(t, mm, soloTicket),
+		"solo ticket should have 1 presence")
+
+	// Step 2: Follower joins the party.
+	followerSID := uuid.Must(uuid.NewV4())
+	followerUID := uuid.Must(uuid.NewV4())
+	followerPresence := &Presence{
+		ID:     PresenceID{SessionID: followerSID, Node: partyTestNode},
+		UserID: followerUID,
+		Meta:   PresenceMeta{Username: "follower"},
+	}
+	_, err := ph.JoinRequest(followerPresence)
+	require.NoError(t, err, "follower JoinRequest")
+	require.Equal(t, 2, lg.Size(), "party should now have 2 members")
+
+	// Step 3: Simulate cancelTicketForLateArrival.
+	// MatchmakerRemoveAll should not remove the solo ticket (no party ID).
+	_ = lg.MatchmakerRemoveAll()
+
+	// The solo ticket should still exist because it has no party ID.
+	mm.Lock()
+	_, soloStillExists := mm.indexes[soloTicket]
+	mm.Unlock()
+	// With the fix, MatchmakerRemoveSessionAll catches it.
+	err = lg.MatchmakerRemoveSessionAll(leaderSID.String())
+	require.NoError(t, err, "RemoveSessionAll")
+
+	// After session removal, the solo ticket should be gone.
+	mm.Lock()
+	_, soloExistsAfterFix := mm.indexes[soloTicket]
+	mm.Unlock()
+	if soloStillExists {
+		// Before the fix, MatchmakerRemoveAll alone would not remove it.
+		require.False(t, soloExistsAfterFix,
+			"solo ticket must be removed after RemoveSessionAll")
+	}
+
+	// Signal the rebuild.
+	lg.SignalTicketRebuild()
+
+	// Verify the signal was sent.
+	select {
+	case <-lg.TicketRebuildCh():
+		// Good — signal received.
+	default:
+		t.Fatal("expected rebuild signal on TicketRebuildCh")
+	}
+
+	// Step 4: Leader rebuilds the ticket via MatchmakerAdd.
+	newTicket := submitLeaderTicket(t, lg, leaderSID)
+
+	// Step 5: New ticket must have 2 presences.
+	require.Equal(t, 2, ticketPresenceCount(t, mm, newTicket),
+		"rebuilt ticket must include both leader and late arrival")
+}
+
+// TestTicketRebuild_MultipleLateArrivals verifies that when two members
+// join after the leader's initial solo ticket, the rebuilt ticket includes
+// all three members.
+func TestTicketRebuild_MultipleLateArrivals(t *testing.T) {
+	t.Parallel()
+
+	logger := loggerForTest(t)
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	// Leader starts alone.
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+	ph.Join([]*Presence{{
+		ID:     PresenceID{SessionID: leaderSID, Node: partyTestNode},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}})
+	lg := &LobbyGroup{name: "test_multi_late", ph: ph}
+
+	// Solo ticket.
+	soloTicket := submitSoloTicket(t, mm, leaderSID, leaderUID)
+	require.Equal(t, 1, ticketPresenceCount(t, mm, soloTicket))
+
+	// Two late arrivals join.
+	for i := 0; i < 2; i++ {
+		sid := uuid.Must(uuid.NewV4())
+		uid := uuid.Must(uuid.NewV4())
+		_, err := ph.JoinRequest(&Presence{
+			ID:     PresenceID{SessionID: sid, Node: partyTestNode},
+			UserID: uid,
+			Meta:   PresenceMeta{Username: "late-" + sid.String()[:4]},
+		})
+		require.NoError(t, err)
+	}
+	require.Equal(t, 3, lg.Size(), "party should have 3 members")
+
+	// Cancel and rebuild.
+	_ = lg.MatchmakerRemoveAll()
+	require.NoError(t, lg.MatchmakerRemoveSessionAll(leaderSID.String()))
+	lg.SignalTicketRebuild()
+
+	// Drain the signal.
+	select {
+	case <-lg.TicketRebuildCh():
+	default:
+		t.Fatal("expected rebuild signal")
+	}
+
+	newTicket := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 3, ticketPresenceCount(t, mm, newTicket),
+		"rebuilt ticket must include all 3 members")
+}
+
+// TestTicketRebuild_NoLateArrival_UnchangedOnFallback verifies that when
+// both members were on the original ticket and the fallback timer fires,
+// the rebuilt ticket still has both members (regression test).
+func TestTicketRebuild_NoLateArrival_UnchangedOnFallback(t *testing.T) {
+	t.Parallel()
+
+	lg, mm, sessionIDs, cleanup := makeTicketRebuildParty(t, 2)
+	defer cleanup()
+	leaderSID := sessionIDs[0]
+
+	require.Equal(t, 2, lg.Size())
+
+	// Submit initial party ticket (both members present from the start).
+	ticket1 := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 2, ticketPresenceCount(t, mm, ticket1))
+
+	// Simulate fallback: remove old ticket, submit new one.
+	mm.Remove([]string{ticket1})
+	ticket2 := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 2, ticketPresenceCount(t, mm, ticket2),
+		"fallback rebuild must preserve both members")
+}
+
+// TestTicketRebuild_LateArrivalAfterMultipleRebuilds verifies that a late
+// arrival is included even when the leader's ticket has been rebuilt
+// multiple times by the fallback timer before the member joins.
+func TestTicketRebuild_LateArrivalAfterMultipleRebuilds(t *testing.T) {
+	t.Parallel()
+
+	logger := loggerForTest(t)
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+	ph.Join([]*Presence{{
+		ID:     PresenceID{SessionID: leaderSID, Node: partyTestNode},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}})
+	lg := &LobbyGroup{name: "test_multi_rebuild", ph: ph}
+
+	// Solo ticket, then two fallback rebuilds.
+	for i := 0; i < 3; i++ {
+		ticket := submitSoloTicket(t, mm, leaderSID, leaderUID)
+		require.Equal(t, 1, ticketPresenceCount(t, mm, ticket))
+		mm.Remove([]string{ticket})
+	}
+
+	// Now a late arrival joins.
+	followerSID := uuid.Must(uuid.NewV4())
+	followerUID := uuid.Must(uuid.NewV4())
+	_, err := ph.JoinRequest(&Presence{
+		ID:     PresenceID{SessionID: followerSID, Node: partyTestNode},
+		UserID: followerUID,
+		Meta:   PresenceMeta{Username: "follower"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, lg.Size())
+
+	// Rebuild after cancellation.
+	require.NoError(t, lg.MatchmakerRemoveSessionAll(leaderSID.String()))
+	lg.SignalTicketRebuild()
+
+	select {
+	case <-lg.TicketRebuildCh():
+	default:
+		t.Fatal("expected rebuild signal")
+	}
+
+	newTicket := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 2, ticketPresenceCount(t, mm, newTicket),
+		"rebuilt ticket after multiple fallbacks must include late arrival")
+}
+
+// TestTicketRebuild_MemberLeavesDuringMatchmaking verifies that when a
+// party member leaves while matchmaking is active, the rebuilt ticket
+// reflects the reduced party size.
+func TestTicketRebuild_MemberLeavesDuringMatchmaking(t *testing.T) {
+	t.Parallel()
+
+	lg, mm, sessionIDs, cleanup := makeTicketRebuildParty(t, 3)
+	defer cleanup()
+	leaderSID := sessionIDs[0]
+	leaverSID := sessionIDs[2]
+
+	require.Equal(t, 3, lg.Size())
+
+	// Submit ticket with all 3.
+	ticket := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 3, ticketPresenceCount(t, mm, ticket))
+
+	// Member leaves.
+	leaverPresence := &Presence{
+		ID: PresenceID{SessionID: leaverSID, Node: partyTestNode},
+	}
+	lg.ph.Leave([]*Presence{leaverPresence})
+	require.Equal(t, 2, lg.Size(), "party should have 2 members after leave")
+
+	// Rebuild.
+	mm.Remove([]string{ticket})
+	newTicket := submitLeaderTicket(t, lg, leaderSID)
+	require.Equal(t, 2, ticketPresenceCount(t, mm, newTicket),
+		"rebuilt ticket must reflect member departure (not stale size=3)")
+}
+
+// TestTicketRebuild_SoloTicketNotCancelledByPartyRemoveAll confirms the
+// root cause: MatchmakerRemoveAll does NOT remove solo tickets (tickets
+// with an empty party ID). This is why RemoveSessionAll is needed.
+func TestTicketRebuild_SoloTicketNotCancelledByPartyRemoveAll(t *testing.T) {
+	t.Parallel()
+
+	logger := loggerForTest(t)
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+	ph.Join([]*Presence{{
+		ID:     PresenceID{SessionID: leaderSID, Node: partyTestNode},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}})
+	lg := &LobbyGroup{name: "test_solo_cancel", ph: ph}
+
+	// Submit solo ticket.
+	soloTicket := submitSoloTicket(t, mm, leaderSID, leaderUID)
+
+	// MatchmakerRemoveAll uses party ID — solo ticket has none.
+	_ = lg.MatchmakerRemoveAll()
+
+	mm.Lock()
+	_, exists := mm.indexes[soloTicket]
+	mm.Unlock()
+	require.True(t, exists,
+		"MatchmakerRemoveAll must NOT remove solo tickets (empty party ID) — "+
+			"this is the root cause of #459")
+
+	// RemoveSessionAll catches it.
+	require.NoError(t, lg.MatchmakerRemoveSessionAll(leaderSID.String()))
+	mm.Lock()
+	_, exists = mm.indexes[soloTicket]
+	mm.Unlock()
+	require.False(t, exists,
+		"RemoveSessionAll must remove the solo ticket")
+}
+
+// TestTicketRebuild_SignalChannelIdempotent verifies that multiple signals
+// don't block or panic (channel capacity is 1, non-blocking send).
+func TestTicketRebuild_SignalChannelIdempotent(t *testing.T) {
+	t.Parallel()
+
+	lg, _, _, cleanup := makeTicketRebuildParty(t, 2)
+	defer cleanup()
+
+	// Signal twice — must not block or panic.
+	lg.SignalTicketRebuild()
+	lg.SignalTicketRebuild()
+
+	// Only one signal should be on the channel.
+	select {
+	case <-lg.TicketRebuildCh():
+	default:
+		t.Fatal("expected at least one rebuild signal")
+	}
+
+	// Channel should now be empty.
+	select {
+	case <-lg.TicketRebuildCh():
+		t.Fatal("channel should be empty after draining one signal")
+	default:
+		// Good.
+	}
+}
+
+// TestTicketRebuild_ChannelSelectDirect verifies the select-on-rebuild-channel
+// behavior in isolation, without the full lobbyMatchMakeWithFallback machinery.
+func TestTicketRebuild_ChannelSelectDirect(t *testing.T) {
+	t.Parallel()
+
+	lg, _, _, cleanup := makeTicketRebuildParty(t, 1)
+	defer cleanup()
+
+	rebuildCh := lg.TicketRebuildCh()
+	require.NotNil(t, rebuildCh, "TicketRebuildCh must not be nil")
+
+	// Signal the rebuild.
+	lg.SignalTicketRebuild()
+
+	// Select should immediately fire on rebuildCh.
+	select {
+	case <-rebuildCh:
+		// Good.
+	case <-time.After(1 * time.Second):
+		t.Fatal("select on rebuildCh did not fire within 1 second")
+	}
+}
+
+// TestTicketRebuild_MatchMakeWithFallbackIntegration verifies that the
+// addTicket function produces a party ticket (count=2) when lobbyGroup
+// has 2 members, even after previously submitting a solo ticket (count=1).
+// This tests the core path that lobbyMatchMakeWithFallback's replaceTicket
+// closure exercises.
+func TestTicketRebuild_MatchMakeWithFallbackIntegration(t *testing.T) {
+	t.Parallel()
+
+	logger := loggerForTest(t)
+	tracker := newMockMatchmakingTracker()
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	ph := &PartyHandler{
+		logger:          logger,
+		members:         NewPartyPresenceList(10),
+		matchmaker:      mm,
+		router:          &DummyMessageRouter{},
+		Open:            true,
+		MaxSize:         10,
+		ctx:             context.Background(),
+		ticketRebuildCh: make(chan struct{}, 1),
+	}
+	ph.Join([]*Presence{{
+		ID:     PresenceID{SessionID: leaderSID, Node: partyTestNode},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}})
+	lg := &LobbyGroup{name: "integration_test", ph: ph}
+	require.Equal(t, 1, lg.Size())
+
+	leaderSession := &sessionWS{}
+	leaderSession.id = leaderSID
+	leaderSession.userID = leaderUID
+	leaderSession.username = uatomic.NewString("leader")
+	leaderSession.matchmaker = mm
+	leaderSession.pipeline = &Pipeline{node: partyTestNode, tracker: tracker}
+
+	lobbyParams := makeMatchmakeTestLobbyParams(leaderUID, groupID, evr.ModeArenaPublic, 1)
+
+	p := &EvrPipeline{
+		node:   partyTestNode,
+		config: cfg,
+		db:     stubDB(t),
+		nk: &RuntimeGoNakamaModule{
+			tracker:       tracker,
+			streamManager: testStreamManager{},
+		},
+	}
+
+	ticketConfig := DefaultMatchmakerTicketConfigs[evr.ModeArenaPublic]
+
+	// Step 1: addTicket with size=1 should produce a solo ticket.
+	soloTicket, err := p.addTicket(context.Background(), logger, leaderSession, lobbyParams, lg, ticketConfig)
+	require.NoError(t, err, "addTicket (solo)")
+	require.NotEmpty(t, soloTicket, "solo ticket should not be empty")
+	require.Equal(t, 1, ticketPresenceCount(t, mm, soloTicket),
+		"solo ticket must have 1 presence")
+
+	// Step 2: Follower joins the party.
+	followerSID := uuid.Must(uuid.NewV4())
+	followerUID := uuid.Must(uuid.NewV4())
+	_, joinErr := ph.JoinRequest(&Presence{
+		ID:     PresenceID{SessionID: followerSID, Node: partyTestNode},
+		UserID: followerUID,
+		Meta:   PresenceMeta{Username: "follower"},
+	})
+	require.NoError(t, joinErr, "follower JoinRequest")
+	require.Equal(t, 2, lg.Size(), "party should now have 2 members")
+
+	// Step 3: Cancel the solo ticket.
+	require.NoError(t, lg.MatchmakerRemoveSessionAll(leaderSID.String()))
+
+	// Step 4: Rebuild — addTicket with size=2 should produce a party ticket.
+	partyTicket, err := p.addTicket(context.Background(), logger, leaderSession, lobbyParams, lg, ticketConfig)
+	require.NoError(t, err, "addTicket (party rebuild)")
+	require.NotEmpty(t, partyTicket, "party ticket should not be empty")
+	require.Equal(t, 2, ticketPresenceCount(t, mm, partyTicket),
+		"rebuilt party ticket must have 2 presences")
+
+	// Step 5: Verify the rebuild channel was signalled by JoinRequest
+	// (JoinRequest calls RemovePartyAll which triggers signal).
+	// Actually, the signal is sent by cancelTicketForLateArrival, not
+	// JoinRequest. Verify the channel mechanism works.
+	lg.SignalTicketRebuild()
+	select {
+	case <-lg.TicketRebuildCh():
+		// Good — signal delivered.
+	case <-time.After(1 * time.Second):
+		t.Fatal("expected rebuild signal on TicketRebuildCh")
+	}
+}
+
+// TestTicketRebuild_NilLobbyGroup_NoPanic verifies that the rebuild
+// channel handling is safe when lobbyGroup is nil (solo player).
+func TestTicketRebuild_NilLobbyGroup_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Nil pointer to LobbyGroup.
+	var lg *LobbyGroup
+	require.Nil(t, lg)
+
+	ch := lg.TicketRebuildCh()
+	require.Nil(t, ch, "nil lobbyGroup should return nil channel")
+
+	lg.SignalTicketRebuild() // Must not panic.
+
+	require.NoError(t, lg.MatchmakerRemoveSessionAll("anything"))
+
+	// LobbyGroup with nil party handler.
+	lgNoHandler := &LobbyGroup{name: "no-handler"}
+	ch2 := lgNoHandler.TicketRebuildCh()
+	require.Nil(t, ch2, "nil party handler should return nil channel")
+
+	lgNoHandler.SignalTicketRebuild() // Must not panic.
+	require.NoError(t, lgNoHandler.MatchmakerRemoveSessionAll("anything"))
+}

--- a/server/evr_matchmaker_quality_floor.go
+++ b/server/evr_matchmaker_quality_floor.go
@@ -1,6 +1,24 @@
 package server
 
-import "math"
+import (
+	"math"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// isCombatCandidate reports whether a predicted match is for the Combat mode
+// (echo_combat / evr.ModeCombatPublic). Combat must NEVER be skill-gated at
+// match creation (issue #479): SBMM is only allowed to sort players onto teams,
+// not to decide whether a combat match forms. The mode is carried per-entry in
+// the "game_mode" property, mirroring how groupEntriesSequentially and
+// predictCandidateOutcomes read it.
+func isCombatCandidate(prediction PredictedMatch) bool {
+	if len(prediction.Candidate) == 0 {
+		return false
+	}
+	modeStr, _ := prediction.Candidate[0].GetProperties()["game_mode"].(string)
+	return modeStr == evr.ModeCombatPublic.String()
+}
 
 // computeQualityFloor calculates the effective quality floor for a given wait time.
 // The floor decays linearly from QualityFloorInitial toward QualityFloorMinimum
@@ -40,6 +58,16 @@ func filterByQualityFloor(predictions []PredictedMatch, settings *GlobalMatchmak
 
 	filtered := make([]PredictedMatch, 0, len(predictions))
 	for _, p := range predictions {
+		// Combat (echo_combat) is never skill-gated at match creation (issue
+		// #479). SBMM may only sort players onto teams for combat, so combat
+		// candidates always pass the quality floor regardless of DrawProb. This
+		// keeps combat match formation count/availability-only. Arena and other
+		// modes are unaffected.
+		if isCombatCandidate(p) {
+			filtered = append(filtered, p)
+			continue
+		}
+
 		maxWaitSeconds := float64(nowUnix - p.OldestTicketTimestamp)
 		if maxWaitSeconds < 0 {
 			maxWaitSeconds = 0

--- a/server/evr_matchmaker_quality_floor_test.go
+++ b/server/evr_matchmaker_quality_floor_test.go
@@ -7,7 +7,74 @@ import (
 	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
 )
+
+// TestFilterByQualityFloorExemptsCombat asserts the issue #479 invariant:
+// Combat (echo_combat / ModeCombatPublic) must NEVER be skill-gated at match
+// creation. With EnableQualityFloor=true, a Combat candidate whose DrawProb is
+// below the floor must NOT be dropped, while an Arena candidate below the same
+// floor IS still dropped (other modes unchanged).
+func TestFilterByQualityFloorExemptsCombat(t *testing.T) {
+	now := time.Now().UTC().Unix()
+	recentTime := now // submitted now => floor is at initial (0.10)
+
+	makeEntry := func(ticket, sessionID, mode string) *MatchmakerEntry {
+		return &MatchmakerEntry{
+			Ticket:   ticket,
+			Presence: &MatchmakerPresence{SessionId: sessionID},
+			Properties: map[string]interface{}{
+				"game_mode":    mode,
+				"rating_mu":    25.0,
+				"rating_sigma": 8.333,
+			},
+		}
+	}
+
+	settings := GlobalMatchmakingSettings{
+		EnableQualityFloor:         true,
+		QualityFloorInitial:        0.10,
+		QualityFloorDecayPerSecond: 0.0005,
+		QualityFloorMinimum:        0.0,
+	}
+
+	combatMode := evr.ModeCombatPublic.String()
+	arenaMode := evr.ModeArenaPublic.String()
+
+	predictions := []PredictedMatch{
+		{
+			// Combat candidate below the floor -- MUST pass (combat is never skill-gated).
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("c1", "cs1", combatMode),
+				makeEntry("c1", "cs2", combatMode),
+			},
+			DrawProb:              0.02, // well below floor of 0.10
+			Size:                  2,
+			OldestTicketTimestamp: recentTime,
+		},
+		{
+			// Arena candidate below the floor -- MUST still be dropped (unchanged).
+			Candidate: []runtime.MatchmakerEntry{
+				makeEntry("a1", "as1", arenaMode),
+				makeEntry("a1", "as2", arenaMode),
+			},
+			DrawProb:              0.02, // well below floor of 0.10
+			Size:                  2,
+			OldestTicketTimestamp: recentTime,
+		},
+	}
+
+	filtered := filterByQualityFloor(predictions, &settings, now)
+
+	if len(filtered) != 1 {
+		t.Fatalf("expected exactly 1 prediction after filtering (combat kept, arena dropped), got %d", len(filtered))
+	}
+
+	gotMode, _ := filtered[0].Candidate[0].GetProperties()["game_mode"].(string)
+	if gotMode != combatMode {
+		t.Fatalf("expected the surviving candidate to be the Combat one (%q), got %q", combatMode, gotMode)
+	}
+}
 
 func TestComputeQualityFloor(t *testing.T) {
 	settings := GlobalMatchmakingSettings{

--- a/server/party_handler.go
+++ b/server/party_handler.go
@@ -59,6 +59,13 @@ type PartyHandler struct {
 	joinRequests          []*PartyJoinRequest
 
 	members *PartyPresenceList
+
+	// ticketRebuildCh is signalled when party membership changes while a
+	// matchmaking ticket is active. The leader's lobbyMatchMakeWithFallback
+	// selects on this channel to trigger an immediate ticket rebuild instead
+	// of waiting for the fallback timer. The channel is non-blocking (cap 1)
+	// so senders never block.
+	ticketRebuildCh chan struct{}
 }
 
 func NewPartyHandler(logger *zap.Logger, partyRegistry PartyRegistry, matchmaker Matchmaker, tracker Tracker, streamManager StreamManager, router MessageRouter, id uuid.UUID, node string, open bool, maxSize int, presence *rtapi.UserPresence) *PartyHandler {
@@ -86,7 +93,8 @@ func NewPartyHandler(logger *zap.Logger, partyRegistry PartyRegistry, matchmaker
 		leader:                nil,
 		joinRequests:          make([]*PartyJoinRequest, 0, maxSize),
 
-		members: NewPartyPresenceList(maxSize),
+		members:         NewPartyPresenceList(maxSize),
+		ticketRebuildCh: make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
Closes #479.

**Invariant:** Combat (`echo_combat` / `ModeCombatPublic`) must never use SBMM to *create* matches — only to *sort players onto teams*. This held only by virtue of `EnableQualityFloor` defaulting false; `filterByQualityFloor` was not mode-gated, so flipping that flag would skill-gate combat *creation*.

**Fix:** combat candidates short-circuit past the quality floor at the per-candidate drop decision (inside `filterByQualityFloor`, before any floor math). Safe regardless of where/whether the function is called. Arena and all other modes are byte-for-byte unchanged.

Mode read via `Candidate[0].GetProperties()["game_mode"]` vs `evr.ModeCombatPublic.String()` — same source/comparison already used by `groupEntriesSequentially` and `predictCandidateOutcomes`. Empty-candidate guard returns non-combat (no nil deref).

**Test (TDD, red-first):** `TestFilterByQualityFloorExemptsCombat` — with `EnableQualityFloor=true`, a Combat candidate below the floor is KEPT while an Arena candidate below the floor is still DROPPED. `go test -race` green; vet + gofmt clean.

Verified: the quality floor was the only skill-derived *drop-from-creation* gate; toxic-separation and RTT filters aren't skill-based; the rest of the SBMM machinery only sorts/forms teams.