### PR TITLE
fix: stop create-match monitor on token expiry; quiet expected interaction errors (#421)

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2,9 +2,9 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
 	"encoding/binary"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2626,10 +2626,20 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				ticker := time.NewTicker(15 * time.Second)
 				defer ticker.Stop()
 
+				// Discord interaction tokens expire ~15 minutes after the
+				// interaction is created. Bound the monitor's lifetime to just
+				// under that as belt-and-suspenders so it never edits with a
+				// dead token even if expiry detection is missed.
+				deadline := time.NewTimer(14 * time.Minute)
+				defer deadline.Stop()
+
 				// Monitor the match and update the interaction
 				for {
 					select {
 					case <-d.ctx.Done():
+						return
+					case <-deadline.C:
+						logger.Info("interaction token lifetime reached; stopping match monitor")
 						return
 					case <-ticker.C:
 					}
@@ -2646,6 +2656,10 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 						if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 							Embeds: &responseContent.Data.Embeds,
 						}); err != nil {
+							if isInteractionTokenExpired(err) {
+								logger.Info("interaction token expired; stopping match monitor")
+								return
+							}
 							logger.Error("Failed to update interaction", zap.Error(err))
 						}
 						return
@@ -2666,6 +2680,10 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 					if _, err = s.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
 						Embeds: &responseContent.Data.Embeds,
 					}); err != nil {
+						if isInteractionTokenExpired(err) {
+							logger.Info("interaction token expired; stopping match monitor")
+							return
+						}
 						logger.Error("Failed to update interaction", zap.Error(err))
 						return
 					}
@@ -3599,7 +3617,16 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 			if handler, ok := commandHandlers[appCommandName]; ok {
 				err := d.handleInteractionApplicationCommand(ctx, logger, s, i, appCommandName, handler)
 				if err != nil {
-					logger.WithField("err", err).Error("Failed to handle interaction")
+					// Expected, user-facing failures (rate limits, no free
+					// servers, player-not-found) are benign outcomes of normal
+					// usage and log at Warn so they don't trip error dashboards.
+					// The deferred response is still edited with err.Error()
+					// below either way.
+					if isExpectedUserError(err) {
+						logger.WithField("err", err).Warn("Failed to handle interaction")
+					} else {
+						logger.WithField("err", err).Error("Failed to handle interaction")
+					}
 					// Queue the user to be updated in the cache
 					userID := d.cache.DiscordIDToUserID(user.ID)
 					groupID := d.cache.GuildIDToGroupID(i.GuildID)
@@ -4788,6 +4815,44 @@ func (d *DiscordAppBot) getSkipDeferredACKCommands() map[string]bool {
 func IsDiscordErrorCode(err error, code int) bool {
 	var restError *discordgo.RESTError
 	if errors.As(err, &restError) && restError.Message != nil && restError.Message.Code == code {
+		return true
+	}
+	return false
+}
+
+// isInteractionTokenExpired reports whether err indicates the Discord
+// interaction/webhook token is no longer usable. Discord interaction tokens
+// expire ~15 minutes after the interaction is created; once expired,
+// InteractionResponseEdit (a webhook edit under the hood) returns one of:
+//
+//	50027 — Invalid Webhook Token
+//	10015 — Unknown Webhook
+//
+// The create-match monitor uses this to stop cleanly instead of spamming the
+// error log every 15s for the life of the process.
+func isInteractionTokenExpired(err error) bool {
+	return IsDiscordErrorCode(err, 50027) || IsDiscordErrorCode(err, 10015)
+}
+
+// isExpectedUserError reports whether err is an expected, user-facing failure
+// that should be logged at Warn rather than Error. These are benign outcomes
+// of normal usage (rate limits, no free game servers, looking up a player who
+// is not in a match) and must not trip error dashboards. Genuinely unexpected
+// failures (DB/storage/internal) return false and stay at Error.
+func isExpectedUserError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// gRPC rate-limit (e.g. /create command rate limiter).
+	if status.Code(err) == codes.ResourceExhausted {
+		return true
+	}
+	// Allocation could not find a free game server.
+	if errors.Is(err, ErrMatchmakingNoAvailableServers) {
+		return true
+	}
+	// A targeted player was not found in the requested match/guild.
+	if errors.Is(err, ErrPlayerNotFound) || strings.Contains(err.Error(), "player not found") {
 		return true
 	}
 	return false

--- a/server/evr_discord_appbot_interaction_noise_test.go
+++ b/server/evr_discord_appbot_interaction_noise_test.go
@@ -1,0 +1,109 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// restErr builds a *discordgo.RESTError carrying the given Discord API error code,
+// matching what IsDiscordErrorCode inspects.
+func restErr(code int) *discordgo.RESTError {
+	return &discordgo.RESTError{
+		Message: &discordgo.APIErrorMessage{Code: code},
+	}
+}
+
+// TestIsInteractionTokenExpired verifies that the create-match monitor's
+// stop condition fires only for the two Discord webhook-token-expiry codes
+// (50027 Invalid Webhook Token, 10015 Unknown Webhook) and nothing else.
+func TestIsInteractionTokenExpired(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "invalid webhook token (50027)", err: restErr(50027), want: true},
+		{name: "unknown webhook (10015)", err: restErr(10015), want: true},
+		{name: "wrapped invalid webhook token", err: fmt.Errorf("edit failed: %w", restErr(50027)), want: true},
+		{name: "wrapped unknown webhook", err: fmt.Errorf("edit failed: %w", restErr(10015)), want: true},
+		{name: "other REST error (rate limited 429)", err: restErr(20028), want: false},
+		{name: "plain error", err: errors.New("boom"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isInteractionTokenExpired(tt.err); got != tt.want {
+				t.Fatalf("isInteractionTokenExpired(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsExpectedUserError verifies the dispatch-error classifier: expected,
+// user-facing failures must be logged at Warn (true), while genuinely
+// unexpected failures (DB/storage/internal) stay at Error (false).
+func TestIsExpectedUserError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{
+			name: "grpc ResourceExhausted (rate limit)",
+			err:  status.Error(codes.ResourceExhausted, "rate limit exceeded for match creation (1 per minute)"),
+			want: true,
+		},
+		{
+			name: "wrapped grpc ResourceExhausted",
+			err:  fmt.Errorf("create: %w", status.Error(codes.ResourceExhausted, "rate limit exceeded")),
+			want: true,
+		},
+		{
+			name: "no available servers (allocate failure)",
+			err:  ErrMatchmakingNoAvailableServers,
+			want: true,
+		},
+		{
+			name: "wrapped no available servers",
+			err:  fmt.Errorf("allocate: %w", ErrMatchmakingNoAvailableServers),
+			want: true,
+		},
+		{
+			name: "player not found",
+			err:  ErrPlayerNotFound,
+			want: true,
+		},
+		{
+			name: "inline player not found",
+			err:  errors.New("player not found"),
+			want: true,
+		},
+		{
+			name: "grpc Internal (DB/storage) stays Error",
+			err:  status.Error(codes.Internal, "failed to read latency history"),
+			want: false,
+		},
+		{
+			name: "generic storage error stays Error",
+			err:  errors.New("storage: write failed"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isExpectedUserError(tt.err); got != tt.want {
+				t.Fatalf("isExpectedUserError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #421.

The ticket conflated two things; only Part A is a real defect.

## Part A — real bug
The create-match status-monitor goroutine (`evr_discord_appbot.go`) polls the match every 15s and edits the interaction response. After the Discord interaction token expires (~15 min) it **spammed errors every 15s for the life of the process.** Now it detects token expiry (`isInteractionTokenExpired` → Discord codes 50027 *Invalid Webhook Token* / 10015 *Unknown Webhook*) in both edit branches, logs at **Info** and stops cleanly. Belt-and-suspenders: a 14-min deadline in the goroutine's select. (Did NOT switch to followups/channel messages — same token expiry, and a channel message would leak the ephemeral reservation.)

## Part B — log noise
The dispatch error path logged **everything** at `Error`. Expected user-facing errors are now `Warn` (response still edited identically): gRPC `ResourceExhausted` (rate limit), `ErrMatchmakingNoAvailableServers`, `player not found`. Genuine/unexpected errors (DB/storage) stay `Error`. Stops benign events from tripping error dashboards.

## Tests
`isInteractionTokenExpired` / `isExpectedUserError` classification covered in isolation (the Discord round-trip isn't unit-testable). `go test -race` green, vet + build clean.

*Read-only inspection confirmed the root cause; implemented TDD-first; diff + tests re-verified before opening.*