### PR TITLE
fix: retry-on-conflict for LatencyHistory writes (#419)

### DIFF
--- a/server/evr_pipeline_matchmaker.go
+++ b/server/evr_pipeline_matchmaker.go
@@ -147,23 +147,37 @@ func (p *EvrPipeline) lobbyPingResponse(ctx context.Context, logger *zap.Logger,
 	// Include global game servers
 	addPresencesFunc(uuid.Nil.String())
 
-	for _, result := range response.Results {
-		ip := result.ExternalIP
-		if result.ExternalIP.IsUnspecified() {
-			ip = result.InternalIP
-		}
-
-		if knownIPs != nil {
-			if _, ok := knownIPs[ip.String()]; !ok {
-				logger.Debug("dropping ping result for unknown game server IP", zap.String("ip", ip.String()))
-				continue
+	// applyPingResults re-applies this session's just-received ping samples onto
+	// the (possibly refreshed) latencyHistory. It is run once now and re-run on
+	// each version-conflict retry after StorableWriteWithRetry re-reads the
+	// concurrent winner's object, so a user's concurrent sessions merge their
+	// samples losslessly instead of one clobbering the other. The Add call keeps
+	// limit/expiry pruning inside the closure so the merged result stays bounded.
+	applyPingResults := func() error {
+		for _, result := range response.Results {
+			ip := result.ExternalIP
+			if result.ExternalIP.IsUnspecified() {
+				ip = result.InternalIP
 			}
-		}
 
-		latencyHistory.Add(ip, int(result.PingMilliseconds), limit, expiry)
+			if knownIPs != nil {
+				if _, ok := knownIPs[ip.String()]; !ok {
+					logger.Debug("dropping ping result for unknown game server IP", zap.String("ip", ip.String()))
+					continue
+				}
+			}
+
+			latencyHistory.Add(ip, int(result.PingMilliseconds), limit, expiry)
+		}
+		return nil
 	}
 
-	if err := StorableWrite(ctx, p.nk, session.UserID().String(), latencyHistory); err != nil {
+	// Apply this session's samples once before the first write attempt.
+	if err := applyPingResults(); err != nil {
+		return status.Errorf(codes.Internal, "failed to apply ping results: %v", err)
+	}
+
+	if err := StorableWriteWithRetry(ctx, p.nk, session.UserID().String(), latencyHistory, applyPingResults); err != nil {
 		return status.Errorf(codes.Internal, "failed to write latency history: %v", err)
 	}
 

--- a/server/evr_storable.go
+++ b/server/evr_storable.go
@@ -4,12 +4,40 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"reflect"
+	"strings"
+	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+const (
+	// storableMaxWriteAttempts bounds StorableWriteWithRetry so a persistently
+	// contended object cannot spin forever. Includes the initial attempt.
+	storableMaxWriteAttempts = 5
+	// storableRetryBaseBackoff is the base unit of jittered backoff between
+	// retry attempts. Kept small: contention here is brief (per-user object).
+	storableRetryBaseBackoff = 5 * time.Millisecond
+)
+
+// isStorableVersionConflict reports whether err is a storage optimistic-
+// concurrency (version-check) conflict, as opposed to any other failure.
+//
+// We match on the version-conflict signature specifically. Nakama's
+// StorageWrite returns runtime.ErrStorageRejectedVersion ("Storage write
+// rejected - version check failed.") for OCC conflicts; StorableWrite wraps
+// that with %v, so the sentinel identity is lost but its message survives.
+// Matching the substring keeps detection working through that wrapper and
+// mirrors the existing isVersionConflictError helper in this package.
+func isStorableVersionConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "version check failed")
+}
 
 // StorageObjectAdapter defines methods for converting to a storage object.
 type StorableAdapter interface {
@@ -135,4 +163,58 @@ func StorableWrite(ctx context.Context, nk runtime.NakamaModule, userID string, 
 		src.SetStorageMeta(meta)
 	}
 	return nil
+}
+
+// StorableWriteWithRetry writes src, retrying on optimistic-concurrency
+// (version-check) conflicts only. On such a conflict it re-reads the current
+// stored object into src (adopting the concurrent winner's version and
+// contents), invokes reapply to re-apply this caller's pending mutation onto
+// that fresh object, and writes again. This makes concurrent writers lossless:
+// neither the winner's nor this caller's new entries are clobbered.
+//
+// reapply MUST be idempotent across attempts and MUST re-apply the same pending
+// mutation onto the (now-refreshed) src each time it is called. It is NOT
+// invoked before the first attempt — the caller is responsible for having
+// applied its mutation to src once before calling. Any pruning/limit/expiry
+// logic that must stay bounded after a merge should live inside reapply.
+//
+// Only version-conflict errors are retried; any other error (including
+// non-conflict storage failures) is returned immediately without re-reading.
+// Attempts are bounded by storableMaxWriteAttempts with small jittered backoff.
+func StorableWriteWithRetry(ctx context.Context, nk runtime.NakamaModule, userID string, src StorableAdapter, reapply func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < storableMaxWriteAttempts; attempt++ {
+		err := StorableWrite(ctx, nk, userID, src)
+		if err == nil {
+			return nil
+		}
+		if !isStorableVersionConflict(err) {
+			// Not an OCC conflict: do not re-read or retry.
+			return err
+		}
+		lastErr = err
+
+		// Conflict: a concurrent writer advanced the version. Re-read the fresh
+		// object (picking up the winner's version + entries) then re-apply this
+		// caller's pending mutation onto it before writing again.
+		if rerr := StorableRead(ctx, nk, userID, src, false); rerr != nil {
+			return fmt.Errorf("StorableWriteWithRetry: re-read after conflict: %w", rerr)
+		}
+		if rerr := reapply(); rerr != nil {
+			return fmt.Errorf("StorableWriteWithRetry: re-apply after conflict: %w", rerr)
+		}
+
+		// Jittered backoff before the next attempt (skip after the final loop).
+		if attempt < storableMaxWriteAttempts-1 {
+			backoff := time.Duration(attempt+1) * storableRetryBaseBackoff
+			// rand is fine here: this is contention jitter, not security.
+			jitter := time.Duration(rand.Int63n(int64(storableRetryBaseBackoff)))
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("StorableWriteWithRetry: %w", ctx.Err())
+			case <-time.After(backoff + jitter):
+			}
+		}
+	}
+	return fmt.Errorf("StorableWriteWithRetry: exhausted %d attempts: %w", storableMaxWriteAttempts, lastErr)
 }

--- a/server/evr_storable_retry_test.go
+++ b/server/evr_storable_retry_test.go
@@ -1,0 +1,248 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// occTestNakamaModule is an in-memory NakamaModule mock with optimistic
+// concurrency control (OCC) semantics that mirror real Nakama: a write whose
+// supplied Version does not match the stored object's current version is
+// rejected with runtime.ErrStorageRejectedVersion. A Version of "" means
+// "create only" and a Version of "*" means "must not already exist".
+type occTestNakamaModule struct {
+	runtime.NakamaModule
+	mu      sync.Mutex
+	objects map[string]*api.StorageObject
+	nextVer int
+
+	// writeAttempts counts every StorageWrite call (used to assert retry/no-retry).
+	writeAttempts int
+	// failNonVersion, when set, makes StorageWrite return a non-version error
+	// (simulating an unrelated Internal failure) instead of an OCC conflict.
+	failNonVersion error
+}
+
+func newOCCTestNakamaModule() *occTestNakamaModule {
+	return &occTestNakamaModule{objects: make(map[string]*api.StorageObject)}
+}
+
+func occStorageKey(userID, collection, key string) string {
+	return userID + ":" + collection + ":" + key
+}
+
+func (m *occTestNakamaModule) versionLocked() string {
+	m.nextVer++
+	return "v" + string(rune('0'+m.nextVer))
+}
+
+func (m *occTestNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.writeAttempts++
+
+	if m.failNonVersion != nil {
+		return nil, m.failNonVersion
+	}
+
+	acks := make([]*api.StorageObjectAck, 0, len(writes))
+	for _, w := range writes {
+		k := occStorageKey(w.UserID, w.Collection, w.Key)
+		existing, ok := m.objects[k]
+
+		switch w.Version {
+		case "":
+			// Unconditional write: allowed regardless of current state.
+		case "*":
+			if ok {
+				return nil, runtime.ErrStorageRejectedVersion
+			}
+		default:
+			if !ok || existing.Version != w.Version {
+				return nil, runtime.ErrStorageRejectedVersion
+			}
+		}
+
+		ver := m.versionLocked()
+		m.objects[k] = &api.StorageObject{
+			Collection: w.Collection,
+			Key:        w.Key,
+			UserId:     w.UserID,
+			Value:      w.Value,
+			Version:    ver,
+		}
+		acks = append(acks, &api.StorageObjectAck{
+			Collection: w.Collection,
+			Key:        w.Key,
+			UserId:     w.UserID,
+			Version:    ver,
+		})
+	}
+	return acks, nil
+}
+
+func (m *occTestNakamaModule) StorageRead(ctx context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	objects := make([]*api.StorageObject, 0, len(reads))
+	for _, r := range reads {
+		if obj, ok := m.objects[occStorageKey(r.UserID, r.Collection, r.Key)]; ok {
+			objects = append(objects, obj)
+		}
+	}
+	return objects, nil
+}
+
+// seedObject writes raw value bytes for a key, bypassing OCC, and returns the
+// assigned version. Used to set up a pre-existing stored object in tests.
+func (m *occTestNakamaModule) seedObject(userID, collection, key, value string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ver := m.versionLocked()
+	m.objects[occStorageKey(userID, collection, key)] = &api.StorageObject{
+		Collection: collection,
+		Key:        key,
+		UserId:     userID,
+		Value:      value,
+		Version:    ver,
+	}
+	return ver
+}
+
+// failOnceNakamaModule wraps occTestNakamaModule to inject a version conflict on
+// the first StorageWrite only, then defers to the real OCC mock. This simulates
+// a concurrent winner having advanced the version between read and write.
+type failOnceNakamaModule struct {
+	*occTestNakamaModule
+	conflicted bool
+}
+
+func (m *failOnceNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	m.occTestNakamaModule.mu.Lock()
+	first := !m.conflicted
+	if first {
+		m.conflicted = true
+	}
+	m.occTestNakamaModule.mu.Unlock()
+	if first {
+		m.occTestNakamaModule.mu.Lock()
+		m.occTestNakamaModule.writeAttempts++
+		m.occTestNakamaModule.mu.Unlock()
+		return nil, runtime.ErrStorageRejectedVersion
+	}
+	return m.occTestNakamaModule.StorageWrite(ctx, writes)
+}
+
+const occTestUserID = "00000000-0000-0000-0000-000000000001"
+
+// TestStorableWriteWithRetry_ReReadsAndReAppliesLossless proves that when the
+// first write hits a version conflict, the helper re-reads the fresh stored
+// object (picking up a concurrent winner's entries) and re-applies the caller's
+// pending mutation, so BOTH the winner's and this caller's new entries survive.
+func TestStorableWriteWithRetry_ReReadsAndReAppliesLossless(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	base := newOCCTestNakamaModule()
+
+	// Session B (the concurrent winner) has already written a LatencyHistory
+	// containing one RTT sample for serverA. Seed it as the current stored state.
+	winner := NewLatencyHistory()
+	winner.GameServerLatencies = map[string][]LatencyHistoryItem{
+		"10.0.0.1": {{Timestamp: time.Now(), RTT: 42 * time.Millisecond}},
+	}
+	winnerVer := base.seedObject(occTestUserID, LatencyHistoryStorageCollection, LatencyHistoryStorageKey, winner.String())
+	_ = winnerVer
+
+	nk := &failOnceNakamaModule{occTestNakamaModule: base}
+
+	// Session A holds a stale in-memory LatencyHistory (empty version, so its
+	// first write would conflict). It just received an RTT for serverB.
+	sessionA := NewLatencyHistory()
+	expiry := time.Now().Add(-14 * 24 * time.Hour)
+	reapply := func() error {
+		sessionA.Add(net.ParseIP("10.0.0.2"), 99, 25, expiry)
+		return nil
+	}
+	// Apply A's pending mutation once before the first write attempt.
+	if err := reapply(); err != nil {
+		t.Fatalf("reapply: %v", err)
+	}
+
+	if err := StorableWriteWithRetry(ctx, nk, occTestUserID, sessionA, reapply); err != nil {
+		t.Fatalf("StorableWriteWithRetry: %v", err)
+	}
+
+	// Read back the final stored object and assert lossless merge.
+	final := NewLatencyHistory()
+	if err := StorableRead(ctx, nk, occTestUserID, final, false); err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if _, ok := final.GameServerLatencies["10.0.0.1"]; !ok {
+		t.Errorf("winner's entry for 10.0.0.1 was clobbered: %v", final.GameServerLatencies)
+	}
+	if _, ok := final.GameServerLatencies["10.0.0.2"]; !ok {
+		t.Errorf("session A's entry for 10.0.0.2 was lost: %v", final.GameServerLatencies)
+	}
+}
+
+// TestStorableWriteWithRetry_NoRetryOnNonVersionError proves that a non-version
+// storage error is returned immediately without re-reading or retrying.
+func TestStorableWriteWithRetry_NoRetryOnNonVersionError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	nk := newOCCTestNakamaModule()
+	nk.failNonVersion = context.DeadlineExceeded
+
+	h := NewLatencyHistory()
+	reapplyCount := 0
+	reapply := func() error {
+		reapplyCount++
+		return nil
+	}
+
+	err := StorableWriteWithRetry(ctx, nk, occTestUserID, h, reapply)
+	if err == nil {
+		t.Fatal("expected error for non-version failure, got nil")
+	}
+	if nk.writeAttempts != 1 {
+		t.Errorf("non-version error must NOT be retried: got %d write attempts, want 1", nk.writeAttempts)
+	}
+	if reapplyCount != 0 {
+		t.Errorf("reapply must NOT be invoked for non-version error: got %d calls", reapplyCount)
+	}
+}
+
+// TestStorableWriteWithRetry_BoundedAttempts proves the helper gives up after a
+// bounded number of attempts when conflicts persist indefinitely.
+func TestStorableWriteWithRetry_BoundedAttempts(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	nk := newOCCTestNakamaModule()
+	// A stored object already exists so re-reads after each conflict succeed,
+	// letting the helper loop until it exhausts its bounded attempts.
+	nk.seedObject(occTestUserID, LatencyHistoryStorageCollection, LatencyHistoryStorageKey, NewLatencyHistory().String())
+	nk.failNonVersion = runtime.ErrStorageRejectedVersion // always conflict
+
+	h := NewLatencyHistory()
+	reapply := func() error { return nil }
+
+	err := StorableWriteWithRetry(ctx, nk, occTestUserID, h, reapply)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	if nk.writeAttempts < 2 {
+		t.Errorf("expected multiple bounded attempts, got %d", nk.writeAttempts)
+	}
+	if nk.writeAttempts > storableMaxWriteAttempts {
+		t.Errorf("attempts %d exceeded bound %d", nk.writeAttempts, storableMaxWriteAttempts)
+	}
+}


### PR DESCRIPTION
Fixes #419.

## Root cause
LatencyHistory uses optimistic concurrency (a `version` in StorageMeta). `lobbyPingResponse` did `Add()` then `StorableWrite()` with **no conflict retry**. A user's multiple concurrent sessions each hold their own in-memory LatencyHistory and write the same stored object → version-check-failure → one session's newly-appended RTT samples are dropped.

## Fix — lossless retry/merge
New `StorableWriteWithRetry(ctx, nk, userID, src, reapply)` helper in `evr_storable.go`:
- On a **version conflict** (detected specifically, not all errors), re-read the current object (adopting the winner's version + entries), call the caller's `reapply` closure to re-apply this caller's mutation onto the fresh object, retry. Bounded (5 attempts) with jittered backoff, honors `ctx.Done()`.
- Non-version errors return immediately (no retry).

`lobbyPingResponse` now re-runs `latencyHistory.Add(...)` inside that closure (pruning kept inside, so the merged result stays bounded). Concurrent sessions **merge** their RTT samples losslessly instead of clobbering each other.

## Tests
`evr_storable_retry_test.go` with an OCC-aware mock: lossless merge under conflict (both sessions' entries survive); no retry on non-version error; bounded attempts. `go test -race` green, vet + build clean.

## Note
Version-conflict detection matches the `"version check failed"` message (mirrors the existing `isVersionConflictError` precedent) because `StorableWrite` wraps with `%v`. A cleaner long-term fix is to switch that wrap to `%w` and use `errors.Is(..., runtime.ErrStorageRejectedVersion)` — flagged as out-of-scope. The helper is generic and ready to adopt for `GuildGroupState` writes too.

*Read-only inspection confirmed the race; implemented TDD-first; diff + tests re-verified before opening.*