### PR TITLE
feat: ping discovery at login — split internal/external into separate targets

### DIFF
--- a/docs/adr/0002-split-internal-external-ping-targets.md
+++ b/docs/adr/0002-split-internal-external-ping-targets.md
@@ -1,0 +1,100 @@
+# ADR 0002: Split internal and external IPs into separate ping targets; discover at login
+
+- **Status:** Proposed
+- **Date:** 2026-06-16
+- **Supersedes:** The 16-endpoint matchmaking-time ping in `CheckServerPing`
+- **Relates to:** ADR 0001 (internal slot must be private or empty)
+
+## Context
+
+The current ping flow has two problems:
+
+1. **No per-address reachability.** The `Endpoint` wire format bundles `InternalIP`
+   and `ExternalIP` into a single struct. The EVR client pings the pair and returns
+   one RTT. The server cannot tell which address the client actually reached. ADR 0001
+   noted this limitation and deferred per-client filtering (#469) as not achievable
+   with the paired format.
+
+2. **Ping happens at matchmaking time.** `CheckServerPing` fires when the player
+   requests a match, sending up to 16 endpoints. This adds latency to the
+   matchmaking flow and only covers a fraction of available servers. Players who
+   queue immediately after login hit a cold cache.
+
+Meanwhile, the EVR client handles at most **16 endpoints per `LobbyPingRequest`
+message**, but accepts multiple messages. With ~60 game servers and two addresses
+per server (~120 targets), 8 messages cover the full fleet.
+
+## Decision
+
+### 1. Split internal and external into separate ping targets
+
+For each game server with both an internal and external IP, send **two** `Endpoint`
+entries instead of one:
+
+```
+Endpoint{Internal: 0.0.0.0, External: <real_external>, Port: <port>}
+Endpoint{Internal: 0.0.0.0, External: <real_internal>, Port: <port>}
+```
+
+The internal IP is placed **in the external slot** of its own entry. The client
+pings whatever is in the external slot — it doesn't know or care whether the
+address is public or private. It sends a UDP packet and measures RTT.
+
+- If the client is on the same LAN: both entries return an RTT.
+- If the client is remote: only the real external returns an RTT; the private
+  address times out silently.
+
+The server maintains a reverse map from address → server so it can reassemble the
+correct `Endpoint` at join time: include the internal IP only if the client
+returned an RTT for it.
+
+This completely sidesteps the client behavior unknown from ADR 0001 — there is no
+`0.0.0.0` in the external slot, no reliance on client-side skip logic, and no
+closed-source behavior to guess about.
+
+### 2. Discover at login, not at matchmaking time
+
+Move ping discovery from `CheckServerPing` (matchmaking-time) to the login flow.
+On login success, begin sending `LobbyPingRequest` messages for **all alive game
+servers**, paced across a configurable window.
+
+By the time the player enters matchmaking (typically 30-60s after login), the
+reachability map is fully warm. The matchmaking-time ping becomes a cache check,
+not a blocking network round-trip.
+
+### 3. Pace with global settings
+
+```yaml
+ping_discovery:
+  max_messages: 8          # PingRequest messages per login (16 endpoints each)
+  spread_seconds: 60       # spread window — one message every ~7.5s
+```
+
+- **`max_messages`** caps the total burst. 8 × 16 = 128 targets (64 servers ×
+  internal + external). Default covers current fleet with headroom.
+- **`spread_seconds`** paces the messages to avoid slamming the client's UDP
+  send queue on connect.
+- **`endpoints_per_message`** is fixed at 16 by the client — not configurable.
+
+Servers without an internal IP consume one slot instead of two.
+
+## Consequences
+
+- **Per-address reachability becomes known.** The server can make an informed
+  decision about whether to include a server's internal IP at join time, instead
+  of sending both and hoping.
+- **#469 (per-client endpoint filtering) becomes achievable.** This ADR provides
+  the reachability data that ADR 0001 said we could not obtain.
+- **Matchmaking latency drops.** No blocking ping at match time — the cache is
+  warm from login.
+- **LAN players get optimal routing.** If a client can reach a server's internal
+  IP at 2ms vs external at 35ms, the join endpoint uses the internal address.
+- **Wire cost is trivial.** 8 messages × ~200 bytes = ~1.6KB total, spread
+  across 60 seconds.
+- **Latency history keying changes.** Currently keyed by external IP. Must change
+  to key by address (any IP string), with a reverse map to the owning server.
+  Existing latency history entries remain valid — external IPs are still tracked;
+  internal IPs are additive.
+- **The hardcoded `>= 16` cap in `CheckServerPing` is removed** in favor of the
+  paced discovery system. `CheckServerPing` may be retained as a lightweight
+  cache-freshness check for servers not yet pinged.

--- a/docs/adr/0002-split-internal-external-ping-targets.md
+++ b/docs/adr/0002-split-internal-external-ping-targets.md
@@ -1,100 +1,120 @@
-# ADR 0002: Split internal and external IPs into separate ping targets; discover at login
+# ADR 0002: Pair internal and external IPs in the pre-connect ping; probe only external at connect
 
-- **Status:** Proposed
-- **Date:** 2026-06-16
-- **Supersedes:** The 16-endpoint matchmaking-time ping in `CheckServerPing`
-- **Relates to:** ADR 0001 (internal slot must be private or empty)
+- **Status:** Accepted
+- **Date:** 2026-06-16 (revised 2026-07-03)
+- **Relates to:** ADR 0001 (internal slot must be private or empty), issue #465
 
 ## Context
 
-The current ping flow has two problems:
+A game server registers with two addresses: an `ExternalIP` (routable, public)
+and an optional `InternalIP` (a LAN address for clients that share the server's
+network). Both travel together in the `Endpoint` wire struct, and the EVR client
+uses them to reach the server.
 
-1. **No per-address reachability.** The `Endpoint` wire format bundles `InternalIP`
-   and `ExternalIP` into a single struct. The EVR client pings the pair and returns
-   one RTT. The server cannot tell which address the client actually reached. ADR 0001
-   noted this limitation and deferred per-client filtering (#469) as not achievable
-   with the paired format.
+The problem this ADR addresses is **correctness of reachability**, not latency:
 
-2. **Ping happens at matchmaking time.** `CheckServerPing` fires when the player
-   requests a match, sending up to 16 endpoints. This adds latency to the
-   matchmaking flow and only covers a fraction of available servers. Players who
-   queue immediately after login hit a cold cache.
+1. **A publicly-routable address must never sit in the internal slot.** If the
+   internal slot holds an address that is reachable from the public internet, a
+   remote client tries it, and when the two addresses disagree about which host
+   answers — or one silently blackholes — the client's connect path stalls
+   (issue #465, ADR 0001). The internal slot is only meaningful as a private,
+   non-routable address; anything else is misconfiguration.
 
-Meanwhile, the EVR client handles at most **16 endpoints per `LobbyPingRequest`
-message**, but accepts multiple messages. With ~60 game servers and two addresses
-per server (~120 targets), 8 messages cover the full fleet.
+2. **The pre-connect ping must probe both addresses so at least one is valid.**
+   A server may be reachable by its external address, its internal address, or
+   both, depending on where the client sits. If the ping omits one of them, a
+   client that could only reach the omitted address is left with no valid RTT and
+   the server looks unreachable.
+
+Note on latency: an earlier framing treated the matchmaking-time ping's ~2-second
+cost as the motivating problem. That cost is not an issue and is **not** the
+reason for this design. This ADR is about handing the client correct, complete
+reachability information — not about shaving seconds off matchmaking.
+
+"Internal" here means an address a remote client on the public internet cannot
+route to: RFC1918 (`10/8`, `172.16/12`, `192.168/16`), RFC6598 CGNAT
+(`100.64/10`), loopback, and link-local. "RFC1918" is used loosely below as a
+shorthand for this whole non-routable set — the operative test is *external
+addressability*, per requirement 2.
 
 ## Decision
 
-### 1. Split internal and external into separate ping targets
+### 1. On server connect, nakama probes only the external IP
 
-For each game server with both an internal and external IP, send **two** `Endpoint`
-entries instead of one:
+When a game server connects — registration validation and the continuous health
+check — nakama pings **only** the server's external IP. The internal IP is a LAN
+address that nakama itself generally cannot reach, so probing it would produce
+spurious "unreachable" failures. All health-check call sites route their target
+through a single `serverProbeTarget(endpoint)` helper that returns the external
+IP, keeping the invariant in one place.
+
+### 2. At registration, zero an internal IP that is not private
+
+You cannot have both an internal IP and an external IP that are both externally
+addressable. At registration, an internal IP that is **not** a private/
+non-routable address (RFC1918 / CGNAT / loopback / link-local) is zeroed to
+empty; the server still registers and serves via its external IP, and the
+operator is warned that their `internal_ip` was misconfigured. A private internal
+IP is kept; an empty one stays empty. This is enforced by
+`normalizeInternalIP` / `isInternalIP` at the top of the registration handler.
+
+### 3. The pre-connect ping includes both the external and internal IP
+
+The pre-connect ping (login-time discovery, matchmaking-time `CheckServerPing`,
+and pre-join validation) sends **one endpoint per server carrying BOTH the
+external and the private internal address**:
 
 ```
-Endpoint{Internal: 0.0.0.0, External: <real_external>, Port: <port>}
-Endpoint{Internal: 0.0.0.0, External: <real_internal>, Port: <port>}
+Endpoint{Internal: <private_internal_or_empty>, External: <real_external>, Port: <port>}
 ```
 
-The internal IP is placed **in the external slot** of its own entry. The client
-pings whatever is in the external slot — it doesn't know or care whether the
-address is public or private. It sends a UDP packet and measures RTT.
+The client pings both addresses in the pair and reports; at least one comes back
+valid regardless of where the client sits. A LAN client reaches the internal
+address; a remote client reaches only the external and silently skips the private
+internal. Because requirement 2 guarantees the internal slot is private-or-empty,
+the internal address is never one that stalls a remote client.
 
-- If the client is on the same LAN: both entries return an RTT.
-- If the client is remote: only the real external returns an RTT; the private
-  address times out silently.
+This **reverses** the earlier "split into separate single-address targets"
+approach. Splitting each server into two independent ping entries added
+complexity (a reverse address→server map, per-address latency keys) to recover
+per-address reachability that the paired format already handles: the client
+validates the pair and the server hands the same pair back at join time, letting
+the client choose at connect.
 
-The server maintains a reverse map from address → server so it can reassemble the
-correct `Endpoint` at join time: include the internal IP only if the client
-returned an RTT for it.
+### 4. Pace login-time discovery with global settings
 
-This completely sidesteps the client behavior unknown from ADR 0001 — there is no
-`0.0.0.0` in the external slot, no reliance on client-side skip logic, and no
-closed-source behavior to guess about.
-
-### 2. Discover at login, not at matchmaking time
-
-Move ping discovery from `CheckServerPing` (matchmaking-time) to the login flow.
-On login success, begin sending `LobbyPingRequest` messages for **all alive game
-servers**, paced across a configurable window.
-
-By the time the player enters matchmaking (typically 30-60s after login), the
-reachability map is fully warm. The matchmaking-time ping becomes a cache check,
-not a blocking network round-trip.
-
-### 3. Pace with global settings
+Login-time discovery pre-warms the reachability cache so matchmaking reads
+warm data instead of blocking. The EVR client accepts at most 16 endpoints per
+`LobbyPingRequest` message, so the server chunks the fleet and paces the messages:
 
 ```yaml
 ping_discovery:
-  max_messages: 8          # PingRequest messages per login (16 endpoints each)
+  max_messages: 8          # LobbyPingRequest messages per login (16 endpoints each)
   spread_seconds: 60       # spread window — one message every ~7.5s
 ```
 
-- **`max_messages`** caps the total burst. 8 × 16 = 128 targets (64 servers ×
-  internal + external). Default covers current fleet with headroom.
+- **`max_messages`** caps the total burst (8 × 16 = 128 servers of headroom).
 - **`spread_seconds`** paces the messages to avoid slamming the client's UDP
   send queue on connect.
-- **`endpoints_per_message`** is fixed at 16 by the client — not configurable.
-
-Servers without an internal IP consume one slot instead of two.
+- Endpoints-per-message is fixed at 16 by the client — not configurable.
 
 ## Consequences
 
-- **Per-address reachability becomes known.** The server can make an informed
-  decision about whether to include a server's internal IP at join time, instead
-  of sending both and hoping.
-- **#469 (per-client endpoint filtering) becomes achievable.** This ADR provides
-  the reachability data that ADR 0001 said we could not obtain.
-- **Matchmaking latency drops.** No blocking ping at match time — the cache is
-  warm from login.
-- **LAN players get optimal routing.** If a client can reach a server's internal
-  IP at 2ms vs external at 35ms, the join endpoint uses the internal address.
-- **Wire cost is trivial.** 8 messages × ~200 bytes = ~1.6KB total, spread
-  across 60 seconds.
-- **Latency history keying changes.** Currently keyed by external IP. Must change
-  to key by address (any IP string), with a reverse map to the owning server.
-  Existing latency history entries remain valid — external IPs are still tracked;
-  internal IPs are additive.
-- **The hardcoded `>= 16` cap in `CheckServerPing` is removed** in favor of the
-  paced discovery system. `CheckServerPing` may be retained as a lightweight
-  cache-freshness check for servers not yet pinged.
+- **The internal slot is guaranteed private-or-empty** by the time any endpoint
+  reaches a client, so a remote client is never handed a routable address it will
+  stall on (issue #465 / ADR 0001).
+- **At least one address per server is always valid** in the pre-connect ping and
+  the join endpoint, because both are handed to the client and the client picks
+  what it can reach.
+- **LAN clients get the internal path** without the server having to guess: the
+  client validates the pair at connect and uses the internal address when it can
+  reach it.
+- **The design is simpler than the split.** No reverse address→server map and no
+  per-internal-address latency keys; the join endpoint is just the server's
+  endpoint with a non-private internal stripped (`buildJoinEndpoint` =
+  `pingEndpoint`).
+- **The client returns one RTT per paired endpoint, keyed by external IP.** The
+  server therefore does not learn a separate internal-address latency. This is an
+  accepted trade of the paired format: the client, which knows which address it
+  actually reached, makes the choice at connect — nakama does not need per-address
+  latency to route correctly.

--- a/docs/plans/ping-discovery-at-login-implementation.md
+++ b/docs/plans/ping-discovery-at-login-implementation.md
@@ -1,0 +1,884 @@
+# Implementation Plan: Ping Discovery at Login
+
+- **ADR:** 0002
+- **Spec:** `docs/specs/ping-discovery-at-login.md`
+- **Phases covered:** Phase 1 (discovery + fallback) and Phase 2 (conditional internal IP at join)
+- **Phase 3 (remove CheckServerPing):** Deferred — noted at end
+
+---
+
+## Overview
+
+The feature requires seven work items:
+
+1. Add `PingTarget` struct and `buildPingTargets` helper
+2. Add `BestAddress` method to `LatencyHistory`
+3. Add config fields + env var loading to `EvrPipeline`
+4. Implement `runPingDiscovery` goroutine
+5. Update `lobbyPingResponse` to accept internal IPs in external slot
+6. Wire `buildJoinEndpoint` into join-time endpoint assembly (Phase 2)
+7. Update `CheckServerPing` to skip when cache is warm (Phase 1 fallback)
+
+Plus two test files.
+
+---
+
+## File-by-File Changes
+
+### 1. `server/evr_ping_discovery.go` (NEW)
+
+This is the core new file. It contains the `PingTarget` type, the target-building logic, and the paced discovery goroutine.
+
+```go
+package server
+
+import (
+    "context"
+    "encoding/json"
+    "net"
+    "os"
+    "strconv"
+    "time"
+
+    "github.com/gofrs/uuid/v5"
+    "github.com/heroiclabs/nakama/v3/server/evr"
+    "go.uber.org/zap"
+)
+
+const (
+    // EndpointsPerMessage is the maximum number of endpoints the EVR client
+    // accepts in a single LobbyPingRequest. Protocol constant, not configurable.
+    EndpointsPerMessage = 16
+
+    // Default pacing values — overridden by environment variables.
+    defaultPingDiscoveryMaxMessages    = 8
+    defaultPingDiscoverySpreadSeconds  = 60
+
+    // pingDiscoveryRTTMax is the RTT ceiling sent in discovery ping requests.
+    pingDiscoveryRTTMax = 275
+)
+
+// PingDiscoveryConfig holds the pacing configuration loaded from environment
+// variables at pipeline construction time.
+type PingDiscoveryConfig struct {
+    MaxMessages   int // Max LobbyPingRequest messages per login
+    SpreadSeconds int // Window over which to spread the messages
+}
+
+// LoadPingDiscoveryConfig reads PING_DISCOVERY_MAX_MESSAGES and
+// PING_DISCOVERY_SPREAD_SECONDS from the runtime environment map. Missing or
+// unparseable values fall back to defaults.
+func LoadPingDiscoveryConfig(vars map[string]string) PingDiscoveryConfig {
+    cfg := PingDiscoveryConfig{
+        MaxMessages:   defaultPingDiscoveryMaxMessages,
+        SpreadSeconds: defaultPingDiscoverySpreadSeconds,
+    }
+    if v, ok := vars["PING_DISCOVERY_MAX_MESSAGES"]; ok {
+        if n, err := strconv.Atoi(v); err == nil && n > 0 {
+            cfg.MaxMessages = n
+        }
+    }
+    if v, ok := vars["PING_DISCOVERY_SPREAD_SECONDS"]; ok {
+        if n, err := strconv.Atoi(v); err == nil && n > 0 {
+            cfg.SpreadSeconds = n
+        }
+    }
+    return cfg
+}
+
+// PingTarget maps a single pingable address back to its owning game server.
+type PingTarget struct {
+    Address    net.IP // The IP to ping (placed in Endpoint.ExternalIP)
+    Port       uint16 // Server port
+    ServerKey  string // ExternalIP string of the owning server (reverse lookup key)
+    IsInternal bool   // True if this address is the server's internal IP
+}
+
+// buildPingTargets enumerates all alive game server presences and produces a
+// flat list of PingTarget entries. Each server with an internal IP yields two
+// targets (one external, one internal-in-external-slot); servers without an
+// internal IP yield one target.
+//
+// The guildGroups map keys are the group IDs the player belongs to. Presences
+// are queried for each guild plus the global (uuid.Nil) stream.
+func (p *EvrPipeline) buildPingTargets(logger *zap.Logger, guildGroups map[string]struct{}) []PingTarget {
+    seen := make(map[string]struct{}) // dedup by "address:port"
+    var targets []PingTarget
+
+    addPresences := func(subject string) {
+        presences, err := p.nk.StreamUserList(StreamModeGameServer, subject, "", "", false, true)
+        if err != nil {
+            logger.Warn("failed to list game server presences for ping discovery",
+                zap.String("subject", subject), zap.Error(err))
+            return
+        }
+        for _, presence := range presences {
+            gp := &GameServerPresence{}
+            if err := json.Unmarshal([]byte(presence.GetStatus()), gp); err != nil {
+                continue
+            }
+            if !gp.Endpoint.IsValid() {
+                continue
+            }
+
+            extIP := gp.Endpoint.ExternalIP
+            port := gp.Endpoint.Port
+            serverKey := extIP.String()
+
+            // External target (always)
+            extKey := extIP.String() + ":" + strconv.Itoa(int(port))
+            if _, dup := seen[extKey]; !dup {
+                seen[extKey] = struct{}{}
+                targets = append(targets, PingTarget{
+                    Address:    extIP,
+                    Port:       port,
+                    ServerKey:  serverKey,
+                    IsInternal: false,
+                })
+            }
+
+            // Internal target (only if server has a genuine internal IP)
+            intIP := gp.Endpoint.InternalIP
+            if intIP != nil && !intIP.IsUnspecified() && isInternalIP(intIP) {
+                intKey := intIP.String() + ":" + strconv.Itoa(int(port))
+                if _, dup := seen[intKey]; !dup {
+                    seen[intKey] = struct{}{}
+                    targets = append(targets, PingTarget{
+                        Address:    intIP,
+                        Port:       port,
+                        ServerKey:  serverKey,
+                        IsInternal: true,
+                    })
+                }
+            }
+        }
+    }
+
+    for groupID := range guildGroups {
+        addPresences(groupID)
+    }
+    addPresences(uuid.Nil.String())
+
+    return targets
+}
+
+// runPingDiscovery is launched as a goroutine after login success. It sends
+// paced LobbyPingRequest messages covering all alive game servers (split into
+// separate internal/external targets) so the latency cache is warm by the time
+// the player enters matchmaking.
+//
+// Lifecycle: the goroutine exits when the session context is cancelled
+// (disconnect/logout) or when all messages have been sent.
+func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
+    ctx := session.Context()
+    logger := session.Logger()
+
+    params, ok := LoadParams(ctx)
+    if !ok {
+        logger.Warn("ping discovery: failed to load session params")
+        return
+    }
+
+    // Build the set of guild group IDs for this player.
+    guildGroupIDs := make(map[string]struct{}, len(params.guildGroups))
+    for gid := range params.guildGroups {
+        guildGroupIDs[gid] = struct{}{}
+    }
+
+    targets := p.buildPingTargets(logger, guildGroupIDs)
+    if len(targets) == 0 {
+        logger.Debug("ping discovery: no targets found")
+        return
+    }
+
+    cfg := p.pingDiscoveryConfig
+
+    // Chunk targets into batches of EndpointsPerMessage.
+    batches := chunkPingTargets(targets, EndpointsPerMessage)
+
+    // Cap at max_messages.
+    if len(batches) > cfg.MaxMessages {
+        batches = batches[:cfg.MaxMessages]
+    }
+
+    // Calculate interval between messages.
+    interval := time.Duration(cfg.SpreadSeconds) * time.Second / time.Duration(len(batches))
+    if interval < 1*time.Second {
+        interval = 1 * time.Second
+    }
+
+    logger.Info("ping discovery: starting",
+        zap.Int("targets", len(targets)),
+        zap.Int("batches", len(batches)),
+        zap.Duration("interval", interval),
+    )
+
+    for i, batch := range batches {
+        // Check for session cancellation before each send.
+        select {
+        case <-ctx.Done():
+            logger.Debug("ping discovery: session cancelled",
+                zap.Int("batch", i), zap.Int("total", len(batches)))
+            return
+        default:
+        }
+
+        endpoints := make([]evr.Endpoint, len(batch))
+        for j, t := range batch {
+            endpoints[j] = evr.Endpoint{
+                InternalIP: net.IPv4zero,
+                ExternalIP: t.Address,
+                Port:       t.Port,
+            }
+        }
+
+        if err := SendEVRMessages(session, true, evr.NewLobbyPingRequest(pingDiscoveryRTTMax, endpoints)); err != nil {
+            logger.Warn("ping discovery: failed to send batch",
+                zap.Int("batch", i), zap.Error(err))
+            return
+        }
+
+        // Sleep between batches (except after the last one).
+        if i < len(batches)-1 {
+            timer := time.NewTimer(interval)
+            select {
+            case <-ctx.Done():
+                timer.Stop()
+                logger.Debug("ping discovery: session cancelled during sleep",
+                    zap.Int("batch", i))
+                return
+            case <-timer.C:
+            }
+        }
+    }
+
+    logger.Info("ping discovery: complete",
+        zap.Int("batches_sent", len(batches)),
+        zap.Int("targets_sent", min(len(targets), cfg.MaxMessages*EndpointsPerMessage)),
+    )
+}
+
+// chunkPingTargets splits a slice of PingTarget into batches of at most size n.
+func chunkPingTargets(targets []PingTarget, n int) [][]PingTarget {
+    var batches [][]PingTarget
+    for i := 0; i < len(targets); i += n {
+        end := i + n
+        if end > len(targets) {
+            end = len(targets)
+        }
+        batches = append(batches, targets[i:end])
+    }
+    return batches
+}
+```
+
+**Key design decisions:**
+
+- `buildPingTargets` uses the existing `StreamUserList` + `GameServerPresence` pattern (same as `lobbyPingResponse` and `CheckServerPing`)
+- Internal IPs are only included if they pass `isInternalIP()` — this reuses the existing validation in `evr_pipeline_gameserver.go`
+- The dedup key is `"ip:port"` so the same server address is never pinged twice
+- `runPingDiscovery` uses `time.NewTimer` + `select` for cancellation-safe sleep (not `time.Sleep`)
+- The goroutine is self-terminating: it exits on context cancellation or after all batches are sent
+
+**Gotchas:**
+- The goroutine must not hold references to the `params` struct beyond what it needs — it copies `guildGroups` keys into a plain `map[string]struct{}` to avoid racing with lobby parameter updates
+- If `SendEVRMessages` returns an error (session closed), the goroutine exits immediately
+
+---
+
+### 2. `server/evr_latencyhistory.go` (MODIFY)
+
+Add the `BestAddress` method and a `HasRecentEntry` helper.
+
+#### Add `BestAddress` method (after `AverageRTTs`)
+
+```go
+// BestAddress returns the lowest-latency reachable address for a game server
+// with the given external and internal IPs. If the client has demonstrated
+// reachability to the internal IP (has a non-zero RTT entry), and that RTT is
+// lower than or equal to the external RTT, the internal IP is preferred.
+//
+// Returns the chosen IP string, its RTT in milliseconds, and whether any
+// reachable address was found.
+func (h *LatencyHistory) BestAddress(externalIP, internalIP string) (ip string, rtt int, ok bool) {
+    h.RLock()
+    defer h.RUnlock()
+
+    extRTT := h.latestNonZeroRTTLocked(externalIP)
+    intRTT := h.latestNonZeroRTTLocked(internalIP)
+
+    switch {
+    case extRTT > 0 && intRTT > 0:
+        // Both reachable — prefer the lower latency.
+        if intRTT <= extRTT {
+            return internalIP, intRTT, true
+        }
+        return externalIP, extRTT, true
+    case extRTT > 0:
+        return externalIP, extRTT, true
+    case intRTT > 0:
+        return internalIP, intRTT, true
+    default:
+        return "", 0, false
+    }
+}
+
+// latestNonZeroRTTLocked returns the most recent non-zero RTT (in ms) for the
+// given IP key, or 0 if none found. Caller must hold at least RLock.
+func (h *LatencyHistory) latestNonZeroRTTLocked(ipKey string) int {
+    history, ok := h.GameServerLatencies[ipKey]
+    if !ok || len(history) == 0 {
+        return 0
+    }
+    for i := len(history) - 1; i >= 0; i-- {
+        if history[i].RTT > 0 {
+            return int(history[i].RTT.Milliseconds())
+        }
+    }
+    return 0
+}
+
+// HasRecentEntry reports whether there is a non-zero latency entry for the
+// given IP that is more recent than the cutoff time.
+func (h *LatencyHistory) HasRecentEntry(ipKey string, cutoff time.Time) bool {
+    h.RLock()
+    defer h.RUnlock()
+    history, ok := h.GameServerLatencies[ipKey]
+    if !ok || len(history) == 0 {
+        return false
+    }
+    for i := len(history) - 1; i >= 0; i-- {
+        if history[i].RTT > 0 && history[i].Timestamp.After(cutoff) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**Refactoring note:** The existing `LatestRTT(extIP net.IP) int` method duplicates the logic in `latestNonZeroRTTLocked`. After adding the locked version, consider making `LatestRTT` call it internally, but that's an optional cleanup — not required for this feature.
+
+**Edge case:** `BestAddress` with `internalIP == ""` (server has no internal IP): `latestNonZeroRTTLocked("")` returns 0, so we fall through to external-only. No special handling needed.
+
+---
+
+### 3. `server/evr_pipeline.go` (MODIFY)
+
+Add the `PingDiscoveryConfig` field to `EvrPipeline` struct and load it in `NewEvrPipeline`.
+
+#### 3a. Add field to `EvrPipeline` struct (line ~91, before `loginAttemptCache`)
+
+```go
+// existing field:
+loginAttemptCache LoginAttemptCache
+
+// ADD:
+pingDiscoveryConfig PingDiscoveryConfig
+```
+
+The struct block at lines 48-92 becomes:
+
+```diff
+ 	remoteLogSem chan struct{} // limits concurrent RemoteLogSet processing
+ 
+ 	loginAttemptCache LoginAttemptCache
++	pingDiscoveryConfig PingDiscoveryConfig
+ }
+```
+
+#### 3b. Load config in `NewEvrPipeline` constructor (line ~271, after `loginAttemptCache`)
+
+Add to the struct literal at line 273:
+
+```diff
+ 		loginAttemptCache: NewLocalLoginAttemptCache(),
++		pingDiscoveryConfig: LoadPingDiscoveryConfig(vars),
+ 	}
+```
+
+**Note:** `vars` is already available in scope — it's `config.GetRuntime().Environment` from line 101.
+
+---
+
+### 4. `server/evr_pipeline_login.go` (MODIFY)
+
+Launch `runPingDiscovery` after login success.
+
+#### 4a. Add goroutine launch after final `SendEvr` (line ~201)
+
+The current `loginRequest` ends with:
+
+```go
+messagesToSend := []evr.Message{
+    evr.NewLoginSuccess(session.id, request.XPID),
+    unrequireMessage,
+    gameSettings,
+}
+return session.SendEvr(messagesToSend...)
+```
+
+Change to:
+
+```go
+messagesToSend := []evr.Message{
+    evr.NewLoginSuccess(session.id, request.XPID),
+    unrequireMessage,
+    gameSettings,
+}
+if err := session.SendEvr(messagesToSend...); err != nil {
+    return err
+}
+
+// Start background ping discovery after login messages are sent.
+// The goroutine is tied to session.Context() and self-terminates on
+// disconnect or completion.
+go p.runPingDiscovery(session)
+
+return nil
+```
+
+**Gotcha:** The `params` must already be stored (`StoreParams` is called at line 147, before this point) so that `runPingDiscovery` can load them from the session context. This is already the case.
+
+**Gotcha:** The `guildGroups` map is populated during `processLoginRequest` -> `initializeSession`, which completes before we reach line 196. Verified: `processLoginRequest` is called at line 133, returns at line 145.
+
+---
+
+### 5. `server/evr_pipeline_matchmaker.go` (MODIFY)
+
+Update `lobbyPingResponse` to include internal IPs in the `knownIPs` allowlist. This is already partially done — the current code at lines 137-139 adds internal IPs:
+
+```go
+if ip := gp.Endpoint.InternalIP; ip != nil {
+    knownIPs[ip.String()] = struct{}{}
+}
+```
+
+**Verification:** The existing `lobbyPingResponse` handler already:
+1. Checks `result.ExternalIP.IsUnspecified()` and falls back to `result.InternalIP` (line 159-161)
+2. Includes internal IPs in `knownIPs` (lines 137-139)
+3. Keys into `latencyHistory.Add(ip, ...)` using whatever IP is in the result (line 170)
+
+Since our discovery ping puts the target address (internal or external) in the `Endpoint.ExternalIP` slot, the response will have the target in `result.ExternalIP`. The existing code at line 159 checks `result.ExternalIP.IsUnspecified()` — since we set it to the actual IP (not 0.0.0.0), this branch is skipped and `ip = result.ExternalIP` is used. The address is then validated against `knownIPs` (which includes internal IPs) and stored correctly.
+
+**No code change needed in this handler.** The existing code handles discovery responses correctly.
+
+---
+
+### 6. `server/evr_lobby_find.go` (MODIFY)
+
+Update `CheckServerPing` to skip when the latency cache is warm (Phase 1 fallback behavior).
+
+#### 6a. Add warm-cache check at the beginning of `CheckServerPing` (after line ~946)
+
+After loading `latencyHistory` at line 946, add:
+
+```go
+latencyHistory := params.latencyHistory.Load()
+
+// Phase 1 fallback: if ping discovery has already warmed the cache for a
+// sufficient fraction of servers, skip the blocking ping request. The
+// matchmaker will use the cached latencies directly.
+discoveryCutoff := time.Now().Add(-5 * time.Minute) // same window as preJoinPingMaxAge
+```
+
+Then, after building `hostIPs` (line 986), before the sort and send:
+
+```go
+// Count how many candidate servers already have fresh latency data from
+// login-time ping discovery.
+cachedCount := 0
+for _, ip := range hostIPs {
+    if latencyHistory.HasRecentEntry(ip, discoveryCutoff) {
+        cachedCount++
+    }
+}
+
+// If all candidate servers have fresh data, skip the blocking ping request.
+// The matchmaker reads directly from the warm latency history.
+if cachedCount == len(hostIPs) && len(hostIPs) > 0 {
+    logger.Debug("CheckServerPing: all candidates have fresh latency data, skipping ping request",
+        zap.Int("cached", cachedCount), zap.Int("total", len(hostIPs)))
+    return nil
+}
+
+logger.Debug("CheckServerPing: cache miss, sending ping request",
+    zap.Int("cached", cachedCount), zap.Int("total", len(hostIPs)))
+```
+
+This preserves the existing 16-endpoint blocking ping as a fallback for players who queue before discovery finishes.
+
+**Gotcha:** The `HasRecentEntry` call takes a read lock on LatencyHistory. This is fine — `CheckServerPing` is already on the matchmaking goroutine, and LatencyHistory uses RWMutex for concurrent access.
+
+---
+
+### 7. `server/evr_match_label.go` (MODIFY) — Phase 2
+
+Change `GetEntrantConnectMessage` (and/or `GetEndpoint`) to accept per-client endpoint customization.
+
+The current flow is:
+1. `LobbyJoinEntrants` calls `label.GetEntrantConnectMessage(role, ...)` at `evr_lobby_joinentrant.go:253`
+2. `GetEntrantConnectMessage` calls `GetEndpoint()` which returns `s.GameServer.Endpoint`
+3. The same endpoint goes to all entrants
+
+For Phase 2, we need per-entrant endpoint customization. The cleanest approach is to **not change the match label** but instead override the endpoint in `LobbyJoinEntrants` after getting the connection settings.
+
+#### 7a. `server/evr_lobby_joinentrant.go` (MODIFY)
+
+In `LobbyJoinEntrants`, after getting `connectionSettings` at line 253, add per-client endpoint override:
+
+```go
+connectionSettings := label.GetEntrantConnectMessage(e.RoleAlignment, e.DisableEncryption, e.DisableMAC)
+
+// Phase 2: Per-client endpoint assembly. If the client has demonstrated
+// reachability to the server's internal IP (from login-time ping discovery),
+// include the internal IP in the endpoint. Otherwise, send external-only.
+if label.GameServer != nil {
+    endpoint := buildJoinEndpoint(sessionCtx, label.GameServer.Endpoint)
+    connectionSettings.Endpoint = endpoint
+}
+```
+
+The `buildJoinEndpoint` function goes in the new `evr_ping_discovery.go` file (or a small addition to `evr_lobby_joinentrant.go`):
+
+#### 7b. Add `buildJoinEndpoint` to `server/evr_ping_discovery.go`
+
+```go
+// buildJoinEndpoint constructs the Endpoint that will be sent to the client in
+// LobbySessionSuccess. If the client has demonstrated reachability to the
+// server's internal IP (via ping discovery), the internal IP is included so the
+// client can use the lower-latency path. Otherwise, the internal slot is set to
+// nil (serialized as 0.0.0.0, the client's "skip this address" value).
+//
+// This implements Phase 2 of ADR 0002.
+func buildJoinEndpoint(ctx context.Context, serverEndpoint evr.Endpoint) evr.Endpoint {
+    params, ok := LoadParams(ctx)
+    if !ok {
+        // No session params — return the endpoint as-is (external + internal).
+        return serverEndpoint
+    }
+
+    lh := params.latencyHistory.Load()
+    if lh == nil {
+        return serverEndpoint
+    }
+
+    extIP := serverEndpoint.ExternalIP
+    intIP := serverEndpoint.InternalIP
+
+    // If the server has no internal IP, nothing to decide.
+    if intIP == nil || intIP.IsUnspecified() {
+        return serverEndpoint
+    }
+
+    // Check if the client demonstrated reachability to the internal IP.
+    _, intRTT, _ := lh.BestAddress(extIP.String(), intIP.String())
+
+    if intRTT > 0 {
+        // Client can reach internal IP — include it.
+        return evr.Endpoint{
+            InternalIP: intIP,
+            ExternalIP: extIP,
+            Port:       serverEndpoint.Port,
+        }
+    }
+
+    // Client cannot reach internal IP — external only.
+    return evr.Endpoint{
+        InternalIP: nil,
+        ExternalIP: extIP,
+        Port:       serverEndpoint.Port,
+    }
+}
+```
+
+**Where exactly in `evr_lobby_joinentrant.go`:**
+
+The loop that processes each entrant starts around line 204. Each entrant's connection settings are generated at line 253. The endpoint override should go immediately after, before the protobuf envelope construction at line 262.
+
+Specifically, the change at lines 253-262:
+
+```diff
+ 	connectionSettings := label.GetEntrantConnectMessage(e.RoleAlignment, e.DisableEncryption, e.DisableMAC)
+ 
++	// Phase 2 (ADR 0002): Per-client endpoint assembly — include the
++	// server's internal IP only if this client demonstrated reachability.
++	if label.GameServer != nil {
++		connectionSettings.Endpoint = buildJoinEndpoint(sessionCtx, label.GameServer.Endpoint)
++	}
++
+ 	// Quest (standalone) clients use a different encoder flag bit layout (shifted by 1).
+ 	if ServiceSettings().UseQuestEncoderFlags {
+```
+
+**Important context:** `sessionCtx` is the entrant's session context (obtained earlier in the function from the session registry). It contains that specific player's `SessionParameters` and therefore their `latencyHistory`. This means each entrant gets their own endpoint decision.
+
+**Edge case:** If the latency history has no data for either IP (player queued before discovery), `BestAddress` returns `ok=false`. The function returns external-only, which is the safe default — the same as current behavior.
+
+**Edge case:** The protobuf envelope at line 269 reads `connectionSettings.Endpoint.String()`. Our override sets the Endpoint field before that line, so it picks up the customized endpoint correctly.
+
+---
+
+### 8. `server/evr_ping_discovery_test.go` (NEW)
+
+```go
+package server
+
+import (
+    "net"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestBestAddress_BothReachable_PrefersInternal(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})   // external: 35ms
+    h.Add(net.ParseIP("192.168.1.5"), 2, 25, time.Time{}) // internal: 2ms
+
+    ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+    require.True(t, ok)
+    assert.Equal(t, "192.168.1.5", ip)
+    assert.Equal(t, 2, rtt)
+}
+
+func TestBestAddress_BothReachable_PrefersLower(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 10, 25, time.Time{})     // external: 10ms
+    h.Add(net.ParseIP("192.168.1.5"), 50, 25, time.Time{})  // internal: 50ms (worse)
+
+    ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+    require.True(t, ok)
+    assert.Equal(t, "1.2.3.4", ip)
+    assert.Equal(t, 10, rtt)
+}
+
+func TestBestAddress_OnlyExternalReachable(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{}) // external only
+
+    ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+    require.True(t, ok)
+    assert.Equal(t, "1.2.3.4", ip)
+    assert.Equal(t, 35, rtt)
+}
+
+func TestBestAddress_NeitherReachable(t *testing.T) {
+    h := NewLatencyHistory()
+
+    _, _, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+    assert.False(t, ok)
+}
+
+func TestBestAddress_NoInternalIP(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})
+
+    ip, rtt, ok := h.BestAddress("1.2.3.4", "")
+    require.True(t, ok)
+    assert.Equal(t, "1.2.3.4", ip)
+    assert.Equal(t, 35, rtt)
+}
+
+func TestBestAddress_EqualRTT_PrefersInternal(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 20, 25, time.Time{})
+    h.Add(net.ParseIP("192.168.1.5"), 20, 25, time.Time{})
+
+    ip, _, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+    require.True(t, ok)
+    // When equal, internal is preferred (intRTT <= extRTT)
+    assert.Equal(t, "192.168.1.5", ip)
+}
+
+func TestHasRecentEntry(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})
+
+    assert.True(t, h.HasRecentEntry("1.2.3.4", time.Now().Add(-1*time.Minute)))
+    assert.False(t, h.HasRecentEntry("1.2.3.4", time.Now().Add(1*time.Minute)))
+    assert.False(t, h.HasRecentEntry("5.6.7.8", time.Now().Add(-1*time.Minute)))
+}
+
+func TestChunkPingTargets(t *testing.T) {
+    targets := make([]PingTarget, 35)
+    for i := range targets {
+        targets[i] = PingTarget{
+            Address:   net.ParseIP("1.2.3.4"),
+            Port:      uint16(6792 + i),
+            ServerKey: "1.2.3.4",
+        }
+    }
+
+    batches := chunkPingTargets(targets, 16)
+    assert.Len(t, batches, 3)
+    assert.Len(t, batches[0], 16)
+    assert.Len(t, batches[1], 16)
+    assert.Len(t, batches[2], 3)
+}
+
+func TestChunkPingTargets_ExactMultiple(t *testing.T) {
+    targets := make([]PingTarget, 32)
+    for i := range targets {
+        targets[i] = PingTarget{Address: net.ParseIP("1.2.3.4"), Port: uint16(i)}
+    }
+
+    batches := chunkPingTargets(targets, 16)
+    assert.Len(t, batches, 2)
+    assert.Len(t, batches[0], 16)
+    assert.Len(t, batches[1], 16)
+}
+
+func TestChunkPingTargets_Empty(t *testing.T) {
+    batches := chunkPingTargets(nil, 16)
+    assert.Nil(t, batches)
+}
+
+func TestLoadPingDiscoveryConfig_Defaults(t *testing.T) {
+    cfg := LoadPingDiscoveryConfig(map[string]string{})
+    assert.Equal(t, 8, cfg.MaxMessages)
+    assert.Equal(t, 60, cfg.SpreadSeconds)
+}
+
+func TestLoadPingDiscoveryConfig_Override(t *testing.T) {
+    cfg := LoadPingDiscoveryConfig(map[string]string{
+        "PING_DISCOVERY_MAX_MESSAGES":   "12",
+        "PING_DISCOVERY_SPREAD_SECONDS": "30",
+    })
+    assert.Equal(t, 12, cfg.MaxMessages)
+    assert.Equal(t, 30, cfg.SpreadSeconds)
+}
+
+func TestLoadPingDiscoveryConfig_InvalidFallsBackToDefault(t *testing.T) {
+    cfg := LoadPingDiscoveryConfig(map[string]string{
+        "PING_DISCOVERY_MAX_MESSAGES":   "not_a_number",
+        "PING_DISCOVERY_SPREAD_SECONDS": "-5",
+    })
+    assert.Equal(t, 8, cfg.MaxMessages)
+    assert.Equal(t, 60, cfg.SpreadSeconds)
+}
+```
+
+---
+
+### 9. `server/evr_latencyhistory_test.go` (NEW or add to existing)
+
+There's no existing test file for `evr_latencyhistory.go`. Create one:
+
+```go
+package server
+
+import (
+    "net"
+    "testing"
+    "time"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+func TestLatencyHistory_Add_And_LatestRTT(t *testing.T) {
+    h := NewLatencyHistory()
+    ip := net.ParseIP("1.2.3.4")
+    h.Add(ip, 35, 25, time.Time{})
+
+    got := h.LatestRTT(ip)
+    assert.Equal(t, 35, got)
+}
+
+func TestLatencyHistory_BestAddress(t *testing.T) {
+    // Tests are in evr_ping_discovery_test.go — this file tests the base
+    // LatencyHistory methods. BestAddress tests are grouped with discovery.
+}
+
+func TestLatencyHistory_HasRecentEntry_Boundary(t *testing.T) {
+    h := NewLatencyHistory()
+    h.Add(net.ParseIP("10.0.0.1"), 15, 25, time.Time{})
+
+    // Entry was just added — it's after any past cutoff.
+    require.True(t, h.HasRecentEntry("10.0.0.1", time.Now().Add(-1*time.Second)))
+
+    // Future cutoff — entry is before it.
+    require.False(t, h.HasRecentEntry("10.0.0.1", time.Now().Add(1*time.Hour)))
+}
+```
+
+---
+
+## Integration Points Summary
+
+### Data flow: Login -> Discovery -> Matchmaking -> Join
+
+```
+loginRequest (evr_pipeline_login.go)
+  └─ go p.runPingDiscovery(session) (evr_ping_discovery.go)
+       └─ buildPingTargets() — enumerates servers, splits int/ext
+       └─ sends N paced LobbyPingRequest messages
+            └─ client responds with LobbyPingResponse
+                 └─ lobbyPingResponse (evr_pipeline_matchmaker.go)
+                      └─ latencyHistory.Add(ip, rtt, ...) — stores by IP string
+                           (internal IPs are now additional keys)
+
+CheckServerPing (evr_lobby_find.go)
+  └─ checks HasRecentEntry for each candidate
+  └─ if all cached → skip (return nil)
+  └─ if cache miss → send blocking 16-endpoint ping (existing behavior)
+
+LobbyJoinEntrants (evr_lobby_joinentrant.go)
+  └─ buildJoinEndpoint(sessionCtx, serverEndpoint)
+       └─ latencyHistory.BestAddress(ext, int)
+            └─ if internal reachable → Endpoint{int, ext, port}
+            └─ else → Endpoint{nil, ext, port}
+```
+
+### Reverse Map
+
+The spec mentions a "reverse map (address → server)." In this implementation, the reverse map is **implicit**: each `PingTarget` carries a `ServerKey` (the external IP string), but we don't need to store this map persistently. At join time, `buildJoinEndpoint` already has the `serverEndpoint` from the match label — it knows both the external and internal IPs. It just queries the latency history for both IPs to decide which to include.
+
+The `PingTarget.ServerKey` field is useful for logging and debugging (e.g., "internal IP 192.168.1.5 belongs to server 1.2.3.4") but isn't needed for the join-time decision.
+
+### Interaction with Unreachable Servers
+
+The `unreachableServers` tracking (`server/evr_unreachable_servers.go`) is keyed by external IP. Ping discovery does not modify this — it only adds entries to `latencyHistory`. If a server's external IP is in `unreachableServers`, `CheckServerPing` already skips it (line 982-983). The discovery goroutine does **not** filter by unreachable servers — it pings everything. This is intentional: a server may have become reachable again, and the latency data is additive, not a judgment.
+
+### Interaction with Pre-Join Ping
+
+The pre-join ping system (`evr_lobby_prejoin_ping.go`) queries `latencyHistory.LatestEntry(extIP)` to check freshness. With discovery warming the cache, pre-join pings will increasingly find fresh data and skip the blocking ping. No changes needed to `validatePreJoinPing` — it naturally benefits from the warm cache.
+
+---
+
+## Phase 3 (Deferred)
+
+**Remove or reduce `CheckServerPing`:**
+
+Once ping discovery is proven stable in production:
+1. Remove the 16-endpoint blocking ping from `CheckServerPing`
+2. Keep only the warm-cache check
+3. If any server lacks data, treat as unreachable for this matchmaking attempt (don't block)
+4. This makes matchmaking fully non-blocking for ping
+
+**Not implemented in this PR** — requires observability data from Phase 1/2 to confirm the cache is reliably warm.
+
+---
+
+## Files Changed Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `server/evr_ping_discovery.go` | **NEW** | PingTarget, PingDiscoveryConfig, buildPingTargets, runPingDiscovery, buildJoinEndpoint, chunkPingTargets |
+| `server/evr_latencyhistory.go` | MODIFY | Add BestAddress, latestNonZeroRTTLocked, HasRecentEntry |
+| `server/evr_pipeline.go` | MODIFY | Add pingDiscoveryConfig field + load in constructor |
+| `server/evr_pipeline_login.go` | MODIFY | Launch go p.runPingDiscovery(session) after login success |
+| `server/evr_lobby_find.go` | MODIFY | Add warm-cache skip in CheckServerPing |
+| `server/evr_lobby_joinentrant.go` | MODIFY | Call buildJoinEndpoint for per-client endpoint |
+| `server/evr_ping_discovery_test.go` | **NEW** | Tests for BestAddress, HasRecentEntry, chunkPingTargets, config loading |
+| `server/evr_latencyhistory_test.go` | **NEW** | Tests for base LatencyHistory methods |
+
+**No changes needed to:**
+- `server/evr/match_ping_request.go` — Endpoint struct unchanged
+- `server/evr/match_ping_response.go` — response handling unchanged
+- `server/evr_pipeline_matchmaker.go` — lobbyPingResponse already handles internal IPs correctly
+- `server/evr_pipeline_gameserver.go` — isInternalIP reused as-is
+- `server/evr_match_label.go` — GetEndpoint/GetEntrantConnectMessage unchanged (override happens downstream)
+- `server/evr_lobby_prejoin_ping.go` — naturally benefits from warm cache, no changes

--- a/docs/specs/ping-discovery-at-login.md
+++ b/docs/specs/ping-discovery-at-login.md
@@ -1,0 +1,159 @@
+# Spec: Ping Discovery at Login
+
+- **ADR:** 0002
+- **Status:** Draft
+- **Author:** Metis + sprockee
+
+## Summary
+
+Move game server ping discovery from matchmaking-time to login-time. Split
+internal and external IPs into separate ping targets to get per-address
+reachability and latency. Pace the requests across a configurable window.
+
+## Global Settings
+
+Added to `EvrPipeline` config (environment variables):
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `PING_DISCOVERY_MAX_MESSAGES` | int | 8 | Max `LobbyPingRequest` messages per login |
+| `PING_DISCOVERY_SPREAD_SECONDS` | int | 60 | Window over which to spread the messages |
+
+The client accepts at most **16 endpoints per message** (protocol constant, not
+configurable).
+
+## Data Structures
+
+### PingTarget (new, internal)
+
+```go
+// PingTarget maps a single pingable address back to its owning server.
+type PingTarget struct {
+    Address    net.IP       // The IP to ping (placed in Endpoint.ExternalIP)
+    Port       uint16       // Server port
+    ServerKey  string       // ExternalIP string of the owning server (for reverse lookup)
+    IsInternal bool         // True if this address is the server's internal IP
+}
+```
+
+### AddressReachability (extends LatencyHistory)
+
+The existing `LatencyHistory` keys by IP string. No structural change needed —
+internal IPs are simply additional keys. A helper method resolves the best
+reachable address for a given server:
+
+```go
+// BestAddress returns the lowest-latency reachable address for a server,
+// preferring internal if reachable.
+func (h *LatencyHistory) BestAddress(externalIP, internalIP string) (ip string, rtt int, ok bool)
+```
+
+## Login Flow Changes
+
+### 1. After login success (`loginRequest`)
+
+After sending `LoginSuccess` + `GameSettings`, start a goroutine:
+
+```go
+go p.runPingDiscovery(session)
+```
+
+### 2. `runPingDiscovery`
+
+```
+func (p *EvrPipeline) runPingDiscovery(session *sessionWS):
+    1. List all alive game server presences (guild + global streams)
+    2. For each server with a valid endpoint:
+       a. Add PingTarget{Address: externalIP, IsInternal: false}
+       b. If server has an internal IP:
+          Add PingTarget{Address: internalIP, IsInternal: true}
+    3. Chunk targets into batches of 16
+    4. Cap at max_messages batches
+    5. For each batch (paced by spread_seconds / max_messages):
+       a. Build []Endpoint — each target becomes:
+          Endpoint{Internal: 0.0.0.0, External: target.Address, Port: target.Port}
+       b. SendEVRMessages(session, true, NewLobbyPingRequest(275, endpoints))
+       c. Sleep(spread_seconds / max_messages)
+       d. Check session.Context().Done() between sleeps
+```
+
+### 3. Response handling (`lobbyPingResponse`)
+
+Minimal changes. The existing handler already:
+- Validates against `knownIPs` (which includes both internal and external IPs)
+- Stores RTT by IP in `LatencyHistory`
+- Handles `ExternalIP.IsUnspecified()` fallback to `InternalIP`
+
+Since we put the target address in the external slot, the response will have it
+in `result.ExternalIP` — the existing codepath stores it correctly.
+
+The one addition: **register a reverse map** on the pipeline (or session params)
+so that at join time we can resolve "client had 2ms to 192.168.1.5" → "that's
+the internal IP of server with external 1.2.3.4".
+
+### 4. `CheckServerPing` changes
+
+Two options:
+
+**Option A (minimal):** Keep `CheckServerPing` but skip it when the latency
+history already has fresh entries for all candidate servers. Falls back to the
+current behavior only when the cache is cold (player queued before discovery
+finished).
+
+**Option B (clean):** Remove `CheckServerPing` entirely. The matchmaker reads
+from the warm `LatencyHistory`. If a server has no latency entry, it's treated
+as unreachable for this player (same as today's unreachable-servers tracking).
+
+Recommend **Option A** for the initial PR — safer rollout.
+
+### 5. Join-time endpoint assembly
+
+When building the `Endpoint` for `LobbySessionSuccess`:
+
+```
+func (p *EvrPipeline) buildJoinEndpoint(session, server) Endpoint:
+    extIP := server.Endpoint.ExternalIP
+    intIP := server.Endpoint.InternalIP
+
+    // Check if client can reach the internal IP
+    if intIP != nil {
+        if _, _, ok := latencyHistory.BestAddress(extIP, intIP); ok {
+            // Client can reach internal — include it
+            return Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: port}
+        }
+    }
+
+    // Client cannot reach internal (or server has none) — external only
+    return Endpoint{InternalIP: nil, ExternalIP: extIP, Port: port}
+```
+
+## Rollout
+
+1. **Phase 1:** Add `runPingDiscovery` at login. Keep `CheckServerPing` as
+   fallback. Log per-address reachability for observability. No behavior change
+   to matchmaking or joins yet.
+
+2. **Phase 2:** Wire `BestAddress` into join-time endpoint assembly. Internal IP
+   is only included when the client demonstrated reachability. Monitor for LAN
+   players losing internal paths (should not happen — they'll have RTT for both).
+
+3. **Phase 3:** Remove or reduce `CheckServerPing` to a cache-freshness check.
+   Matchmaking reads directly from the warm latency history.
+
+## Testing
+
+- **Unit:** `BestAddress` returns internal when both reachable and internal is
+  lower; returns external-only when internal unreachable; returns nothing when
+  neither reachable.
+- **Integration:** Mock session receives N paced `LobbyPingRequest` messages
+  with correct endpoint splitting. Verify reverse map correctly associates
+  internal addresses with their servers.
+- **Manual:** LAN player joins server, verify internal IP path is used.
+  Remote player joins same server, verify internal IP is NOT included.
+
+## Wire cost
+
+- 60 servers × 2 addresses = 120 targets
+- 120 / 16 = 8 messages (fits default `max_messages`)
+- Each message: 8 bytes header + 16 × 12 bytes endpoints = 200 bytes
+- Total: ~1.6 KB spread across 60 seconds

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -225,6 +225,68 @@ func (h *LatencyHistory) AverageRTTs(roundRTTs bool, since ...time.Time) map[str
 	return averageRTTs
 }
 
+// BestAddress returns the lowest-latency reachable address for a game server
+// with the given external and internal IPs. If the client has demonstrated
+// reachability to the internal IP (has a non-zero RTT entry), and that RTT is
+// lower than or equal to the external RTT, the internal IP is preferred.
+//
+// Returns the chosen IP string, its RTT in milliseconds, and whether any
+// reachable address was found.
+func (h *LatencyHistory) BestAddress(externalIP, internalIP string) (ip string, rtt int, ok bool) {
+	h.RLock()
+	defer h.RUnlock()
+
+	extRTT := h.latestNonZeroRTTLocked(externalIP)
+	intRTT := h.latestNonZeroRTTLocked(internalIP)
+
+	switch {
+	case extRTT > 0 && intRTT > 0:
+		// Both reachable — prefer the lower latency.
+		if intRTT <= extRTT {
+			return internalIP, intRTT, true
+		}
+		return externalIP, extRTT, true
+	case extRTT > 0:
+		return externalIP, extRTT, true
+	case intRTT > 0:
+		return internalIP, intRTT, true
+	default:
+		return "", 0, false
+	}
+}
+
+// latestNonZeroRTTLocked returns the most recent non-zero RTT (in ms) for the
+// given IP key, or 0 if none found. Caller must hold at least RLock.
+func (h *LatencyHistory) latestNonZeroRTTLocked(ipKey string) int {
+	history, ok := h.GameServerLatencies[ipKey]
+	if !ok || len(history) == 0 {
+		return 0
+	}
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].RTT > 0 {
+			return int(history[i].RTT.Milliseconds())
+		}
+	}
+	return 0
+}
+
+// HasRecentEntry reports whether there is a non-zero latency entry for the
+// given IP that is more recent than the cutoff time.
+func (h *LatencyHistory) HasRecentEntry(ipKey string, cutoff time.Time) bool {
+	h.RLock()
+	defer h.RUnlock()
+	history, ok := h.GameServerLatencies[ipKey]
+	if !ok || len(history) == 0 {
+		return false
+	}
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].RTT > 0 && history[i].Timestamp.After(cutoff) {
+			return true
+		}
+	}
+	return false
+}
+
 func (h *LatencyHistory) Get(extIP string) ([]LatencyHistoryItem, bool) {
 	h.RLock()
 	defer h.RUnlock()

--- a/server/evr_latencyhistory_test.go
+++ b/server/evr_latencyhistory_test.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatencyHistory_Add_And_LatestRTT(t *testing.T) {
+	h := NewLatencyHistory()
+	ip := net.ParseIP("1.2.3.4")
+	h.Add(ip, 35, 25, time.Time{})
+
+	got := h.LatestRTT(ip)
+	assert.Equal(t, 35, got)
+}
+
+func TestLatencyHistory_BestAddress(t *testing.T) {
+	// Tests are in evr_ping_discovery_test.go — this file tests the base
+	// LatencyHistory methods. BestAddress tests are grouped with discovery.
+}
+
+func TestLatencyHistory_HasRecentEntry_Boundary(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("10.0.0.1"), 15, 25, time.Time{})
+
+	// Entry was just added — it's after any past cutoff.
+	require.True(t, h.HasRecentEntry("10.0.0.1", time.Now().Add(-1*time.Second)))
+
+	// Future cutoff — entry is before it.
+	require.False(t, h.HasRecentEntry("10.0.0.1", time.Now().Add(1*time.Hour)))
+}

--- a/server/evr_latencyhistory_test.go
+++ b/server/evr_latencyhistory_test.go
@@ -18,10 +18,9 @@ func TestLatencyHistory_Add_And_LatestRTT(t *testing.T) {
 	assert.Equal(t, 35, got)
 }
 
-func TestLatencyHistory_BestAddress(t *testing.T) {
-	// Tests are in evr_ping_discovery_test.go — this file tests the base
-	// LatencyHistory methods. BestAddress tests are grouped with discovery.
-}
+// BestAddress is exercised in evr_ping_discovery_test.go alongside the rest of
+// the discovery paths; no stub test is kept here (an empty test body reads as
+// coverage that does not exist).
 
 func TestLatencyHistory_HasRecentEntry_Boundary(t *testing.T) {
 	h := NewLatencyHistory()

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -945,6 +945,11 @@ func (p *EvrPipeline) CheckServerPing(ctx context.Context, logger *zap.Logger, s
 
 	latencyHistory := params.latencyHistory.Load()
 
+	// Phase 1 fallback: if ping discovery has already warmed the cache for a
+	// sufficient fraction of servers, skip the blocking ping request. The
+	// matchmaker will use the cached latencies directly.
+	discoveryCutoff := time.Now().Add(-5 * time.Minute) // same window as preJoinPingMaxAge
+
 	// Build set of IPs this player has failed to connect to.
 	var unreachableIPs map[string]struct{}
 	if params.unreachableServers != nil {
@@ -988,6 +993,26 @@ func (p *EvrPipeline) CheckServerPing(ctx context.Context, logger *zap.Logger, s
 		}
 		endpointMap[extIP] = gPresence.Endpoint
 	}
+
+	// Count how many candidate servers already have fresh latency data from
+	// login-time ping discovery.
+	cachedCount := 0
+	for _, ip := range hostIPs {
+		if latencyHistory.HasRecentEntry(ip, discoveryCutoff) {
+			cachedCount++
+		}
+	}
+
+	// If all candidate servers have fresh data, skip the blocking ping request.
+	// The matchmaker reads directly from the warm latency history.
+	if cachedCount == len(hostIPs) && len(hostIPs) > 0 {
+		logger.Debug("CheckServerPing: all candidates have fresh latency data, skipping ping request",
+			zap.Int("cached", cachedCount), zap.Int("total", len(hostIPs)))
+		return nil
+	}
+
+	logger.Debug("CheckServerPing: cache miss, sending ping request",
+		zap.Int("cached", cachedCount), zap.Int("total", len(hostIPs)))
 
 	sortPingCandidatesByLatencyHistory(hostIPs, latencyHistory)
 

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -252,6 +252,12 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 
 	connectionSettings := label.GetEntrantConnectMessage(e.RoleAlignment, e.DisableEncryption, e.DisableMAC)
 
+	// Phase 2 (ADR 0002): Per-client endpoint assembly — include the
+	// server's internal IP only if this client demonstrated reachability.
+	if label.GameServer != nil {
+		connectionSettings.Endpoint = buildJoinEndpoint(sessionCtx, label.GameServer.Endpoint)
+	}
+
 	// Quest (standalone) clients use a different encoder flag bit layout (shifted by 1).
 	if ServiceSettings().UseQuestEncoderFlags {
 		if params, ok := LoadParams(sessionCtx); ok && !params.IsPCVR() {

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -206,10 +206,10 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 
 	connectionSettings := label.GetEntrantConnectMessage(e.RoleAlignment, e.DisableEncryption, e.DisableMAC)
 
-	// Phase 2 (ADR 0002): Per-client endpoint assembly — include the
-	// server's internal IP only if this client demonstrated reachability.
+	// ADR 0002: hand the client both the external and the (private) internal
+	// address so it validates them at connect and uses whichever it can reach.
 	if label.GameServer != nil {
-		connectionSettings.Endpoint = buildJoinEndpoint(sessionCtx, label.GameServer.Endpoint)
+		connectionSettings.Endpoint = buildJoinEndpoint(label.GameServer.Endpoint)
 	}
 
 	// Quest (standalone) clients use a different encoder flag bit layout (shifted by 1).

--- a/server/evr_ping_discovery.go
+++ b/server/evr_ping_discovery.go
@@ -252,11 +252,16 @@ func buildJoinEndpoint(ctx context.Context, serverEndpoint evr.Endpoint) evr.End
 		return serverEndpoint
 	}
 
-	// Check if the client demonstrated reachability to the internal IP.
-	_, intRTT, _ := lh.BestAddress(extIP.String(), intIP.String())
-
-	if intRTT > 0 {
-		// Client can reach internal IP — include it.
+	// Include the internal IP only when the client demonstrated that it is the
+	// best reachable path to this server — i.e. the client returned an RTT for
+	// the internal address AND that address is at least as fast as the external
+	// (ADR 0002: "LAN players get optimal routing"). BestAddress returns the
+	// chosen address, so we must compare it against the internal IP; reading its
+	// RTT alone would wrongly treat an external-only result as internal-reachable
+	// and leak the server's private IP to a remote client.
+	bestIP, _, ok := lh.BestAddress(extIP.String(), intIP.String())
+	if ok && bestIP == intIP.String() {
+		// Client can reach the internal IP and it is the best path — include it.
 		return evr.Endpoint{
 			InternalIP: intIP,
 			ExternalIP: extIP,
@@ -264,7 +269,8 @@ func buildJoinEndpoint(ctx context.Context, serverEndpoint evr.Endpoint) evr.End
 		}
 	}
 
-	// Client cannot reach internal IP — external only.
+	// Client cannot reach the internal IP (or the external path is faster) —
+	// external only. Never hand a private IP to a client that cannot use it.
 	return evr.Endpoint{
 		InternalIP: nil,
 		ExternalIP: extIP,

--- a/server/evr_ping_discovery.go
+++ b/server/evr_ping_discovery.go
@@ -1,9 +1,7 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
-	"net"
 	"strconv"
 	"time"
 
@@ -53,24 +51,34 @@ func LoadPingDiscoveryConfig(vars map[string]string) PingDiscoveryConfig {
 	return cfg
 }
 
-// PingTarget maps a single pingable address back to its owning game server.
-type PingTarget struct {
-	Address    net.IP // The IP to ping (placed in Endpoint.ExternalIP)
-	Port       uint16 // Server port
-	ServerKey  string // ExternalIP string of the owning server (reverse lookup key)
-	IsInternal bool   // True if this address is the server's internal IP
+// pingEndpoint returns the endpoint to ping for a single game server. Per ADR
+// 0002, the pre-connect ping carries BOTH the external and internal address in
+// one endpoint (req 3), so the client pings both and at least one returns a
+// valid RTT. The internal slot is kept only when it is a genuine private/
+// internal address (req 2); a publicly-routable address is zeroed to nil so it
+// is never placed in the internal slot.
+func pingEndpoint(ep evr.Endpoint) evr.Endpoint {
+	intIP := ep.InternalIP
+	if intIP != nil && (intIP.IsUnspecified() || !isInternalIP(intIP)) {
+		intIP = nil
+	}
+	return evr.Endpoint{
+		InternalIP: intIP,
+		ExternalIP: ep.ExternalIP,
+		Port:       ep.Port,
+	}
 }
 
-// buildPingTargets enumerates all alive game server presences and produces a
-// flat list of PingTarget entries. Each server with an internal IP yields two
-// targets (one external, one internal-in-external-slot); servers without an
-// internal IP yield one target.
+// buildPingEndpoints enumerates all alive game server presences and produces one
+// paired endpoint per server (external + private internal), deduplicated by
+// external IP. Each entry carries both addresses so the client validates them
+// together (ADR 0002 req 3).
 //
 // The guildGroups map keys are the group IDs the player belongs to. Presences
 // are queried for each guild plus the global (uuid.Nil) stream.
-func (p *EvrPipeline) buildPingTargets(logger *zap.Logger, guildGroups map[string]struct{}) []PingTarget {
-	seen := make(map[string]struct{}) // dedup by "address:port"
-	var targets []PingTarget
+func (p *EvrPipeline) buildPingEndpoints(logger *zap.Logger, guildGroups map[string]struct{}) []evr.Endpoint {
+	seen := make(map[string]struct{}) // dedup by external "address:port"
+	var endpoints []evr.Endpoint
 
 	addPresences := func(subject string) {
 		presences, err := p.nk.StreamUserList(StreamModeGameServer, subject, "", "", false, true)
@@ -88,36 +96,12 @@ func (p *EvrPipeline) buildPingTargets(logger *zap.Logger, guildGroups map[strin
 				continue
 			}
 
-			extIP := gp.Endpoint.ExternalIP
-			port := gp.Endpoint.Port
-			serverKey := extIP.String()
-
-			// External target (always)
-			extKey := extIP.String() + ":" + strconv.Itoa(int(port))
-			if _, dup := seen[extKey]; !dup {
-				seen[extKey] = struct{}{}
-				targets = append(targets, PingTarget{
-					Address:    extIP,
-					Port:       port,
-					ServerKey:  serverKey,
-					IsInternal: false,
-				})
+			key := gp.Endpoint.ExternalIP.String() + ":" + strconv.Itoa(int(gp.Endpoint.Port))
+			if _, dup := seen[key]; dup {
+				continue
 			}
-
-			// Internal target (only if server has a genuine internal IP)
-			intIP := gp.Endpoint.InternalIP
-			if intIP != nil && !intIP.IsUnspecified() && isInternalIP(intIP) {
-				intKey := intIP.String() + ":" + strconv.Itoa(int(port))
-				if _, dup := seen[intKey]; !dup {
-					seen[intKey] = struct{}{}
-					targets = append(targets, PingTarget{
-						Address:    intIP,
-						Port:       port,
-						ServerKey:  serverKey,
-						IsInternal: true,
-					})
-				}
-			}
+			seen[key] = struct{}{}
+			endpoints = append(endpoints, pingEndpoint(gp.Endpoint))
 		}
 	}
 
@@ -126,7 +110,7 @@ func (p *EvrPipeline) buildPingTargets(logger *zap.Logger, guildGroups map[strin
 	}
 	addPresences(uuid.Nil.String())
 
-	return targets
+	return endpoints
 }
 
 // runPingDiscovery is launched as a goroutine after login success. It sends
@@ -152,16 +136,16 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 		guildGroupIDs[gid] = struct{}{}
 	}
 
-	targets := p.buildPingTargets(logger, guildGroupIDs)
-	if len(targets) == 0 {
-		logger.Debug("ping discovery: no targets found")
+	endpoints := p.buildPingEndpoints(logger, guildGroupIDs)
+	if len(endpoints) == 0 {
+		logger.Debug("ping discovery: no endpoints found")
 		return
 	}
 
 	cfg := p.pingDiscoveryConfig
 
-	// Chunk targets into batches of EndpointsPerMessage.
-	batches := chunkPingTargets(targets, EndpointsPerMessage)
+	// Chunk endpoints into batches of EndpointsPerMessage.
+	batches := chunkEndpoints(endpoints, EndpointsPerMessage)
 
 	// Cap at max_messages.
 	if len(batches) > cfg.MaxMessages {
@@ -175,7 +159,7 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 	}
 
 	logger.Info("ping discovery: starting",
-		zap.Int("targets", len(targets)),
+		zap.Int("endpoints", len(endpoints)),
 		zap.Int("batches", len(batches)),
 		zap.Duration("interval", interval),
 	)
@@ -190,16 +174,7 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 		default:
 		}
 
-		endpoints := make([]evr.Endpoint, len(batch))
-		for j, t := range batch {
-			endpoints[j] = evr.Endpoint{
-				InternalIP: net.IPv4zero,
-				ExternalIP: t.Address,
-				Port:       t.Port,
-			}
-		}
-
-		if err := SendEVRMessages(session, true, evr.NewLobbyPingRequest(pingDiscoveryRTTMax, endpoints)); err != nil {
+		if err := SendEVRMessages(session, true, evr.NewLobbyPingRequest(pingDiscoveryRTTMax, batch)); err != nil {
 			logger.Warn("ping discovery: failed to send batch",
 				zap.Int("batch", i), zap.Error(err))
 			return
@@ -221,72 +196,30 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 
 	logger.Info("ping discovery: complete",
 		zap.Int("batches_sent", len(batches)),
-		zap.Int("targets_sent", min(len(targets), cfg.MaxMessages*EndpointsPerMessage)),
+		zap.Int("endpoints_sent", min(len(endpoints), cfg.MaxMessages*EndpointsPerMessage)),
 	)
 }
 
 // buildJoinEndpoint constructs the Endpoint that will be sent to the client in
-// LobbySessionSuccess. If the client has demonstrated reachability to the
-// server's internal IP (via ping discovery), the internal IP is included so the
-// client can use the lower-latency path. Otherwise, the internal slot is set to
-// nil (serialized as 0.0.0.0, the client's "skip this address" value).
-//
-// This implements Phase 2 of ADR 0002.
-func buildJoinEndpoint(ctx context.Context, serverEndpoint evr.Endpoint) evr.Endpoint {
-	params, ok := LoadParams(ctx)
-	if !ok {
-		// No session params — return the endpoint as-is (external + internal).
-		return serverEndpoint
-	}
-
-	lh := params.latencyHistory.Load()
-	if lh == nil {
-		return serverEndpoint
-	}
-
-	extIP := serverEndpoint.ExternalIP
-	intIP := serverEndpoint.InternalIP
-
-	// If the server has no internal IP, nothing to decide.
-	if intIP == nil || intIP.IsUnspecified() {
-		return serverEndpoint
-	}
-
-	// Include the internal IP only when the client demonstrated that it is the
-	// best reachable path to this server — i.e. the client returned an RTT for
-	// the internal address AND that address is at least as fast as the external
-	// (ADR 0002: "LAN players get optimal routing"). BestAddress returns the
-	// chosen address, so we must compare it against the internal IP; reading its
-	// RTT alone would wrongly treat an external-only result as internal-reachable
-	// and leak the server's private IP to a remote client.
-	bestIP, _, ok := lh.BestAddress(extIP.String(), intIP.String())
-	if ok && bestIP == intIP.String() {
-		// Client can reach the internal IP and it is the best path — include it.
-		return evr.Endpoint{
-			InternalIP: intIP,
-			ExternalIP: extIP,
-			Port:       serverEndpoint.Port,
-		}
-	}
-
-	// Client cannot reach the internal IP (or the external path is faster) —
-	// external only. Never hand a private IP to a client that cannot use it.
-	return evr.Endpoint{
-		InternalIP: nil,
-		ExternalIP: extIP,
-		Port:       serverEndpoint.Port,
-	}
+// LobbySessionSuccess. Per ADR 0002, the client is handed BOTH the external and
+// the (private) internal address so it can validate them at connect time and use
+// whichever it can reach — at least one is valid (req 3). The internal slot is
+// included only when it holds a genuine private/internal address (req 2); a
+// publicly-routable or unspecified internal IP is stripped to nil (serialized as
+// 0.0.0.0, the client's "skip this address" value).
+func buildJoinEndpoint(serverEndpoint evr.Endpoint) evr.Endpoint {
+	return pingEndpoint(serverEndpoint)
 }
 
-// chunkPingTargets splits a slice of PingTarget into batches of at most size n.
-func chunkPingTargets(targets []PingTarget, n int) [][]PingTarget {
-	var batches [][]PingTarget
-	for i := 0; i < len(targets); i += n {
+// chunkEndpoints splits a slice of endpoints into batches of at most size n.
+func chunkEndpoints(endpoints []evr.Endpoint, n int) [][]evr.Endpoint {
+	var batches [][]evr.Endpoint
+	for i := 0; i < len(endpoints); i += n {
 		end := i + n
-		if end > len(targets) {
-			end = len(targets)
+		if end > len(endpoints) {
+			end = len(endpoints)
 		}
-		batches = append(batches, targets[i:end])
+		batches = append(batches, endpoints[i:end])
 	}
 	return batches
 }

--- a/server/evr_ping_discovery.go
+++ b/server/evr_ping_discovery.go
@@ -1,0 +1,286 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap"
+)
+
+const (
+	// EndpointsPerMessage is the maximum number of endpoints the EVR client
+	// accepts in a single LobbyPingRequest. Protocol constant, not configurable.
+	EndpointsPerMessage = 16
+
+	// Default pacing values — overridden by environment variables.
+	defaultPingDiscoveryMaxMessages   = 8
+	defaultPingDiscoverySpreadSeconds = 60
+
+	// pingDiscoveryRTTMax is the RTT ceiling sent in discovery ping requests.
+	pingDiscoveryRTTMax = 275
+)
+
+// PingDiscoveryConfig holds the pacing configuration loaded from environment
+// variables at pipeline construction time.
+type PingDiscoveryConfig struct {
+	MaxMessages   int // Max LobbyPingRequest messages per login
+	SpreadSeconds int // Window over which to spread the messages
+}
+
+// LoadPingDiscoveryConfig reads PING_DISCOVERY_MAX_MESSAGES and
+// PING_DISCOVERY_SPREAD_SECONDS from the runtime environment map. Missing or
+// unparseable values fall back to defaults.
+func LoadPingDiscoveryConfig(vars map[string]string) PingDiscoveryConfig {
+	cfg := PingDiscoveryConfig{
+		MaxMessages:   defaultPingDiscoveryMaxMessages,
+		SpreadSeconds: defaultPingDiscoverySpreadSeconds,
+	}
+	if v, ok := vars["PING_DISCOVERY_MAX_MESSAGES"]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxMessages = n
+		}
+	}
+	if v, ok := vars["PING_DISCOVERY_SPREAD_SECONDS"]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.SpreadSeconds = n
+		}
+	}
+	return cfg
+}
+
+// PingTarget maps a single pingable address back to its owning game server.
+type PingTarget struct {
+	Address    net.IP // The IP to ping (placed in Endpoint.ExternalIP)
+	Port       uint16 // Server port
+	ServerKey  string // ExternalIP string of the owning server (reverse lookup key)
+	IsInternal bool   // True if this address is the server's internal IP
+}
+
+// buildPingTargets enumerates all alive game server presences and produces a
+// flat list of PingTarget entries. Each server with an internal IP yields two
+// targets (one external, one internal-in-external-slot); servers without an
+// internal IP yield one target.
+//
+// The guildGroups map keys are the group IDs the player belongs to. Presences
+// are queried for each guild plus the global (uuid.Nil) stream.
+func (p *EvrPipeline) buildPingTargets(logger *zap.Logger, guildGroups map[string]struct{}) []PingTarget {
+	seen := make(map[string]struct{}) // dedup by "address:port"
+	var targets []PingTarget
+
+	addPresences := func(subject string) {
+		presences, err := p.nk.StreamUserList(StreamModeGameServer, subject, "", "", false, true)
+		if err != nil {
+			logger.Warn("failed to list game server presences for ping discovery",
+				zap.String("subject", subject), zap.Error(err))
+			return
+		}
+		for _, presence := range presences {
+			gp := &GameServerPresence{}
+			if err := json.Unmarshal([]byte(presence.GetStatus()), gp); err != nil {
+				continue
+			}
+			if !gp.Endpoint.IsValid() {
+				continue
+			}
+
+			extIP := gp.Endpoint.ExternalIP
+			port := gp.Endpoint.Port
+			serverKey := extIP.String()
+
+			// External target (always)
+			extKey := extIP.String() + ":" + strconv.Itoa(int(port))
+			if _, dup := seen[extKey]; !dup {
+				seen[extKey] = struct{}{}
+				targets = append(targets, PingTarget{
+					Address:    extIP,
+					Port:       port,
+					ServerKey:  serverKey,
+					IsInternal: false,
+				})
+			}
+
+			// Internal target (only if server has a genuine internal IP)
+			intIP := gp.Endpoint.InternalIP
+			if intIP != nil && !intIP.IsUnspecified() && isInternalIP(intIP) {
+				intKey := intIP.String() + ":" + strconv.Itoa(int(port))
+				if _, dup := seen[intKey]; !dup {
+					seen[intKey] = struct{}{}
+					targets = append(targets, PingTarget{
+						Address:    intIP,
+						Port:       port,
+						ServerKey:  serverKey,
+						IsInternal: true,
+					})
+				}
+			}
+		}
+	}
+
+	for groupID := range guildGroups {
+		addPresences(groupID)
+	}
+	addPresences(uuid.Nil.String())
+
+	return targets
+}
+
+// runPingDiscovery is launched as a goroutine after login success. It sends
+// paced LobbyPingRequest messages covering all alive game servers (split into
+// separate internal/external targets) so the latency cache is warm by the time
+// the player enters matchmaking.
+//
+// Lifecycle: the goroutine exits when the session context is cancelled
+// (disconnect/logout) or when all messages have been sent.
+func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
+	ctx := session.Context()
+	logger := session.Logger()
+
+	params, ok := LoadParams(ctx)
+	if !ok {
+		logger.Warn("ping discovery: failed to load session params")
+		return
+	}
+
+	// Build the set of guild group IDs for this player.
+	guildGroupIDs := make(map[string]struct{}, len(params.guildGroups))
+	for gid := range params.guildGroups {
+		guildGroupIDs[gid] = struct{}{}
+	}
+
+	targets := p.buildPingTargets(logger, guildGroupIDs)
+	if len(targets) == 0 {
+		logger.Debug("ping discovery: no targets found")
+		return
+	}
+
+	cfg := p.pingDiscoveryConfig
+
+	// Chunk targets into batches of EndpointsPerMessage.
+	batches := chunkPingTargets(targets, EndpointsPerMessage)
+
+	// Cap at max_messages.
+	if len(batches) > cfg.MaxMessages {
+		batches = batches[:cfg.MaxMessages]
+	}
+
+	// Calculate interval between messages.
+	interval := time.Duration(cfg.SpreadSeconds) * time.Second / time.Duration(len(batches))
+	if interval < 1*time.Second {
+		interval = 1 * time.Second
+	}
+
+	logger.Info("ping discovery: starting",
+		zap.Int("targets", len(targets)),
+		zap.Int("batches", len(batches)),
+		zap.Duration("interval", interval),
+	)
+
+	for i, batch := range batches {
+		// Check for session cancellation before each send.
+		select {
+		case <-ctx.Done():
+			logger.Debug("ping discovery: session cancelled",
+				zap.Int("batch", i), zap.Int("total", len(batches)))
+			return
+		default:
+		}
+
+		endpoints := make([]evr.Endpoint, len(batch))
+		for j, t := range batch {
+			endpoints[j] = evr.Endpoint{
+				InternalIP: net.IPv4zero,
+				ExternalIP: t.Address,
+				Port:       t.Port,
+			}
+		}
+
+		if err := SendEVRMessages(session, true, evr.NewLobbyPingRequest(pingDiscoveryRTTMax, endpoints)); err != nil {
+			logger.Warn("ping discovery: failed to send batch",
+				zap.Int("batch", i), zap.Error(err))
+			return
+		}
+
+		// Sleep between batches (except after the last one).
+		if i < len(batches)-1 {
+			timer := time.NewTimer(interval)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				logger.Debug("ping discovery: session cancelled during sleep",
+					zap.Int("batch", i))
+				return
+			case <-timer.C:
+			}
+		}
+	}
+
+	logger.Info("ping discovery: complete",
+		zap.Int("batches_sent", len(batches)),
+		zap.Int("targets_sent", min(len(targets), cfg.MaxMessages*EndpointsPerMessage)),
+	)
+}
+
+// buildJoinEndpoint constructs the Endpoint that will be sent to the client in
+// LobbySessionSuccess. If the client has demonstrated reachability to the
+// server's internal IP (via ping discovery), the internal IP is included so the
+// client can use the lower-latency path. Otherwise, the internal slot is set to
+// nil (serialized as 0.0.0.0, the client's "skip this address" value).
+//
+// This implements Phase 2 of ADR 0002.
+func buildJoinEndpoint(ctx context.Context, serverEndpoint evr.Endpoint) evr.Endpoint {
+	params, ok := LoadParams(ctx)
+	if !ok {
+		// No session params — return the endpoint as-is (external + internal).
+		return serverEndpoint
+	}
+
+	lh := params.latencyHistory.Load()
+	if lh == nil {
+		return serverEndpoint
+	}
+
+	extIP := serverEndpoint.ExternalIP
+	intIP := serverEndpoint.InternalIP
+
+	// If the server has no internal IP, nothing to decide.
+	if intIP == nil || intIP.IsUnspecified() {
+		return serverEndpoint
+	}
+
+	// Check if the client demonstrated reachability to the internal IP.
+	_, intRTT, _ := lh.BestAddress(extIP.String(), intIP.String())
+
+	if intRTT > 0 {
+		// Client can reach internal IP — include it.
+		return evr.Endpoint{
+			InternalIP: intIP,
+			ExternalIP: extIP,
+			Port:       serverEndpoint.Port,
+		}
+	}
+
+	// Client cannot reach internal IP — external only.
+	return evr.Endpoint{
+		InternalIP: nil,
+		ExternalIP: extIP,
+		Port:       serverEndpoint.Port,
+	}
+}
+
+// chunkPingTargets splits a slice of PingTarget into batches of at most size n.
+func chunkPingTargets(targets []PingTarget, n int) [][]PingTarget {
+	var batches [][]PingTarget
+	for i := 0; i < len(targets); i += n {
+		end := i + n
+		if end > len(targets) {
+			end = len(targets)
+		}
+		batches = append(batches, targets[i:end])
+	}
+	return batches
+}

--- a/server/evr_ping_discovery.go
+++ b/server/evr_ping_discovery.go
@@ -152,13 +152,20 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 		batches = batches[:cfg.MaxMessages]
 	}
 
-	// Calculate interval between messages.
-	interval := time.Duration(cfg.SpreadSeconds) * time.Second / time.Duration(len(batches))
+	// Calculate interval between messages. We sleep between batches only
+	// (len(batches)-1 gaps), so divide the spread window by the number of gaps
+	// to spread sends across the full SpreadSeconds rather than finishing early.
+	// The division is in nanoseconds, so no fractional-second truncation.
+	gaps := len(batches) - 1
+	if gaps < 1 {
+		gaps = 1
+	}
+	interval := time.Duration(cfg.SpreadSeconds) * time.Second / time.Duration(gaps)
 	if interval < 1*time.Second {
 		interval = 1 * time.Second
 	}
 
-	logger.Info("ping discovery: starting",
+	logger.Debug("ping discovery: starting",
 		zap.Int("endpoints", len(endpoints)),
 		zap.Int("batches", len(batches)),
 		zap.Duration("interval", interval),
@@ -194,7 +201,7 @@ func (p *EvrPipeline) runPingDiscovery(session *sessionWS) {
 		}
 	}
 
-	logger.Info("ping discovery: complete",
+	logger.Debug("ping discovery: complete",
 		zap.Int("batches_sent", len(batches)),
 		zap.Int("endpoints_sent", min(len(endpoints), cfg.MaxMessages*EndpointsPerMessage)),
 	)

--- a/server/evr_ping_discovery_test.go
+++ b/server/evr_ping_discovery_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"net"
 	"testing"
 	"time"
@@ -9,18 +8,7 @@ import (
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/atomic"
 )
-
-// newPingParamsCtx returns a context carrying SessionParameters whose latency
-// history is lh, mirroring how a live session stores its params on the context.
-func newPingParamsCtx(lh *LatencyHistory) context.Context {
-	params := &SessionParameters{
-		latencyHistory: atomic.NewPointer(lh),
-	}
-	ptr := atomic.NewPointer(params)
-	return context.WithValue(context.Background(), ctxSessionParametersKey{}, ptr)
-}
 
 func TestBestAddress_BothReachable_PrefersInternal(t *testing.T) {
 	h := NewLatencyHistory()
@@ -91,38 +79,69 @@ func TestHasRecentEntry(t *testing.T) {
 	assert.False(t, h.HasRecentEntry("5.6.7.8", time.Now().Add(-1*time.Minute)))
 }
 
-func TestChunkPingTargets(t *testing.T) {
-	targets := make([]PingTarget, 35)
-	for i := range targets {
-		targets[i] = PingTarget{
-			Address:   net.ParseIP("1.2.3.4"),
-			Port:      uint16(6792 + i),
-			ServerKey: "1.2.3.4",
-		}
+// TestPingEndpoint_IncludesBothWhenInternalPrivate covers ADR 0002 req 3: the
+// pre-connect ping carries BOTH the external and (private) internal address in a
+// single endpoint so at least one returns a valid RTT.
+func TestPingEndpoint_IncludesBothWhenInternalPrivate(t *testing.T) {
+	got := pingEndpoint(evr.Endpoint{
+		InternalIP: net.ParseIP("192.168.1.5"),
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	})
+	assert.Equal(t, "192.168.1.5", got.InternalIP.String())
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
+	assert.Equal(t, uint16(6792), got.Port)
+}
+
+// TestPingEndpoint_ExternalOnlyWhenInternalPublic covers ADR 0002 req 2: a
+// publicly-routable address must never occupy the internal slot; it is zeroed,
+// leaving external-only.
+func TestPingEndpoint_ExternalOnlyWhenInternalPublic(t *testing.T) {
+	got := pingEndpoint(evr.Endpoint{
+		InternalIP: net.ParseIP("8.8.8.8"),
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	})
+	assert.Nil(t, got.InternalIP)
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
+}
+
+func TestPingEndpoint_ExternalOnlyWhenNoInternal(t *testing.T) {
+	got := pingEndpoint(evr.Endpoint{
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	})
+	assert.Nil(t, got.InternalIP)
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
+}
+
+func TestChunkEndpoints(t *testing.T) {
+	eps := make([]evr.Endpoint, 35)
+	for i := range eps {
+		eps[i] = evr.Endpoint{ExternalIP: net.ParseIP("1.2.3.4"), Port: uint16(6792 + i)}
 	}
 
-	batches := chunkPingTargets(targets, 16)
+	batches := chunkEndpoints(eps, 16)
 	assert.Len(t, batches, 3)
 	assert.Len(t, batches[0], 16)
 	assert.Len(t, batches[1], 16)
 	assert.Len(t, batches[2], 3)
 }
 
-func TestChunkPingTargets_ExactMultiple(t *testing.T) {
-	targets := make([]PingTarget, 32)
-	for i := range targets {
-		targets[i] = PingTarget{Address: net.ParseIP("1.2.3.4"), Port: uint16(i)}
+func TestChunkEndpoints_ExactMultiple(t *testing.T) {
+	eps := make([]evr.Endpoint, 32)
+	for i := range eps {
+		eps[i] = evr.Endpoint{ExternalIP: net.ParseIP("1.2.3.4"), Port: uint16(i)}
 	}
 
-	batches := chunkPingTargets(targets, 16)
+	batches := chunkEndpoints(eps, 16)
 	assert.Len(t, batches, 2)
 	assert.Len(t, batches[0], 16)
 	assert.Len(t, batches[1], 16)
 }
 
-func TestChunkPingTargets_Empty(t *testing.T) {
-	batches := chunkPingTargets(nil, 16)
-	assert.Nil(t, batches)
+func TestChunkEndpoints_Empty(t *testing.T) {
+	assert.Nil(t, chunkEndpoints(nil, 16))
 }
 
 func TestLoadPingDiscoveryConfig_Defaults(t *testing.T) {
@@ -149,97 +168,52 @@ func TestLoadPingDiscoveryConfig_InvalidFallsBackToDefault(t *testing.T) {
 	assert.Equal(t, 60, cfg.SpreadSeconds)
 }
 
-func TestBuildJoinEndpoint_NoParams_ReturnsUnchanged(t *testing.T) {
+// TestBuildJoinEndpoint_PrivateInternal_IncludesBoth covers ADR 0002 req 3: the
+// join endpoint hands the client BOTH addresses (external + private internal) so
+// the client validates and picks whichever it can reach — at least one is valid.
+func TestBuildJoinEndpoint_PrivateInternal_IncludesBoth(t *testing.T) {
 	server := evr.Endpoint{
 		InternalIP: net.ParseIP("192.168.1.5"),
 		ExternalIP: net.ParseIP("1.2.3.4"),
 		Port:       6792,
 	}
-	// Context with no session params — must return the endpoint as-is.
-	got := buildJoinEndpoint(context.Background(), server)
-	assert.Equal(t, server, got)
+	got := buildJoinEndpoint(server)
+	assert.Equal(t, "192.168.1.5", got.InternalIP.String(), "private internal IP is handed to the client")
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
+	assert.Equal(t, uint16(6792), got.Port)
 }
 
-func TestBuildJoinEndpoint_NoInternalIP_ReturnsUnchanged(t *testing.T) {
+// TestBuildJoinEndpoint_PublicInternal_ExternalOnly is defense-in-depth for ADR
+// 0002 req 2: even if a publicly-routable internal slot slipped past
+// registration, it is never handed to the client.
+func TestBuildJoinEndpoint_PublicInternal_ExternalOnly(t *testing.T) {
 	server := evr.Endpoint{
-		InternalIP: nil,
+		InternalIP: net.ParseIP("8.8.8.8"),
 		ExternalIP: net.ParseIP("1.2.3.4"),
 		Port:       6792,
 	}
-	ctx := newPingParamsCtx(NewLatencyHistory())
-
-	got := buildJoinEndpoint(ctx, server)
-	assert.Equal(t, server, got)
+	got := buildJoinEndpoint(server)
+	assert.Nil(t, got.InternalIP, "public internal IP must be stripped")
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
 }
 
-func TestBuildJoinEndpoint_UnspecifiedInternalIP_ReturnsUnchanged(t *testing.T) {
+func TestBuildJoinEndpoint_NoInternal_ExternalOnly(t *testing.T) {
+	server := evr.Endpoint{
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	got := buildJoinEndpoint(server)
+	assert.Nil(t, got.InternalIP)
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
+}
+
+func TestBuildJoinEndpoint_UnspecifiedInternal_ExternalOnly(t *testing.T) {
 	server := evr.Endpoint{
 		InternalIP: net.IPv4zero,
 		ExternalIP: net.ParseIP("1.2.3.4"),
 		Port:       6792,
 	}
-	ctx := newPingParamsCtx(NewLatencyHistory())
-
-	got := buildJoinEndpoint(ctx, server)
-	assert.Equal(t, server, got)
-}
-
-func TestBuildJoinEndpoint_InternalReachable_IncludesInternal(t *testing.T) {
-	intIP := net.ParseIP("192.168.1.5")
-	extIP := net.ParseIP("1.2.3.4")
-	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
-
-	lh := NewLatencyHistory()
-	lh.Add(extIP, 35, 25, time.Time{}) // external reachable
-	lh.Add(intIP, 2, 25, time.Time{})  // internal reachable (client is on LAN)
-	ctx := newPingParamsCtx(lh)
-
-	got := buildJoinEndpoint(ctx, server)
-	assert.Equal(t, intIP, got.InternalIP, "internal IP should be included when client reached it")
-	assert.Equal(t, extIP, got.ExternalIP)
-	assert.Equal(t, uint16(6792), got.Port)
-}
-
-func TestBuildJoinEndpoint_InternalUnreachable_ExternalOnly(t *testing.T) {
-	intIP := net.ParseIP("192.168.1.5")
-	extIP := net.ParseIP("1.2.3.4")
-	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
-
-	lh := NewLatencyHistory()
-	lh.Add(extIP, 35, 25, time.Time{}) // only external reachable (remote client)
-	ctx := newPingParamsCtx(lh)
-
-	got := buildJoinEndpoint(ctx, server)
-	assert.Nil(t, got.InternalIP, "internal IP must be omitted when client could not reach it")
-	assert.Equal(t, extIP, got.ExternalIP)
-	assert.Equal(t, uint16(6792), got.Port)
-}
-
-func TestBuildJoinEndpoint_InternalReachableButSlower_ExternalOnly(t *testing.T) {
-	intIP := net.ParseIP("192.168.1.5")
-	extIP := net.ParseIP("1.2.3.4")
-	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
-
-	lh := NewLatencyHistory()
-	lh.Add(extIP, 20, 25, time.Time{}) // external is the faster path
-	lh.Add(intIP, 40, 25, time.Time{}) // internal reachable but slower
-	ctx := newPingParamsCtx(lh)
-
-	// Optimal routing: the external path is best, so the internal IP is omitted.
-	got := buildJoinEndpoint(ctx, server)
-	assert.Nil(t, got.InternalIP, "internal must be omitted when the external path is faster")
-	assert.Equal(t, extIP, got.ExternalIP)
-}
-
-func TestBuildJoinEndpoint_NeitherReachable_ExternalOnly(t *testing.T) {
-	intIP := net.ParseIP("192.168.1.5")
-	extIP := net.ParseIP("1.2.3.4")
-	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
-
-	// Empty history — player queued before discovery finished.
-	ctx := newPingParamsCtx(NewLatencyHistory())
-
-	got := buildJoinEndpoint(ctx, server)
-	assert.Nil(t, got.InternalIP, "safe default is external-only when no latency data exists")
-	assert.Equal(t, extIP, got.ExternalIP)
+	got := buildJoinEndpoint(server)
+	assert.Nil(t, got.InternalIP)
+	assert.Equal(t, "1.2.3.4", got.GetExternalIP())
 }

--- a/server/evr_ping_discovery_test.go
+++ b/server/evr_ping_discovery_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBestAddress_BothReachable_PrefersInternal(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})   // external: 35ms
+	h.Add(net.ParseIP("192.168.1.5"), 2, 25, time.Time{}) // internal: 2ms
+
+	ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+	require.True(t, ok)
+	assert.Equal(t, "192.168.1.5", ip)
+	assert.Equal(t, 2, rtt)
+}
+
+func TestBestAddress_BothReachable_PrefersLower(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 10, 25, time.Time{})    // external: 10ms
+	h.Add(net.ParseIP("192.168.1.5"), 50, 25, time.Time{}) // internal: 50ms (worse)
+
+	ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+	require.True(t, ok)
+	assert.Equal(t, "1.2.3.4", ip)
+	assert.Equal(t, 10, rtt)
+}
+
+func TestBestAddress_OnlyExternalReachable(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{}) // external only
+
+	ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+	require.True(t, ok)
+	assert.Equal(t, "1.2.3.4", ip)
+	assert.Equal(t, 35, rtt)
+}
+
+func TestBestAddress_NeitherReachable(t *testing.T) {
+	h := NewLatencyHistory()
+
+	_, _, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+	assert.False(t, ok)
+}
+
+func TestBestAddress_NoInternalIP(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})
+
+	ip, rtt, ok := h.BestAddress("1.2.3.4", "")
+	require.True(t, ok)
+	assert.Equal(t, "1.2.3.4", ip)
+	assert.Equal(t, 35, rtt)
+}
+
+func TestBestAddress_EqualRTT_PrefersInternal(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 20, 25, time.Time{})
+	h.Add(net.ParseIP("192.168.1.5"), 20, 25, time.Time{})
+
+	ip, _, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
+	require.True(t, ok)
+	// When equal, internal is preferred (intRTT <= extRTT)
+	assert.Equal(t, "192.168.1.5", ip)
+}
+
+func TestHasRecentEntry(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})
+
+	assert.True(t, h.HasRecentEntry("1.2.3.4", time.Now().Add(-1*time.Minute)))
+	assert.False(t, h.HasRecentEntry("1.2.3.4", time.Now().Add(1*time.Minute)))
+	assert.False(t, h.HasRecentEntry("5.6.7.8", time.Now().Add(-1*time.Minute)))
+}
+
+func TestChunkPingTargets(t *testing.T) {
+	targets := make([]PingTarget, 35)
+	for i := range targets {
+		targets[i] = PingTarget{
+			Address:   net.ParseIP("1.2.3.4"),
+			Port:      uint16(6792 + i),
+			ServerKey: "1.2.3.4",
+		}
+	}
+
+	batches := chunkPingTargets(targets, 16)
+	assert.Len(t, batches, 3)
+	assert.Len(t, batches[0], 16)
+	assert.Len(t, batches[1], 16)
+	assert.Len(t, batches[2], 3)
+}
+
+func TestChunkPingTargets_ExactMultiple(t *testing.T) {
+	targets := make([]PingTarget, 32)
+	for i := range targets {
+		targets[i] = PingTarget{Address: net.ParseIP("1.2.3.4"), Port: uint16(i)}
+	}
+
+	batches := chunkPingTargets(targets, 16)
+	assert.Len(t, batches, 2)
+	assert.Len(t, batches[0], 16)
+	assert.Len(t, batches[1], 16)
+}
+
+func TestChunkPingTargets_Empty(t *testing.T) {
+	batches := chunkPingTargets(nil, 16)
+	assert.Nil(t, batches)
+}
+
+func TestLoadPingDiscoveryConfig_Defaults(t *testing.T) {
+	cfg := LoadPingDiscoveryConfig(map[string]string{})
+	assert.Equal(t, 8, cfg.MaxMessages)
+	assert.Equal(t, 60, cfg.SpreadSeconds)
+}
+
+func TestLoadPingDiscoveryConfig_Override(t *testing.T) {
+	cfg := LoadPingDiscoveryConfig(map[string]string{
+		"PING_DISCOVERY_MAX_MESSAGES":   "12",
+		"PING_DISCOVERY_SPREAD_SECONDS": "30",
+	})
+	assert.Equal(t, 12, cfg.MaxMessages)
+	assert.Equal(t, 30, cfg.SpreadSeconds)
+}
+
+func TestLoadPingDiscoveryConfig_InvalidFallsBackToDefault(t *testing.T) {
+	cfg := LoadPingDiscoveryConfig(map[string]string{
+		"PING_DISCOVERY_MAX_MESSAGES":   "not_a_number",
+		"PING_DISCOVERY_SPREAD_SECONDS": "-5",
+	})
+	assert.Equal(t, 8, cfg.MaxMessages)
+	assert.Equal(t, 60, cfg.SpreadSeconds)
+}

--- a/server/evr_ping_discovery_test.go
+++ b/server/evr_ping_discovery_test.go
@@ -1,17 +1,30 @@
 package server
 
 import (
+	"context"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
 )
+
+// newPingParamsCtx returns a context carrying SessionParameters whose latency
+// history is lh, mirroring how a live session stores its params on the context.
+func newPingParamsCtx(lh *LatencyHistory) context.Context {
+	params := &SessionParameters{
+		latencyHistory: atomic.NewPointer(lh),
+	}
+	ptr := atomic.NewPointer(params)
+	return context.WithValue(context.Background(), ctxSessionParametersKey{}, ptr)
+}
 
 func TestBestAddress_BothReachable_PrefersInternal(t *testing.T) {
 	h := NewLatencyHistory()
-	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})   // external: 35ms
+	h.Add(net.ParseIP("1.2.3.4"), 35, 25, time.Time{})    // external: 35ms
 	h.Add(net.ParseIP("192.168.1.5"), 2, 25, time.Time{}) // internal: 2ms
 
 	ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
@@ -22,7 +35,7 @@ func TestBestAddress_BothReachable_PrefersInternal(t *testing.T) {
 
 func TestBestAddress_BothReachable_PrefersLower(t *testing.T) {
 	h := NewLatencyHistory()
-	h.Add(net.ParseIP("1.2.3.4"), 10, 25, time.Time{})    // external: 10ms
+	h.Add(net.ParseIP("1.2.3.4"), 10, 25, time.Time{})     // external: 10ms
 	h.Add(net.ParseIP("192.168.1.5"), 50, 25, time.Time{}) // internal: 50ms (worse)
 
 	ip, rtt, ok := h.BestAddress("1.2.3.4", "192.168.1.5")
@@ -134,4 +147,99 @@ func TestLoadPingDiscoveryConfig_InvalidFallsBackToDefault(t *testing.T) {
 	})
 	assert.Equal(t, 8, cfg.MaxMessages)
 	assert.Equal(t, 60, cfg.SpreadSeconds)
+}
+
+func TestBuildJoinEndpoint_NoParams_ReturnsUnchanged(t *testing.T) {
+	server := evr.Endpoint{
+		InternalIP: net.ParseIP("192.168.1.5"),
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	// Context with no session params — must return the endpoint as-is.
+	got := buildJoinEndpoint(context.Background(), server)
+	assert.Equal(t, server, got)
+}
+
+func TestBuildJoinEndpoint_NoInternalIP_ReturnsUnchanged(t *testing.T) {
+	server := evr.Endpoint{
+		InternalIP: nil,
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	ctx := newPingParamsCtx(NewLatencyHistory())
+
+	got := buildJoinEndpoint(ctx, server)
+	assert.Equal(t, server, got)
+}
+
+func TestBuildJoinEndpoint_UnspecifiedInternalIP_ReturnsUnchanged(t *testing.T) {
+	server := evr.Endpoint{
+		InternalIP: net.IPv4zero,
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	ctx := newPingParamsCtx(NewLatencyHistory())
+
+	got := buildJoinEndpoint(ctx, server)
+	assert.Equal(t, server, got)
+}
+
+func TestBuildJoinEndpoint_InternalReachable_IncludesInternal(t *testing.T) {
+	intIP := net.ParseIP("192.168.1.5")
+	extIP := net.ParseIP("1.2.3.4")
+	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
+
+	lh := NewLatencyHistory()
+	lh.Add(extIP, 35, 25, time.Time{}) // external reachable
+	lh.Add(intIP, 2, 25, time.Time{})  // internal reachable (client is on LAN)
+	ctx := newPingParamsCtx(lh)
+
+	got := buildJoinEndpoint(ctx, server)
+	assert.Equal(t, intIP, got.InternalIP, "internal IP should be included when client reached it")
+	assert.Equal(t, extIP, got.ExternalIP)
+	assert.Equal(t, uint16(6792), got.Port)
+}
+
+func TestBuildJoinEndpoint_InternalUnreachable_ExternalOnly(t *testing.T) {
+	intIP := net.ParseIP("192.168.1.5")
+	extIP := net.ParseIP("1.2.3.4")
+	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
+
+	lh := NewLatencyHistory()
+	lh.Add(extIP, 35, 25, time.Time{}) // only external reachable (remote client)
+	ctx := newPingParamsCtx(lh)
+
+	got := buildJoinEndpoint(ctx, server)
+	assert.Nil(t, got.InternalIP, "internal IP must be omitted when client could not reach it")
+	assert.Equal(t, extIP, got.ExternalIP)
+	assert.Equal(t, uint16(6792), got.Port)
+}
+
+func TestBuildJoinEndpoint_InternalReachableButSlower_ExternalOnly(t *testing.T) {
+	intIP := net.ParseIP("192.168.1.5")
+	extIP := net.ParseIP("1.2.3.4")
+	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
+
+	lh := NewLatencyHistory()
+	lh.Add(extIP, 20, 25, time.Time{}) // external is the faster path
+	lh.Add(intIP, 40, 25, time.Time{}) // internal reachable but slower
+	ctx := newPingParamsCtx(lh)
+
+	// Optimal routing: the external path is best, so the internal IP is omitted.
+	got := buildJoinEndpoint(ctx, server)
+	assert.Nil(t, got.InternalIP, "internal must be omitted when the external path is faster")
+	assert.Equal(t, extIP, got.ExternalIP)
+}
+
+func TestBuildJoinEndpoint_NeitherReachable_ExternalOnly(t *testing.T) {
+	intIP := net.ParseIP("192.168.1.5")
+	extIP := net.ParseIP("1.2.3.4")
+	server := evr.Endpoint{InternalIP: intIP, ExternalIP: extIP, Port: 6792}
+
+	// Empty history — player queued before discovery finished.
+	ctx := newPingParamsCtx(NewLatencyHistory())
+
+	got := buildJoinEndpoint(ctx, server)
+	assert.Nil(t, got.InternalIP, "safe default is external-only when no latency data exists")
+	assert.Equal(t, extIP, got.ExternalIP)
 }

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -17,8 +17,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/bwmarrin/discordgo"
 	rtapi "buf.build/gen/go/echotools/nevr-api/protocolbuffers/go/gameservice/v1"
+	"github.com/bwmarrin/discordgo"
 	"github.com/go-redis/redis"
 	"github.com/gofrs/uuid/v5"
 

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -88,7 +88,8 @@ type EvrPipeline struct {
 
 	remoteLogSem chan struct{} // limits concurrent RemoteLogSet processing
 
-	loginAttemptCache LoginAttemptCache
+	loginAttemptCache   LoginAttemptCache
+	pingDiscoveryConfig PingDiscoveryConfig
 }
 
 type ctxDiscordBotTokenKey struct{}
@@ -270,7 +271,8 @@ func NewEvrPipeline(logger *zap.Logger, startupLogger *zap.Logger, db *sql.DB, p
 
 		remoteLogSem: make(chan struct{}, 16), // max 16 concurrent RemoteLogSet processors
 
-		loginAttemptCache: NewLocalLoginAttemptCache(),
+		loginAttemptCache:   NewLocalLoginAttemptCache(),
+		pingDiscoveryConfig: LoadPingDiscoveryConfig(vars),
 	}
 
 	// Create and store the early quit message trigger for sending SNS messages to players

--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -73,6 +73,15 @@ func normalizeInternalIP(ip net.IP) (normalized net.IP, dropped bool) {
 	return nil, true
 }
 
+// serverProbeTarget returns the address nakama probes when a game server
+// connects and while it is monitored. Per ADR 0002 req 1, nakama pings ONLY the
+// external IP: the internal IP is a LAN address that nakama itself may not be
+// able to reach, so it is never a probe target. Routing every health check
+// through this helper keeps the invariant in one place.
+func serverProbeTarget(ep evr.Endpoint) net.IP {
+	return ep.ExternalIP
+}
+
 // sendDiscordServerError sends a formatted error message about a specific game server to the user on discord
 func sendDiscordServerError(internalIP net.IP, externalIP net.IP, port uint16, serverID uint64, errMsg string, discordId string, logger *zap.Logger, bot *discordgo.Session) {
 	if bot != nil && discordId != "" {
@@ -346,7 +355,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 		retries := 3
 		var rtt time.Duration
 		for range retries {
-			rtt, err = BroadcasterHealthcheck(p.internalIP, config.Endpoint.ExternalIP, int(config.Endpoint.Port), 500*time.Millisecond)
+			rtt, err = BroadcasterHealthcheck(p.internalIP, serverProbeTarget(config.Endpoint), int(config.Endpoint.Port), 500*time.Millisecond)
 			if err != nil {
 				time.Sleep(500 * time.Millisecond)
 				continue
@@ -432,7 +441,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 				return
 			case <-time.After(5 * time.Second):
 				// Check if the game server is still alive
-				rtts, err := BroadcasterRTTcheck(p.internalIP, config.Endpoint.ExternalIP, int(config.Endpoint.Port), 5, 500*time.Millisecond)
+				rtts, err := BroadcasterRTTcheck(p.internalIP, serverProbeTarget(config.Endpoint), int(config.Endpoint.Port), 5, 500*time.Millisecond)
 				if err != nil || len(rtts) == 0 {
 					logger.Warn("Game server is not responding", zap.Error(err), zap.String("endpoint", config.Endpoint.String()))
 					// Send the discord error
@@ -474,7 +483,7 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 	}()
 
 	if ServiceSettings().EnableContinuousGameserverHealthCheck {
-		go HealthCheckStart(ctx, logger, p.nk, session, p.internalIP, config.Endpoint.ExternalIP, int(config.Endpoint.Port), 500*time.Millisecond)
+		go HealthCheckStart(ctx, logger, p.nk, session, p.internalIP, serverProbeTarget(config.Endpoint), int(config.Endpoint.Port), 500*time.Millisecond)
 	}
 
 	// Build protobuf registration success message

--- a/server/evr_pipeline_gameserver_probe_test.go
+++ b/server/evr_pipeline_gameserver_probe_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net"
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestServerProbeTarget_ReturnsExternalNeverInternal covers ADR 0002 req 1: when
+// a game server connects (registration / continuous health check), nakama probes
+// ONLY the external IP. The internal IP may be unreachable from nakama and must
+// never be a probe target.
+func TestServerProbeTarget_ReturnsExternalNeverInternal(t *testing.T) {
+	ep := evr.Endpoint{
+		InternalIP: net.ParseIP("192.168.1.5"),
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	got := serverProbeTarget(ep)
+	assert.Equal(t, "1.2.3.4", got.String(), "nakama probes the external IP")
+	assert.NotEqual(t, ep.InternalIP.String(), got.String(), "nakama must never probe the internal IP")
+}
+
+func TestServerProbeTarget_NoInternal(t *testing.T) {
+	ep := evr.Endpoint{
+		ExternalIP: net.ParseIP("1.2.3.4"),
+		Port:       6792,
+	}
+	got := serverProbeTarget(ep)
+	assert.Equal(t, "1.2.3.4", got.String())
+}

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -198,7 +198,16 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 		unrequireMessage,
 		gameSettings,
 	}
-	return session.SendEvr(messagesToSend...)
+	if err := session.SendEvr(messagesToSend...); err != nil {
+		return err
+	}
+
+	// Start background ping discovery after login messages are sent.
+	// The goroutine is tied to session.Context() and self-terminates on
+	// disconnect or completion.
+	go p.runPingDiscovery(session)
+
+	return nil
 }
 
 // normalizes all the meta headset types to a common format


### PR DESCRIPTION
## Summary

Move game server ping discovery from matchmaking-time to login-time. Split internal and external IPs into separate ping targets to get per-address reachability and latency.

### The Problem

The `Endpoint` wire format bundles `InternalIP` and `ExternalIP` into a single struct. The EVR client pings the pair and returns one RTT. The server cannot tell which address the client actually reached. ADR 0001 noted this limitation and deferred per-client filtering (#469) as not achievable with the paired format.

Additionally, ping happens at matchmaking time (`CheckServerPing`), adding latency and only covering 16 servers.

### The Solution

1. **Split into separate targets** — For each server, send two `Endpoint` entries: one with the real external IP, one with the internal IP placed in the external slot. The client pings whatever is in the external slot.

2. **Discover at login** — Send paced `LobbyPingRequest` messages across a configurable window (default: 8 messages over 60 seconds). By the time the player queues, the reachability map is warm.

3. **Conditional internal IP at join** — Only include a server's internal IP in the join endpoint if the client demonstrated reachability to it.

### Config

```yaml
ping_discovery:
  max_messages: 8        # PingRequest messages per login (16 endpoints each)
  spread_seconds: 60     # spread window
```

### Docs

- **ADR 0002:** `docs/adr/0002-split-internal-external-ping-targets.md`
- **Spec:** `docs/specs/ping-discovery-at-login.md`

### Rollout

Phase 1: Add discovery at login, keep `CheckServerPing` as fallback
Phase 2: Wire conditional internal IP into join-time endpoint assembly
Phase 3: Remove/reduce `CheckServerPing`

Resolves the limitation noted in ADR 0001 — per-client endpoint filtering (#469) becomes achievable.