### PR TITLE
fix: Parties not seeing lobby after finishing a match

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -1088,6 +1088,17 @@ func (p *EvrPipeline) isLeaderHeadingToSocial(ctx context.Context, logger *zap.L
 // Fixes #460: player mid-match was pulled back to social when party leader
 // hit matchmaking.
 func (p *EvrPipeline) isFollowerInActiveMatch(ctx context.Context, logger *zap.Logger, session *sessionWS) bool {
+	// StateReturning means MatchLeave already happened, the match is over and
+	// the player is heading back to social. The service-stream presence may
+	// still be populated at this point (race between tracker cleanup and the
+	// client's next LobbyFindSessionRequest), so check the lifecycle first
+	// to avoid treating a just-finished match as an active one
+	if lc := getMatchLifecycle(session); lc != nil {
+		if lc.State() == StateReturning {
+			return false
+		}
+	}
+
 	matchStream := PresenceStream{
 		Mode:    StreamModeService,
 		Subject: session.id,

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -2415,6 +2415,48 @@ func TestIsFollowerInActiveMatch_PrivateArenaCombat(t *testing.T) {
 	}
 }
 
+// TestIsFollowerInActiveMatch_StateReturning is the regression test for the
+// post-match party-stuck bug: after a match ends the follower's service-stream
+// presence may still point to the arena match while the lifecycle is already
+// StateReturning. Without the lifecycle guard, isFollowerInActiveMatch returns
+// true and drops the LobbyFindSessionRequest, leaving the follower stuck... forever... how sad :(
+func TestIsFollowerInActiveMatch_StateReturning(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	// Service stream still shows the arena match (tracker not yet cleaned up).
+	registry := newMockFollowMatchRegistry()
+	groupID := env.groupID
+	registry.SetMatch(arenaMatchID, &MatchLabel{
+		ID:          arenaMatchID,
+		Mode:        evr.ModeArenaPublic,
+		Open:        false, // match is over but presence lingers
+		PlayerLimit: 8,
+		GroupID:     &groupID,
+	})
+	env.withMockNK(registry)
+	env.setFollowerMatch(arenaMatchID)
+
+	// Put the follower's lifecycle into StateReturning (MatchLeave already went)
+	lc := NewPlayerMatchLifecycle(zap.NewNop())
+	lc.Transition(StateInMatch, "in match")
+	lc.Transition(StateReturning, "match ended")
+
+	params := &SessionParameters{MatchLifecycle: lc}
+	ptr := atomic.NewPointer(params)
+	env.session.ctx = context.WithValue(context.Background(), ctxSessionParametersKey{}, ptr)
+
+	logger := loggerForTest(t)
+	result := env.pipeline.isFollowerInActiveMatch(context.Background(), logger, env.session)
+
+	if result {
+		t.Error("Expected false when follower lifecycle is StateReturning — " +
+			"the match ended; service-stream presence should not block lobby find")
+	}
+}
+
 func TestPoll_NilNK_FollowerNotInLeaderMatch_LoopsUntilContextExpiry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
After finishing a match while in a party, they
never see the lobby until they restart their games (reported by BagOchips in EVRL). This was caused
by ``isFollowerInActiveMatch`` seeing a stale
arena presence in the tracker.