### PR TITLE
fix: store EnforcementMetrics under bot owner, group as key (#417, #420)

### DIFF
--- a/server/evr_enforcement_metrics.go
+++ b/server/evr_enforcement_metrics.go
@@ -12,7 +12,6 @@ import (
 
 const (
 	StorageCollectionEnforcementMetrics = "EnforcementMetrics"
-	StorageKeyEnforcementMetrics        = "metrics"
 )
 
 // EnforcementActionMetrics tracks statistics about enforcement actions
@@ -53,18 +52,23 @@ func NewEnforcementActionMetrics(groupID string) *EnforcementActionMetrics {
 }
 
 func (m *EnforcementActionMetrics) StorageMeta() StorableMetadata {
+	// The object is per-guild and keyed by the guild groupID. The storage OWNER
+	// (UserID) is supplied at write time as the bot user — NOT the groupID — to
+	// satisfy the storage table's FOREIGN KEY (user_id) REFERENCES users(id).
+	// Mirrors GuildGroupState. See #417 / #420.
 	return StorableMetadata{
 		Collection:      StorageCollectionEnforcementMetrics,
-		Key:             StorageKeyEnforcementMetrics,
+		Key:             m.GroupID,
 		PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
 		PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
 		Version:         m.version,
-		UserID:          m.GroupID,
 	}
 }
 
 func (m *EnforcementActionMetrics) SetStorageMeta(meta StorableMetadata) {
-	m.GroupID = meta.UserID
+	// The group id lives in the Key (the owner is the bot user), so derive
+	// GroupID from the Key, not the owner.
+	m.GroupID = meta.Key
 	m.version = meta.Version
 }
 
@@ -77,7 +81,8 @@ func EnforcementActionMetricsFromStorageObject(obj *api.StorageObject) (*Enforce
 	if err := json.Unmarshal([]byte(obj.GetValue()), metrics); err != nil {
 		return nil, err
 	}
-	metrics.GroupID = obj.GetUserId()
+	// The group id lives in the Key; the owner (UserId) is the bot user.
+	metrics.GroupID = obj.GetKey()
 	metrics.version = obj.GetVersion()
 	return metrics, nil
 }
@@ -204,10 +209,14 @@ func (m *EnforcementActionMetrics) CleanupOldMetrics(retentionDays int) int {
 // LoadEnforcementMetrics loads the enforcement metrics for a guild
 func LoadEnforcementMetrics(ctx context.Context, nk runtime.NakamaModule, groupID string) (*EnforcementActionMetrics, error) {
 	metrics := NewEnforcementActionMetrics(groupID)
-	if err := StorableRead(ctx, nk, groupID, metrics, true); err != nil {
+	// The metrics object is owned by the bot user and keyed by the groupID.
+	if err := StorableRead(ctx, nk, ServiceSettings().DiscordBotUserID, metrics, true); err != nil {
 		// If not found, return a new empty metrics object (don't treat as error)
 		return metrics, nil
 	}
+	// StorableRead/SetStorageMeta restore GroupID from the Key; ensure it stays
+	// the requested group even on the not-found/create path.
+	metrics.GroupID = groupID
 	return metrics, nil
 }
 
@@ -215,7 +224,8 @@ func LoadEnforcementMetrics(ctx context.Context, nk runtime.NakamaModule, groupI
 func SaveEnforcementMetrics(ctx context.Context, nk runtime.NakamaModule, metrics *EnforcementActionMetrics) error {
 	// Cleanup old metrics before saving
 	metrics.CleanupOldMetrics(90)
-	return StorableWrite(ctx, nk, metrics.GroupID, metrics)
+	// Owner is the bot user (an existing users row); the groupID is the Key.
+	return StorableWrite(ctx, nk, ServiceSettings().DiscordBotUserID, metrics)
 }
 
 // RecordEnforcementMetrics records an enforcement action in the metrics

--- a/server/evr_enforcement_metrics_test.go
+++ b/server/evr_enforcement_metrics_test.go
@@ -1,0 +1,175 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// fkEnforcingNakamaModule is a storage mock that emulates the real Postgres
+// storage table's `FOREIGN KEY (user_id) REFERENCES users(id)` constraint:
+// a write whose owner (UserID) is not a known user row is rejected, exactly
+// like the production failure behind #417 / #420.
+type fkEnforcingNakamaModule struct {
+	runtime.NakamaModule
+	knownUsers     map[string]bool
+	storageObjects map[string]*api.StorageObject
+}
+
+func newFKEnforcingNakamaModule(userIDs ...string) *fkEnforcingNakamaModule {
+	m := &fkEnforcingNakamaModule{
+		knownUsers:     make(map[string]bool, len(userIDs)),
+		storageObjects: make(map[string]*api.StorageObject),
+	}
+	for _, id := range userIDs {
+		m.knownUsers[id] = true
+	}
+	return m
+}
+
+func (m *fkEnforcingNakamaModule) key(userID, collection, key string) string {
+	return userID + ":" + collection + ":" + key
+}
+
+func (m *fkEnforcingNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	acks := make([]*api.StorageObjectAck, 0, len(writes))
+	for _, write := range writes {
+		// Emulate the FK constraint: the owner must be an existing user row.
+		if !m.knownUsers[write.UserID] {
+			return nil, runtime.ErrStorageRejectedPermission
+		}
+		obj := &api.StorageObject{
+			Collection: write.Collection,
+			Key:        write.Key,
+			UserId:     write.UserID,
+			Value:      write.Value,
+			Version:    "v1",
+		}
+		m.storageObjects[m.key(write.UserID, write.Collection, write.Key)] = obj
+		acks = append(acks, &api.StorageObjectAck{
+			Collection: write.Collection,
+			Key:        write.Key,
+			UserId:     write.UserID,
+			Version:    "v1",
+		})
+	}
+	return acks, nil
+}
+
+func (m *fkEnforcingNakamaModule) StorageRead(ctx context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	objects := make([]*api.StorageObject, 0, len(reads))
+	for _, read := range reads {
+		if obj, ok := m.storageObjects[m.key(read.UserID, read.Collection, read.Key)]; ok {
+			objects = append(objects, obj)
+		}
+	}
+	return objects, nil
+}
+
+// TestEnforcementMetricsStorageMeta_OwnerIsBotKeyIsGroup verifies the storage
+// addressing: the per-guild metrics object is keyed by groupID, while the
+// owner is supplied at write time as the bot user (mirroring GuildGroupState).
+func TestEnforcementMetricsStorageMeta_OwnerIsBotKeyIsGroup(t *testing.T) {
+	t.Parallel()
+
+	groupID := uuid.Must(uuid.NewV4()).String()
+	m := NewEnforcementActionMetrics(groupID)
+	meta := m.StorageMeta()
+
+	if meta.Collection != StorageCollectionEnforcementMetrics {
+		t.Fatalf("collection = %q, want %q", meta.Collection, StorageCollectionEnforcementMetrics)
+	}
+	if meta.Key != groupID {
+		t.Fatalf("Key = %q, want groupID %q (per-guild object keyed by group)", meta.Key, groupID)
+	}
+	// The owner must NOT be the groupID; it is set to the bot user at write time.
+	if meta.UserID == groupID {
+		t.Fatalf("StorageMeta().UserID = groupID %q; group must not be the storage owner (FK violation)", groupID)
+	}
+}
+
+// TestEnforcementMetrics_RoundTripWritesWithBotOwner is the core regression
+// test for #417 / #420: a save no longer FK-fails because the owner is the
+// (existing) bot user, not the guild groupID; and the group is read back from
+// the storage Key, not the owner.
+func TestEnforcementMetrics_RoundTripWritesWithBotOwner(t *testing.T) {
+	botUserID := uuid.Must(uuid.NewV4()).String()
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	ServiceSettingsUpdate(&ServiceSettingsData{DiscordBotUserID: botUserID})
+	t.Cleanup(func() { ServiceSettingsUpdate(&ServiceSettingsData{}) })
+
+	ctx := context.Background()
+	// Only the bot user exists; the groupID is deliberately NOT a user row.
+	nk := newFKEnforcingNakamaModule(botUserID)
+
+	record := GuildEnforcementRecord{
+		GroupID:      groupID,
+		UserID:       uuid.Must(uuid.NewV4()).String(),
+		RuleViolated: "rule-1",
+	}
+
+	// This previously failed with ErrStorageRejectedPermission (groupID owner).
+	if err := RecordEnforcementMetrics(ctx, nk, record, true); err != nil {
+		t.Fatalf("RecordEnforcementMetrics: unexpected error (FK violation regression): %v", err)
+	}
+
+	// The object must be owned by the bot user and keyed by the groupID.
+	if _, ok := nk.storageObjects[nk.key(botUserID, StorageCollectionEnforcementMetrics, groupID)]; !ok {
+		t.Fatalf("expected stored object owned by bot %q keyed by group %q; have keys %v", botUserID, groupID, keysOf(nk.storageObjects))
+	}
+
+	// Read it back: GroupID must come from the Key, not the owner.
+	loaded, err := LoadEnforcementMetrics(ctx, nk, groupID)
+	if err != nil {
+		t.Fatalf("LoadEnforcementMetrics: %v", err)
+	}
+	if loaded.GroupID != groupID {
+		t.Fatalf("loaded GroupID = %q, want %q (must derive from Key, not owner)", loaded.GroupID, groupID)
+	}
+	if loaded.TotalKicks != 1 {
+		t.Fatalf("loaded TotalKicks = %d, want 1 (round-trip lost data)", loaded.TotalKicks)
+	}
+	if loaded.GroupID == botUserID {
+		t.Fatalf("loaded GroupID == botUserID %q; group must not be derived from owner", botUserID)
+	}
+}
+
+// TestEnforcementMetricsFromStorageObject_GroupFromKey verifies the
+// reconstruction path reads the group from the object Key, not the owner.
+func TestEnforcementMetricsFromStorageObject_GroupFromKey(t *testing.T) {
+	t.Parallel()
+
+	botUserID := uuid.Must(uuid.NewV4()).String()
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	obj := &api.StorageObject{
+		Collection: StorageCollectionEnforcementMetrics,
+		Key:        groupID,
+		UserId:     botUserID,
+		Value:      `{"group_id":"","total_kicks":3}`,
+		Version:    "v1",
+	}
+
+	m, err := EnforcementActionMetricsFromStorageObject(obj)
+	if err != nil {
+		t.Fatalf("EnforcementActionMetricsFromStorageObject: %v", err)
+	}
+	if m.GroupID != groupID {
+		t.Fatalf("GroupID = %q, want %q (from Key)", m.GroupID, groupID)
+	}
+	if m.TotalKicks != 3 {
+		t.Fatalf("TotalKicks = %d, want 3", m.TotalKicks)
+	}
+}
+
+func keysOf(m map[string]*api.StorageObject) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #417. Fixes #420. **Same root cause** behind both.

## Root cause
`EnforcementMetrics` was written with the guild **groupID as the storage owner** (`user_id`) + fixed `Key="metrics"`. The storage table has `FOREIGN KEY (user_id) REFERENCES users(id)`, so a groupID owner **violates the FK** → every write rejected as `ForeignKeyViolation` → "user no longer exists / permission denied" (`core_storage.go:651`), fired from the kick/void flow. That's #420 (writes to non-existent user) and #417 (metrics permission denied) — one bug.

## Fix
Mirror the correct `GuildGroupState` pattern — owner = bot user, groupID as the **Key**:
- `StorageMeta()`: `Key = m.GroupID`; dropped `UserID: m.GroupID`.
- `Load/SaveEnforcementMetrics`: owner is `ServiceSettings().DiscordBotUserID` (a real users row), not the groupID.
- `SetStorageMeta` / `EnforcementActionMetricsFromStorageObject`: derive GroupID from the **Key**, not the owner.
- Did NOT use a nil/system owner (FK-fails the same).

## No migration needed
Verified against a production-scale DB: **zero** `EnforcementMetrics` rows ever persisted (every write has failed since the feature was introduced), so there's nothing to migrate.

## Tests
New `evr_enforcement_metrics_test.go`: storage round-trip succeeds under an FK-enforcing mock; owner=bot, key=groupID; GroupID read back from the Key. `go test -race` green, vet + build clean.

*Read-only inspection found the shared root cause; implemented TDD-first; diff + tests + the no-migration claim re-verified before opening.*