### PR TITLE
fix: Add `platform-role-override` command; fix platform role assignment

### DIFF
--- a/server/evr_authenticate_history.go
+++ b/server/evr_authenticate_history.go
@@ -22,9 +22,16 @@ import (
 const (
 	LoginStorageCollection = "Login"
 	LoginHistoryStorageKey = "history"
+	PlatformRoleOverrideKey = "platform_role_override"
 	LoginHistoryCacheIndex = "index_login_cache"
 	MaxCacheSize           = 10000 // Maximum number of cache entries
 )
+
+type PlatformRoleOverride struct {
+	IsPCVR  bool      `json:"is_pcvr"`
+	SetBy   string    `json:"set_by"`   // Discord user ID of enforcer
+	SetAt   time.Time `json:"set_at"`
+}
 
 var (
 	IgnoredLoginValues = map[string]struct{}{

--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -516,6 +516,29 @@ var (
 			Description: "Place a link button in this channel.",
 		},
 		{
+			Name:        "platform-role-override",
+			Description: "Manually set a user's PCVR or Standalone role, overriding automatic detection. (Enforcer only)",
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionUser,
+					Name:        "user",
+					Description: "Target user",
+					Required:    true,
+				},
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "platform",
+					Description: "Platform to assign, or clear to revert to automatic detection",
+					Required:    true,
+					Choices: []*discordgo.ApplicationCommandOptionChoice{
+						{Name: "PCVR", Value: "pcvr"},
+						{Name: "Standalone", Value: "standalone"},
+						{Name: "Clear (automatic)", Value: "clear"},
+					},
+				},
+			},
+		},
+		{
 			Name:        "join-player",
 			Description: "Join a player's session as a moderator.",
 			Options: []*discordgo.ApplicationCommandOption{
@@ -3024,6 +3047,69 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				return editInteractionResponse(s, i, content)
 			}
 			return editInteractionResponse(s, i, "No match found.")
+		},
+		"platform-role-override": func(ctx context.Context, logger runtime.Logger, s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User, callerMember *discordgo.Member, userID string, groupID string) error {
+			if user == nil {
+				return nil
+			}
+
+			options := i.ApplicationCommandData().Options
+			if len(options) < 2 {
+				return errors.New("missing required options")
+			}
+
+			target := options[0].UserValue(s)
+			platform := options[1].StringValue()
+
+			targetUserID := d.cache.DiscordIDToUserID(target.ID)
+			if targetUserID == "" {
+				return simpleInteractionResponse(s, i, fmt.Sprintf("No linked account found for %s.", target.Mention()))
+			}
+
+			if platform == "clear" {
+				if err := d.nk.StorageDelete(ctx, []*runtime.StorageDelete{
+					{
+						Collection: LoginStorageCollection,
+						Key:        PlatformRoleOverrideKey,
+						UserID:     targetUserID,
+					},
+				}); err != nil {
+					return fmt.Errorf("error clearing platform role override: %w", err)
+				}
+				_, _ = d.LogAuditMessage(ctx, groupID, fmt.Sprintf("<@%s> cleared platform role override for <@%s> (reverted to automatic detection)", user.ID, target.ID), false)
+				d.cache.QueueSyncMember(groupID, target.ID, false)
+				return editInteractionResponse(s, i, fmt.Sprintf("Cleared platform override for %s. Role will revert to automatic detection.", target.Mention()))
+			}
+
+			override := &PlatformRoleOverride{
+				IsPCVR: platform == "pcvr",
+				SetBy:  user.ID,
+				SetAt:  time.Now(),
+			}
+			data, err := json.Marshal(override)
+			if err != nil {
+				return fmt.Errorf("error marshalling platform role override: %w", err)
+			}
+			if _, err := d.nk.StorageWrite(ctx, []*runtime.StorageWrite{
+				{
+					Collection:      LoginStorageCollection,
+					Key:             PlatformRoleOverrideKey,
+					UserID:          targetUserID,
+					Value:           string(data),
+					PermissionRead:  runtime.STORAGE_PERMISSION_NO_READ,
+					PermissionWrite: runtime.STORAGE_PERMISSION_NO_WRITE,
+				},
+			}); err != nil {
+				return fmt.Errorf("error writing platform role override: %w", err)
+			}
+
+			platformLabel := "Standalone"
+			if override.IsPCVR {
+				platformLabel = "PCVR"
+			}
+			_, _ = d.LogAuditMessage(ctx, groupID, fmt.Sprintf("<@%s> set platform role override for <@%s> to %s", user.ID, target.ID, platformLabel), false)
+			d.cache.QueueSyncMember(groupID, target.ID, false)
+			return editInteractionResponse(s, i, fmt.Sprintf("Set %s's platform role to **%s**.", target.Mention(), platformLabel))
 		},
 		"set-division": func(ctx context.Context, logger runtime.Logger, s *discordgo.Session, i *discordgo.InteractionCreate, user *discordgo.User, callerMember *discordgo.Member, userID string, groupID string) error {
 			if user == nil {

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -157,7 +157,7 @@ func (d *DiscordAppBot) handleInteractionApplicationCommand(ctx context.Context,
 			logger.Warn("Failed to log interaction to channel")
 		}
 
-	case "join-player", "igp", "ign":
+	case "join-player", "igp", "ign", "platform-role-override":
 
 		gg := d.guildGroupRegistry.Get(groupID)
 		if gg == nil {

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -1156,10 +1156,36 @@ func (d *DiscordIntegrator) GuildGroupName(groupID string) string {
 	return guild.Name
 }
 
-// updatePlatformRoles updates Standalone and PCVR roles based on the user's login history
+// updatePlatformRoles updates Standalone and PCVR roles based on the user's login history,
+// or a manual override set by a guild enforcer
 func (d *DiscordIntegrator) updatePlatformRoles(ctx context.Context, _ *zap.Logger, member *discordgo.Member, group *GuildGroup, userID string) error {
 	// Skip if neither role is configured
 	if group.RoleMap.Standalone == "" && group.RoleMap.PCVR == "" {
+		return nil
+	}
+
+	// Check for a manual enforcer override first
+	overrideObjs, err := d.nk.StorageRead(ctx, []*runtime.StorageRead{
+		{
+			Collection: LoginStorageCollection,
+			Key:        PlatformRoleOverrideKey,
+			UserID:     userID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error reading platform role override: %w", err)
+	}
+	if len(overrideObjs) > 0 {
+		override := &PlatformRoleOverride{}
+		if err := json.Unmarshal([]byte(overrideObjs[0].Value), override); err != nil {
+			return fmt.Errorf("error unmarshalling platform role override: %w", err)
+		}
+		if err := d.updateMemberRole(member, group.RoleMap.PCVR, override.IsPCVR); err != nil {
+			return fmt.Errorf("error updating PCVR role: %w", err)
+		}
+		if err := d.updateMemberRole(member, group.RoleMap.Standalone, !override.IsPCVR); err != nil {
+			return fmt.Errorf("error updating Standalone role: %w", err)
+		}
 		return nil
 	}
 
@@ -1192,7 +1218,7 @@ func (d *DiscordIntegrator) updatePlatformRoles(ctx context.Context, _ *zap.Logg
 		return fmt.Errorf("error unmarshalling login history: %w", err)
 	}
 
-	// Determine the most recent platform used
+	// Determine the most recent platform used across both active and history maps
 	var mostRecentEntry *LoginHistoryEntry
 	var mostRecentTime time.Time
 
@@ -1203,14 +1229,10 @@ func (d *DiscordIntegrator) updatePlatformRoles(ctx context.Context, _ *zap.Logg
 			mostRecentEntry = entry
 		}
 	}
-
-	// If no active entries, check history
-	if mostRecentEntry == nil {
-		for _, entry := range loginHistory.History {
-			if entry.UpdatedAt.After(mostRecentTime) {
-				mostRecentTime = entry.UpdatedAt
-				mostRecentEntry = entry
-			}
+	for _, entry := range loginHistory.History {
+		if entry.UpdatedAt.After(mostRecentTime) {
+			mostRecentTime = entry.UpdatedAt
+			mostRecentEntry = entry
 		}
 	}
 
@@ -1225,9 +1247,8 @@ func (d *DiscordIntegrator) updatePlatformRoles(ctx context.Context, _ *zap.Logg
 		return nil
 	}
 
-	// Determine if user is on PCVR or Standalone based on explicit BuildNumber check
-	// Only classify as PCVR if it's the known PCVR build, otherwise default to Standalone
-	isPCVR := mostRecentEntry.LoginData.BuildNumber == evr.PCVRBuild
+	// Standalone has one fixed build number; anything else is PCVR
+	isPCVR := mostRecentEntry.LoginData.BuildNumber != evr.StandaloneBuildNumber
 
 	// Update roles accordingly
 	if err := d.updateMemberRole(member, group.RoleMap.PCVR, isPCVR); err != nil {


### PR DESCRIPTION
Added a `/platform-role-override` command which
will let guild enforcers change a user's platform
role (PCVR or Standalone). Also fixed the incorrect assignment on login too.