### PR TITLE
fix: guard LobbyBuilder.mapQueue with mapQueueMu (concurrent-map data race)

### DIFF
--- a/server/evr_lobby_builder.go
+++ b/server/evr_lobby_builder.go
@@ -49,6 +49,7 @@ type LobbyBuilder struct {
 	metrics         Metrics
 
 	mapQueue          map[evr.Symbol][]evr.Symbol // map[mode][]level
+	mapQueueMu        sync.Mutex                  // Protects mapQueue: selectNextMap is called concurrently from handleMatchedEntries and the (periodic + immediate) backfill goroutines.
 	postMatchBackfill *PostMatchmakerBackfill
 	skillBasedMM      *SkillBasedMatchmaker
 
@@ -777,6 +778,17 @@ func (b *LobbyBuilder) groupIDFromEntrants(entrants []*MatchmakerEntry) (uuid.UU
 }
 
 func (b *LobbyBuilder) selectNextMap(mode evr.Symbol) evr.Symbol {
+	// selectNextMap reads and mutates the shared mapQueue map. It is invoked
+	// from buildMatch, which runs concurrently in (1) handleMatchedEntries via
+	// the fire-and-forget `go m.matchedEntriesFn` (matchmaker.go:598), (2) the
+	// immediate post-matchmaker backfill `go b.runPostMatchmakerBackfill`
+	// (evr_lobby_builder.go:105), and (3) the periodic backfill goroutine.
+	// Without this lock those goroutines race on mapQueue (confirmed by
+	// `go test -race`), which can corrupt the level queue or panic with
+	// "concurrent map writes".
+	b.mapQueueMu.Lock()
+	defer b.mapQueueMu.Unlock()
+
 	queue := b.mapQueue[mode]
 
 	if _, ok := evr.LevelsByMode[mode]; !ok {

--- a/server/evr_lobby_builder_test.go
+++ b/server/evr_lobby_builder_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -385,6 +386,42 @@ func TestSelectNextMapCombatRandomizes(t *testing.T) {
 	// With 4 combat maps and 20 calls, at least 2 distinct levels must appear.
 	assert.Greater(t, len(seen), 1,
 		"selectNextMap returned the same level on all 20 calls; queue rotation is broken")
+}
+
+// TestSelectNextMapConcurrentNoRace exercises selectNextMap from multiple
+// goroutines simultaneously, which is exactly what happens in production:
+// handleMatchedEntries (via the fire-and-forget `go m.matchedEntriesFn` at
+// matchmaker.go:598) and runPostMatchmakerBackfill (via `go
+// b.runPostMatchmakerBackfill` at evr_lobby_builder.go:105, plus the periodic
+// backfill goroutine) both call buildMatch -> selectNextMap on the SAME
+// LobbyBuilder.mapQueue map with no synchronization.
+//
+// Without locking inside selectNextMap this test fails under `go test -race`
+// with a concurrent map read/write data race (and can panic with "concurrent
+// map writes"). After adding b.mapQueueMu around the map access it passes.
+func TestSelectNextMapConcurrentNoRace(t *testing.T) {
+	lb := &LobbyBuilder{
+		mapQueue: make(map[evr.Symbol][]evr.Symbol),
+	}
+
+	modes := []evr.Symbol{evr.ModeCombatPublic, evr.ModeArenaPublic}
+
+	const goroutines = 16
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			mode := modes[g%len(modes)]
+			for i := 0; i < iterations; i++ {
+				level := lb.selectNextMap(mode)
+				_ = level
+			}
+		}(g)
+	}
+	wg.Wait()
 }
 
 // TestRankEndpointsByAverageLatency_SymmetricRTT_UsesMean verifies that when all


### PR DESCRIPTION
## Summary

`selectNextMap` reads and writes the shared `LobbyBuilder.mapQueue` map with no lock, while `buildMatch` (which calls it) runs concurrently from three goroutines:
- `handleMatchedEntries` via `go m.matchedEntriesFn` (`matchmaker.go:598`)
- the immediate post-matchmaker backfill `go b.runPostMatchmakerBackfill` (`evr_lobby_builder.go:105`)
- the periodic backfill goroutine

This is a confirmed data race (`go test -race`) that can corrupt the map queue or panic with `concurrent map writes`. Beyond the crash risk, a corrupted build feeds failed joins back into the matchmaking re-find cycle.

## Fix
Add a dedicated `mapQueueMu sync.Mutex` and `Lock`/`defer Unlock` around `selectNextMap`.

## Finding closed
- **H5 (high)** — unlocked concurrent `mapQueue` access → runtime-fatal data race.

## Tests
- `TestSelectNextMapConcurrentNoRace` — 16 goroutines × 200 iterations; **RED** under `-race` pre-fix (DATA RACE on the `mapQueue` read/write), **GREEN** after.
- `TestSelectNextMapCombatRandomizes` (existing) still green under `-race` — rotation logic unchanged.

## Notes
- Pairs with the enforcement chokepoint PR (#487); both touch `evr_lobby_builder.go` but disjoint regions (this PR is in the `selectNextMap` body; #487 edits the `LobbyJoinEntrants` call site), so they compose without conflict. If #487 merges first this branch rebases cleanly.
- The broader matchmaking re-find loop (the user-visible "infinite matchmaking") is diagnosed separately; this PR removes one concrete corruption source feeding it.

_Produced via an automated security-audit + fix workflow; backed by a `-race` regression test._
