### PR TITLE
fix: game-server-authoritative match state + reservation-based party system

### DIFF
--- a/cmd/logreplay/main.go
+++ b/cmd/logreplay/main.go
@@ -1,0 +1,386 @@
+// Command logreplay extracts events for a single user from a nakama JSONL log
+// file, anonymises identifying fields deterministically, and writes an
+// anonymised JSONL fixture suitable for replay-based debugging.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// CLI flags
+// ---------------------------------------------------------------------------
+
+var (
+	flagLogfile = flag.String("logfile", "", "path to JSONL log file (required)")
+	flagUID     = flag.String("uid", "", "user ID to extract (required)")
+	flagOut     = flag.String("out", "", "output JSONL file path (required)")
+	flagWindow  = flag.String("window", "", "time window filter, e.g. 20:22-20:24")
+)
+
+// ---------------------------------------------------------------------------
+// Anonymiser — deterministic, counter-based remapping
+// ---------------------------------------------------------------------------
+
+type anonymiser struct {
+	uuids      map[string]string
+	uuidCount  int
+	usernames  map[string]string
+	userCount  int
+	evrIDs     map[string]string
+	evrCount   int
+	dispNames  map[string]string
+	dispCount  int
+	clientIPs  map[string]string
+	ipCount    int
+	discordIDs map[string]string
+}
+
+func newAnonymiser() *anonymiser {
+	return &anonymiser{
+		uuids:      make(map[string]string),
+		usernames:  make(map[string]string),
+		evrIDs:     make(map[string]string),
+		dispNames:  make(map[string]string),
+		clientIPs:  make(map[string]string),
+		discordIDs: make(map[string]string),
+	}
+}
+
+func (a *anonymiser) anonUUID(real string) string {
+	if real == "" {
+		return ""
+	}
+	if v, ok := a.uuids[real]; ok {
+		return v
+	}
+	a.uuidCount++
+	fake := fmt.Sprintf("00000000-0000-0000-0000-%012d", a.uuidCount)
+	a.uuids[real] = fake
+	return fake
+}
+
+func (a *anonymiser) anonUsername(real string) string {
+	if real == "" {
+		return ""
+	}
+	if v, ok := a.usernames[real]; ok {
+		return v
+	}
+	a.userCount++
+	// player_A, player_B, ...
+	letter := string(rune('A' - 1 + a.userCount))
+	if a.userCount > 26 {
+		letter = fmt.Sprintf("%d", a.userCount)
+	}
+	fake := "player_" + letter
+	a.usernames[real] = fake
+	return fake
+}
+
+func (a *anonymiser) anonEvrID(real string) string {
+	if real == "" {
+		return ""
+	}
+	if v, ok := a.evrIDs[real]; ok {
+		return v
+	}
+	a.evrCount++
+	fake := fmt.Sprintf("OVR-ORG-%05d", 10000+a.evrCount)
+	a.evrIDs[real] = fake
+	return fake
+}
+
+func (a *anonymiser) anonDisplayName(real string) string {
+	if real == "" {
+		return ""
+	}
+	if v, ok := a.dispNames[real]; ok {
+		return v
+	}
+	a.dispCount++
+	fake := fmt.Sprintf("User_%d", a.dispCount)
+	a.dispNames[real] = fake
+	return fake
+}
+
+func (a *anonymiser) anonClientIP(real string) string {
+	if real == "" {
+		return ""
+	}
+	if v, ok := a.clientIPs[real]; ok {
+		return v
+	}
+	a.ipCount++
+	fake := fmt.Sprintf("10.0.0.%d", a.ipCount)
+	a.clientIPs[real] = fake
+	return fake
+}
+
+// replaceInlineIDs replaces UUID and EVR-ID patterns that appear inside
+// arbitrary string values (e.g. "request", "message" fields).
+func (a *anonymiser) replaceInlineIDs(s string) string {
+	s = reUUID.ReplaceAllStringFunc(s, func(m string) string {
+		return a.anonUUID(m)
+	})
+	s = reEvrID.ReplaceAllStringFunc(s, func(m string) string {
+		return a.anonEvrID(m)
+	})
+	return s
+}
+
+var (
+	reUUID  = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	reEvrID = regexp.MustCompile(`OVR-ORG-\d+`)
+)
+
+// uuidFields are top-level keys whose values are UUIDs to anonymise.
+var uuidFields = []string{
+	"uid", "sid", "login_sid", "loginsid", "match_id", "mid",
+	"party_id", "operator_id",
+}
+
+// anonymiseLine rewrites identifying fields in a parsed log line.
+func (a *anonymiser) anonymiseLine(m map[string]any) {
+	for _, k := range uuidFields {
+		if v, ok := m[k].(string); ok && v != "" {
+			m[k] = a.anonUUID(v)
+		}
+	}
+	if v, ok := m["username"].(string); ok && v != "" {
+		m["username"] = a.anonUsername(v)
+	}
+	if v, ok := m["evrid"].(string); ok && v != "" {
+		m["evrid"] = a.anonEvrID(v)
+	}
+	if v, ok := m["display_name"].(string); ok && v != "" {
+		m["display_name"] = a.anonDisplayName(v)
+	}
+	if v, ok := m["client_ip"].(string); ok && v != "" {
+		m["client_ip"] = a.anonClientIP(v)
+	}
+
+	// Strip Discord IDs entirely.
+	delete(m, "discord_id")
+	delete(m, "discordId")
+
+	// Replace inline UUIDs/EVR-IDs in string fields that carry payloads.
+	for _, k := range []string{"request", "message", "request_type"} {
+		if v, ok := m[k].(string); ok && v != "" {
+			m[k] = a.replaceInlineIDs(v)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Event filter
+// ---------------------------------------------------------------------------
+
+// isReplayRelevant returns true if the log line should be included in
+// the replay fixture.
+func isReplayRelevant(m map[string]any) bool {
+	msg, _ := m["msg"].(string)
+	if msg == "" {
+		return false
+	}
+
+	// Exact matches.
+	switch msg {
+	case "Received message",
+		"Player match lifecycle transition",
+		"Illegal player match lifecycle transition",
+		"Sending messages.",
+		"Player joining the match.",
+		"Player leaving the match.":
+		return true
+	}
+
+	// Prefix match for "Sending *evr.*".
+	if strings.HasPrefix(msg, "Sending ") {
+		return true
+	}
+
+	// Substring matches.
+	for _, sub := range []string{
+		"Joined party group",
+		"Social lobby search",
+		"Lobby find complete",
+		"Joined entrant",
+		"Authorized access",
+		"Leader is currently matchmaking",
+		"Already in leader's match",
+	} {
+		if strings.Contains(msg, sub) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// direction classifies a log line for the _direction field.
+func direction(m map[string]any) string {
+	msg, _ := m["msg"].(string)
+	if msg == "Received message" {
+		return "in"
+	}
+	if strings.HasPrefix(msg, "Sending") {
+		return "out"
+	}
+	return "internal"
+}
+
+// ---------------------------------------------------------------------------
+// Time window parsing
+// ---------------------------------------------------------------------------
+
+// parseWindow splits a "HH:MM-HH:MM" window into start/end strings.
+// Returns ("", "", false) when no window is set.
+func parseWindow(w string) (start, end string, ok bool) {
+	if w == "" {
+		return "", "", false
+	}
+	parts := strings.SplitN(w, "-", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), true
+}
+
+// inWindow checks whether the timestamp in a log line falls within the
+// configured window. The timestamp field is expected to be an ISO-8601
+// string; the window is compared against the "HH:MM" portion.
+func inWindow(m map[string]any, start, end string) bool {
+	ts, _ := m["ts"].(string)
+	if ts == "" {
+		// Try alternate key.
+		ts, _ = m["T"].(string)
+	}
+	if ts == "" {
+		ts, _ = m["time"].(string)
+	}
+	if ts == "" {
+		return true // no timestamp — include by default
+	}
+
+	// Extract HH:MM — look for "T" separator in ISO-8601.
+	idx := strings.IndexByte(ts, 'T')
+	if idx < 0 {
+		// Maybe space-separated.
+		idx = strings.IndexByte(ts, ' ')
+	}
+	if idx < 0 {
+		return true
+	}
+	timePart := ts[idx+1:]
+	if len(timePart) < 5 {
+		return true
+	}
+	hhmm := timePart[:5] // "HH:MM"
+	return hhmm >= start && hhmm <= end
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+func main() {
+	flag.Parse()
+
+	if *flagLogfile == "" || *flagUID == "" || *flagOut == "" {
+		fmt.Fprintf(os.Stderr, "Usage: logreplay -logfile <path> -uid <id> -out <path> [-window HH:MM-HH:MM]\n")
+		os.Exit(1)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// Open input.
+	f, err := os.Open(*flagLogfile)
+	if err != nil {
+		logger.Error("open logfile", "error", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	// Open output.
+	out, err := os.Create(*flagOut)
+	if err != nil {
+		logger.Error("create output", "error", err)
+		os.Exit(1)
+	}
+	defer out.Close()
+
+	// Parse optional time window.
+	winStart, winEnd, hasWindow := parseWindow(*flagWindow)
+	if *flagWindow != "" && !hasWindow {
+		logger.Error("invalid window format, expected HH:MM-HH:MM", "window", *flagWindow)
+		os.Exit(1)
+	}
+
+	anon := newAnonymiser()
+
+	scanner := bufio.NewScanner(f)
+	// Some log lines (e.g. match built events) exceed the default 64 KiB.
+	const maxLine = 4 * 1024 * 1024 // 4 MiB
+	scanner.Buffer(make([]byte, 0, maxLine), maxLine)
+
+	var totalLines, matchedLines int
+	enc := json.NewEncoder(out)
+
+	for scanner.Scan() {
+		totalLines++
+		line := scanner.Bytes()
+
+		var m map[string]any
+		if err := json.Unmarshal(line, &m); err != nil {
+			// Skip non-JSON lines (e.g. startup banners).
+			continue
+		}
+
+		// UID filter — check uid field.
+		uid, _ := m["uid"].(string)
+		if uid != *flagUID {
+			continue
+		}
+
+		// Time window filter.
+		if hasWindow && !inWindow(m, winStart, winEnd) {
+			continue
+		}
+
+		// Event relevance filter.
+		if !isReplayRelevant(m) {
+			continue
+		}
+
+		// Classify direction.
+		m["_direction"] = direction(m)
+
+		// Anonymise.
+		anon.anonymiseLine(m)
+
+		if err := enc.Encode(m); err != nil {
+			logger.Error("write output line", "error", fmt.Errorf("encode line %d: %w", totalLines, err))
+			os.Exit(1)
+		}
+		matchedLines++
+	}
+
+	if err := scanner.Err(); err != nil {
+		logger.Error("scan error", "error", fmt.Errorf("reading logfile: %w", err))
+		os.Exit(1)
+	}
+
+	logger.Info("done",
+		"total_lines", totalLines,
+		"matched_lines", matchedLines,
+		"output", *flagOut,
+	)
+}

--- a/docs/implementation-plan-party-reservations.md
+++ b/docs/implementation-plan-party-reservations.md
@@ -1,0 +1,1595 @@
+# Implementation Plan: Reservation-Based Party System
+
+**Source spec**: `docs/spec-party-reservation-system.md`
+**Behavior matrix**: `docs/party-behavior-matrix.md`
+**Go conventions**: project uses zap (not slog), `%w` error wrapping, context-first params
+**Reconciliation report**: `docs/lifecycle-state-machine-reconciliation.md`
+
+---
+
+## Preamble: StreamModeReservation Dropped
+
+The original plan used a `StreamModeReservation` tracker stream as the follower notification
+mechanism. This has been **dropped**. Reservations are discovered via the match label's
+`Players` slice: `rebuildCache()` already populates `PlayerInfo.IsReservation = true` for
+every entry in `reservationMap` (see `evr_match_label.go:469,487,503,518,533`).
+
+The follower queries for their reservation by calling `nk.MatchList` with a query that
+matches their session ID in the `label.players.session_id` field, or by looking up the
+leader's match via the leader's service stream and calling `MatchLabelByID`, then checking
+the `Players` slice for an entry matching their session with `IsReservation: true`.
+
+**Consequences of this change:**
+
+- Step 1 (add `StreamModeReservation` constant) is removed.
+- Steps 12 and 12b (untrack `StreamModeReservation`) are removed.
+- `findReservation` does a match label query, not a tracker read.
+- `clearMemberReservation` signals the match to delete the reservation slot (no stream to untrack).
+- `createPartyReservations` does not track any stream presences.
+- No new stream mode constant is needed.
+
+---
+
+## Already Committed Changes
+
+The following changes are already committed and should NOT be re-implemented:
+
+| Commit      | Description                                                        | Files                                                         |
+| ----------- | ------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `671456443` | Defer service/guild/matchmaking streams to `lobbyEntrantConnected` | `evr_lobby_joinentrant.go`, `evr_pipeline_lobby.go`           |
+| `f4e87462f` | Route authoritative match leave through game server signal         | `pipeline_match.go`                                           |
+| `522309f75` | Expand lifecycle transition table and add state guards             | `evr_match_lifecycle.go`, `evr_match.go`, `evr_lobby_find.go` |
+| `27465b928` | Log-replay test framework phase 1                                  | `evr_logreplay_test.go`, `server/testdata/replay/*`           |
+| `af4d2c276` | Add 6 diverse lifecycle replay fixtures                            | `server/testdata/replay/*`                                    |
+
+---
+
+## Section 1: Behavioral Acceptance Criteria (BACs)
+
+### BAC-001: Leader joins social lobby, reservations created for party members
+
+**Given**: A party of 3 (leader + 2 followers). Leader sends `LobbyFindSessionRequest` and joins a social lobby. Game server confirms the leader connected (`lobbyEntrantConnected` fires).
+**When**: `lobbyEntrantConnected` processes the leader's entrant.
+**Then**:
+
+1. `createPartyReservations` is called.
+2. For each non-leader party member with a live session (`sessionRegistry.Get` != nil), a `SignalCreatePartyReservations` signal is sent to the match.
+3. The match handler creates `slotReservation` entries in `reservationMap` with 5-minute expiry for each member not already in the match or already reserved.
+4. `rebuildCache()` is called, which populates `PlayerInfo.IsReservation = true` for each reserved member in the `Players` slice.
+
+**Verification**: `TestLeaderJoinsSocial_ReservationsCreated` -- create a party, simulate `lobbyEntrantConnected` for leader, verify `reservationMap` entries exist and `rebuildCache` marks them as `IsReservation`.
+**Replay fixtures that must still pass**: All 7 existing fixtures (none exercise reservation creation yet; this is a regression guard).
+**Source**: Spec section 1 "Leader Joins a Match -> Creates Reservations"
+
+---
+
+### BAC-002: Follower finds reservation and joins directly
+
+**Given**: Leader is in a social lobby. Reservation exists for follower (in `reservationMap`, visible via `PlayerInfo.IsReservation` in match label).
+**When**: Follower sends `LobbyFindSessionRequest`, entering `lobbyFind`.
+**Then**:
+
+1. `findReservation` is called early in the follower path (before existing follower logic at line 118 of `evr_lobby_find.go`).
+2. `findReservation` looks up the party leader's match via the leader's service stream, then calls `MatchLabelByID` and checks the `Players` slice for an entry matching the follower's session ID with `IsReservation: true`.
+3. The match ID is extracted from the label.
+4. Follower joins via `lobbyJoin(ctx, logger, session, lobbyParams, matchID)`.
+5. `TryFollowPartyLeader` and `pollFollowPartyLeader` are NOT entered.
+
+**Verification**: `TestFollowerFindsReservation_JoinsDirectly` -- set up reservation in match, call `findReservation`, verify it returns the correct match ID, verify `TryFollowPartyLeader` is not called.
+**Source**: Spec section 2 "Follower Matchmakes -> Searches for Reservation"
+
+---
+
+### BAC-003: Follower with no reservation enters hold state
+
+**Given**: Follower is in a party. Leader has NOT yet joined a match (no reservation exists).
+**When**: Follower sends `LobbyFindSessionRequest`.
+**Then**:
+
+1. `findReservation` returns `MatchID{}, false`.
+2. Follower falls through to existing follower logic (as fallback during migration).
+3. Eventually, when leader joins a match, `lobbyEntrantConnected` creates reservations, and the follower's next poll/retry finds it.
+
+**Verification**: `TestFollowerNoReservation_FallsThrough` -- no reservation exists, verify `findReservation` returns false, verify follower enters the existing follow path.
+**Source**: Spec section 5 "Follower Matchmakes Before Leader"
+
+---
+
+### BAC-004: Reservation consumed on player join
+
+**Given**: Reservation exists for follower in match's `reservationMap`.
+**When**: Follower joins the match via `MatchJoinAttempt`.
+**Then**:
+
+1. `LoadAndDeleteReservationRaw` or `LoadAndDeleteReservationByUserIDRaw` consumes the reservation (existing behavior at `evr_match.go:416-422`).
+2. `rebuildCache()` is called, removing the `IsReservation` entry from the `Players` slice.
+
+**Verification**: `TestReservationConsumed` -- create reservation, simulate join, verify `reservationMap` entry removed and `Players` slice updated.
+**Source**: Spec section 0 event table: "Player's game server confirms connection"
+
+---
+
+### BAC-005: Leader leaves match, party reservations cleared; non-leader leaves, only their reservation cleared
+
+**Given**: Leader is in a social lobby with reservations for 2 followers (A and B).
+**When**: A player with a `PartyID` leaves the match (`MatchLeave` fires).
+**Then**:
+
+1. `MatchLeave` detects the leaving player has a `PartyID` != nil.
+2. `MatchLeave` determines whether the leaving player is the party leader by casting `nk` to `*RuntimeGoNakamaModule`, calling `partyRegistry.Get(mp.PartyID)`, and comparing `ph.leader.UserPresence.SessionId` against `mp.GetSessionId()`. This is the same pattern used in Step 4 (`lobbyEntrantConnected`).
+3. **If the leaving player IS the leader**: All `reservationMap` entries where `Presence.PartyID` matches are deleted. `rebuildCache()` is called. This ensures followers don't try to join a match the leader has left.
+4. **If the leaving player is NOT the leader**: Only the leaving player's own reservation is deleted from `reservationMap` (keyed by their session ID). If no reservation exists for them, this is a no-op. `rebuildCache()` is called only if a reservation was actually deleted.
+5. **If the party cannot be looked up** (party already disbanded, `partyRegistry.Get` returns false): Fall back to clearing only the leaving player's own reservation. This is the safe default -- clearing all party reservations without knowing the leader could delete valid reservations for other members.
+6. `MatchLeave` modifies `state.reservationMap` directly (not via signal -- `MatchLeave` already runs inside the match handler goroutine, so direct modification is safe and correct; signals cannot be sent from within the match goroutine due to `matchSignalBlockedNakamaModule`).
+
+**Verification**: `TestLeaderLeavesMatch_ReservationsCleared` -- set up reservations, simulate leader leaving, verify all party reservations in `reservationMap` are empty. `TestNonLeaderLeavesMatch_OnlyTheirReservationCleared` -- set up reservations for followers A and B, simulate follower A leaving, verify only A's reservation is removed and B's remains.
+**Replay fixtures that must still pass**: All 7 existing fixtures.
+**Source**: Spec section 3 bullet 2: "Leader leaves the lobby"
+
+---
+
+### BAC-006: Member leaves party, their reservation cleared
+
+**Given**: Leader is in a social lobby with reservations for followers A and B.
+**When**: Follower A calls `snsPartyLeaveRequest`.
+**Then**:
+
+1. BEFORE `snsPartyLeaveCleanup` (which clears `params.currentPartyID`), `clearMemberReservation` looks up the leader's current match and signals it to delete the leaving member's reservation slot.
+2. Follower B's reservation remains.
+3. Then `snsPartyLeaveCleanup` runs normally.
+
+**Verification**: `TestMemberLeavesParty_TheirReservationCleared` -- set up 2 reservations, simulate one leave, verify only that member's reservation is removed.
+**Source**: Spec section 3 bullet 3: "Reserved player leaves the party"
+
+---
+
+### BAC-007: Member kicked from party, their reservation cleared
+
+**Given**: Leader is in a social lobby with reservations for followers A and B.
+**When**: Leader kicks follower A via `snsPartyKickRequest`.
+**Then**:
+
+1. Same as BAC-006 -- kicked member's reservation is cleared, other member's remains.
+
+**Verification**: `TestMemberKicked_TheirReservationCleared`
+**Source**: Behavior matrix #8: kick from party
+
+---
+
+### BAC-008: New member joins party while leader in match (late join)
+
+**Given**: Leader is in a social lobby.
+**When**: New member joins party via `snsPartyJoinRequest`.
+**Then**:
+
+1. After successful join and `snsPartyTrackAndJoin`, `createReservationForNewPartyMember` is called.
+2. It looks up the leader's current match via `StreamModeService`.
+3. If leader is in a social match, signals the match to create a reservation for the new member.
+4. `rebuildCache()` runs, adding the new member to `Players` with `IsReservation: true`.
+5. New member's next `lobbyFind` -> `findReservation` finds it -> joins directly.
+
+**Verification**: `TestLateJoin_ReservationCreated` -- leader in match, new member joins party, verify reservation created.
+**Source**: Spec section 6 "Late Join"
+
+---
+
+### BAC-009: New member accepts invite while leader in match
+
+**Given**: Leader is in a social lobby.
+**When**: New member accepts invite via `snsPartyRespondToInviteRequest`.
+**Then**: Same as BAC-008 -- `createReservationForNewPartyMember` is called after successful join.
+
+**Verification**: `TestInviteAccept_ReservationCreated`
+**Source**: Behavior matrix #5: Accept party invite
+
+---
+
+### BAC-010: Leader in arena/combat, no reservation for late joiner
+
+**Given**: Leader is in an arena match.
+**When**: New member joins party.
+**Then**:
+
+1. `createReservationForNewPartyMember` checks leader's match label.
+2. If arena/combat, skips reservation creation.
+3. No reservation created.
+
+**Verification**: `TestLateJoin_ArenaLeader_NoReservation` -- leader in arena, new member joins, verify no reservation created.
+**Source**: Behavior matrix #4: Join party (leader IN arena/combat match)
+
+---
+
+### BAC-011: SignalCreatePartyReservations skips existing presences and reservations
+
+**Given**: Match has 2 players already connected (including member X). Match also has a reservation for member Y.
+**When**: `SignalCreatePartyReservations` is received with members [X, Y, Z].
+**Then**:
+
+1. X is skipped (already in `presenceMap`).
+2. Y is skipped (already in `reservationMap`).
+3. Z gets a new `slotReservation` with 5-minute expiry.
+4. `rebuildCache()` is called once.
+
+**Verification**: `TestSignalCreatePartyReservations_SkipsDuplicates`
+**Source**: Spec section "New Signal: SignalCreatePartyReservations"
+
+---
+
+### BAC-012: SignalClearPartyReservations clears by party ID
+
+**Given**: Match has 3 reservations: 2 from party A, 1 from party B.
+**When**: `SignalClearPartyReservations` is received with party A's ID.
+**Then**:
+
+1. Both party A reservations are deleted.
+2. Party B reservation remains.
+3. `rebuildCache()` is called.
+
+**Verification**: `TestSignalClearPartyReservations_ClearsByPartyID`
+**Source**: Spec section "New Signal: SignalClearPartyReservations"
+
+---
+
+### BAC-013: Reservation for offline member skipped
+
+**Given**: Party has 3 members: leader, follower A (live session), follower B (dead session).
+**When**: `createPartyReservations` runs.
+**Then**:
+
+1. `sessionRegistry.Get(followerB.SessionID)` returns nil.
+2. No reservation is created for follower B.
+3. Reservation IS created for follower A.
+
+**Verification**: `TestReservationForOfflineMember_Skipped`
+**Source**: Spec edge case 7 "Reservation Created for Offline Member"
+
+---
+
+### BAC-014: Concurrent lobbyFind -- findReservation is idempotent
+
+**Given**: Reservation exists for follower.
+**When**: Two `LobbyFindSessionRequest` messages arrive simultaneously, both enter `findReservation`.
+**Then**:
+
+1. Both calls read the match label (read-only).
+2. First call: reservation found -> `lobbyJoin` -> succeeds -> reservation consumed by `MatchJoinAttempt`.
+3. Second call: reservation still visible in cached label -> `lobbyJoin` -> `ErrJoinRejectReasonDuplicateJoin` -> no-op (existing behavior at `evr_lobby_joinentrant.go:95-98`).
+
+**Verification**: `TestConcurrentLobbyFind_IdempotentReservation`
+**Source**: Spec edge case 8 "Concurrent lobbyFind Calls"
+
+---
+
+### BAC-015: Session ID change -- reservation found via user ID fallback
+
+**Given**: Leader in social lobby with reservation for follower (session A).
+**When**: Follower disconnects and reconnects with session B, re-joins party.
+**Then**:
+
+1. `snsPartyTrackAndJoin` fires.
+2. `createReservationForNewPartyMember` re-creates reservation with new session ID.
+3. Follower's `findReservation` finds it (new session ID in `Players` slice).
+4. Alternatively: if the old reservation is still present, `MatchJoinAttempt` falls back to `LoadAndDeleteReservationByUserIDRaw` (existing behavior at `evr_match.go:419`).
+
+**Verification**: `TestSessionIDChange_ReservationStillFound`
+**Source**: Spec edge case 1 "Session ID Change"
+
+---
+
+### BAC-016: Leader promoted -- old reservations cleared, new ones created
+
+**Given**: Leader A is in a social lobby with reservations for members B and C.
+**When**: Leadership is passed to member B via `snsPartyPassOwnershipRequest`.
+**Then**:
+
+1. Old leader A's reservations in their current match are cleared (`SignalClearPartyReservations` with old party context).
+2. Active matchmaking tickets are cancelled.
+3. If new leader B is in a match, `createPartyReservations` creates new reservations for members A and C.
+
+**Verification**: `TestLeaderPromotion_ReservationsRebuilt`
+**Source**: Spec section 7 "Party Leader Removal" and behavior matrix #9
+
+---
+
+### BAC-017: lobbyEntrantConnected only creates reservations for leader
+
+**Given**: Party of 2 (leader + follower). Both join same match via matchmaker.
+**When**: `lobbyEntrantConnected` fires for the follower.
+**Then**:
+
+1. `createPartyReservations` is called.
+2. Follower is NOT the party leader.
+3. No reservations are created (only leaders create reservations).
+
+**Verification**: `TestFollowerConnected_NoReservationsCreated`
+**Source**: Spec section 1: "If leader, enumerate party members..."
+
+---
+
+### BAC-018: appendPartyReservationPlaceholders still works (belt-and-suspenders)
+
+**Given**: Leader in party, calls `lobbyFind` for social lobby.
+**When**: `PrepareEntrantPresences` runs, followed by `appendPartyReservationPlaceholders`.
+**Then**:
+
+1. Placeholder reservations are still created for party members not in entrants list.
+2. These flow through `LobbyJoinEntrants` -> `MatchJoinAttempt` as before.
+3. `lobbyEntrantConnected` later refreshes/extends these via `SignalCreatePartyReservations`.
+
+**Verification**: Existing tests for `appendPartyReservationPlaceholders` continue to pass.
+**Source**: Spec section 3 "Social Lobby Reservations Persist" -- "belt-and-suspenders"
+
+---
+
+### BAC-019: lobbyFindOrCreateSocial priority join replaced with findReservation
+
+**Given**: Follower is in a party. Leader is in a social lobby. Reservation exists.
+**When**: Follower enters `lobbyFindOrCreateSocial`.
+**Then**:
+
+1. Before the priority join logic at line 791 of `evr_lobby_find.go`, `findReservation` is checked.
+2. If reservation found, joins directly -- bypasses the tracker-read leader lookup at lines 791-888.
+
+**Verification**: `TestSocialLobbyFind_ReservationBeforePriorityJoin`
+**Source**: Spec gap resolution #65
+
+---
+
+### BAC-020: Migration fallback -- old path still works when no reservation exists
+
+**Given**: Rolling deploy. Leader is on old server (no reservation created). Follower is on new server.
+**When**: Follower's `lobbyFind` calls `findReservation`.
+**Then**:
+
+1. `findReservation` returns false (no reservation in match label).
+2. Follower falls through to existing `TryFollowPartyLeader` / `pollFollowPartyLeader` path.
+3. The existing path works as before.
+
+**Verification**: `TestMigrationFallback_OldPathStillWorks`
+**Source**: Spec "Migration Notes" section
+
+---
+
+### BAC-021: Any member cancels matchmaking -- ALL members' matchmaking cancelled, ticket removed
+
+**Given**: A party of 3 (leader + 2 followers). The leader has submitted a matchmaking ticket after the 15s formation period. All 3 members are matchmaking.
+**When**: Any member (leader or follower) sends `LobbyPendingSessionCancel`.
+**Then**:
+
+1. The cancelling member's `lobbyPendingSessionCancel` handler detects the party via `LoadParams(session.Context())`.
+2. The handler enumerates party members via `tracker.ListByStream(partyStream, ...)`.
+3. For each party member (including the cancelling member): `LeaveMatchmakingStream` is called, which untracks their `StreamModeMatchmaking` presence.
+4. Each member's `monitorMatchmakingStream` goroutine detects the stream closure and cancels their `lobbyFind` context.
+5. The active matchmaking ticket is removed via `lobbyGroup.MatchmakerRemoveAll()`.
+6. No partial tickets remain -- the party either matchmakes together or not at all.
+
+**Verification**: `TestAnyCancelMatchmaking_AllMembersCancelled` -- create a party with active ticket, simulate one member cancelling, verify all members' matchmaking streams are closed and ticket is removed.
+**Source**: Spec section 4 "Cancellation Rules" rule 1
+
+---
+
+### BAC-022: Cancel does NOT remove from party
+
+**Given**: A party of 3 (leader + 2 followers). All are matchmaking.
+**When**: Any member cancels matchmaking (via `LobbyPendingSessionCancel`).
+**Then**:
+
+1. All members' matchmaking is cancelled (per BAC-021).
+2. All members remain in the party group -- `params.currentPartyID` is unchanged.
+3. All members remain on the party stream (`StreamModeParty`).
+4. No `snsPartyLeaveCleanup` is called.
+5. Members can re-queue for matchmaking together by sending a new `LobbyFindSessionRequest`.
+
+**Verification**: `TestCancelMatchmaking_StaysInParty` -- cancel matchmaking, verify party membership unchanged, verify party stream presences intact.
+**Source**: Spec section 4 "Cancellation Rules" rule 2
+
+---
+
+### BAC-023: Cancel during formation (before ticket submitted) -- formation stops, everyone back to social-ready
+
+**Given**: A party of 3 (leader + 2 followers). The leader has started matchmaking. The 15s formation period is active. The ticket has NOT yet been submitted (still waiting for followers to join).
+**When**: Any member sends `LobbyPendingSessionCancel` during the formation period.
+**Then**:
+
+1. The formation timer is cancelled.
+2. All members' matchmaking streams are closed (per BAC-021).
+3. No ticket was ever submitted to the matchmaker, so no ticket removal is needed.
+4. All members transition back to `StateSocialReady` (if they were in a social lobby) or their `lobbyFind` context is cancelled.
+5. All members remain in the party (per BAC-022).
+
+**Verification**: `TestCancelDuringFormation_NoTicketSubmitted` -- start formation, cancel before 15s, verify no ticket was added to the matchmaker, verify all members back to social-ready.
+**Source**: Spec section 4 "Cancellation Rules" rule 3
+
+---
+
+### BAC-024: Cancel during matchmaking (after ticket submitted) -- ticket removed, everyone back to social-ready
+
+**Given**: A party of 3 (leader + 2 followers). The 15s formation period has completed. The ticket has been submitted to the matchmaker.
+**When**: Any member sends `LobbyPendingSessionCancel` after the ticket is active.
+**Then**:
+
+1. All members' matchmaking is cancelled (per BAC-021).
+2. The active matchmaking ticket is removed from the matchmaker via `lobbyGroup.MatchmakerRemoveAll()`.
+3. All members transition back to `StateSocialReady`.
+4. All members remain in the party (per BAC-022).
+
+**Verification**: `TestCancelDuringMatchmaking_TicketRemoved` -- submit ticket, cancel, verify ticket is removed from matchmaker, verify all members back to social-ready.
+**Source**: Spec section 4 "Cancellation Rules" rule 4
+
+---
+
+### BAC-025: Ticket NOT submitted until after 15s formation period
+
+**Given**: A party of 3 (leader + 2 followers). The leader starts matchmaking for arena/combat.
+**When**: The leader's `lobbyMatchMakeWithFallback` is entered.
+**Then**:
+
+1. The leader does NOT call `replaceTicket` / `addTicket` immediately.
+2. A 15-second formation timer starts.
+3. During the formation period, followers' `LobbyFindSessionRequest` arrivals are tracked.
+4. After the 15s timer fires, the ticket is submitted with all members who are on the matchmaking stream.
+5. Members who did NOT start matchmaking within the 15s window are excluded from the ticket (but NOT removed from the party -- per AMBIGUITY-4 resolution).
+
+**Verification**: `TestDeferredTicketSubmission_WaitsForFormation` -- start matchmaking, verify no ticket exists for the first 14 seconds, verify ticket is submitted after 15 seconds.
+**Source**: Spec section 4 "Phase 3 -- Matchmaking" rule 1
+
+---
+
+## Section 2: Architectural Decision Records (ADRs)
+
+### ADR-001: Reservation as coordination mechanism, not tracker reads
+
+**Context**: The tracker-read follow pattern (5+ tracker reads to find leader's match) is TOCTOU-prone. The `isFollowerInLeaderDestination` test at `evr_lobby_find_follower_test.go:57` documents the exact ambiguity: when `followerMatchID == leaderMatchID == currentMatchID`, the system cannot distinguish "leaving this match" from "already in this match."
+**Decision**: Use match-level reservations as the coordination mechanism. Leaders create reservations when they join a match; followers search for their reservation, not the leader's location. No ambiguity, no stale data, no race conditions.
+**Alternatives considered**: (1) Fix the tracker reads with version numbers -- rejected because the fundamental problem is reading stale data, not ordering it. (2) Use a separate service/database -- rejected because reservations already exist in match labels.
+**Consequences**: Followers never read the leader's tracker service stream for follow purposes. The reservation IS the signal. Six functions become unnecessary after stabilization.
+**Source**: Spec "Principle" section, behavior matrix bugs #42-#44
+
+---
+
+### ADR-002: Game server as authority for "player is in match"
+
+**Context**: Service stream presences can be stale between the leader calling `LobbyJoinEntrants` and the game server confirming connection. Followers reading these stale presences cause false-positive convergence.
+**Decision**: "Player is in match" is true only when the game server confirms it via `lobbyEntrantConnected`. Reservation creation for party members happens at this event, not at `LobbyJoinEntrants`.
+**Status**: **COMPLETED** -- service/guild/matchmaking streams already deferred to `lobbyEntrantConnected` in commit `671456443`.
+**Consequences**: `lobbyEntrantConnected` gains party logic (currently has zero). The chain `sessionRegistry.Get(sessionID)` -> `LoadParams(s.Context())` -> `currentPartyID` is used to resolve party membership.
+**Source**: Spec section 1, gap resolution #69
+
+---
+
+### ADR-003: Match label PlayerInfo.IsReservation as discovery mechanism
+
+**Context**: Followers need to discover where their reservation is without scanning the match registry.
+**Decision**: `rebuildCache()` already populates `PlayerInfo.IsReservation = true` for entries in `reservationMap` (see `evr_match_label.go:469,487,503,518,533`). Followers look up the leader's match via the leader's service stream, call `MatchLabelByID`, and check if their session appears in the `Players` slice with `IsReservation: true`.
+**Previous approach (dropped)**: A `StreamModeReservation` stream mode was considered but dropped. The match label approach is simpler: no new stream constant, no tracker Track/Untrack calls, and reservation cleanup happens automatically when `reservationMap` entries are deleted and `rebuildCache` runs.
+**Consequences**: One `MatchLabelByID` call per `findReservation` invocation. Label is always fresh (not cached). No stream cleanup needed.
+**Source**: Spec section 2 -- adapted from "Recommended: Option A"
+
+---
+
+### ADR-004: Match signal for state modification (not direct writes)
+
+**Context**: `MatchLabel` is the match handler's state, accessed only within the match goroutine. External code must not write to it directly.
+**Decision**: Use `MatchSignal` with new opcodes (`SignalCreatePartyReservations`, `SignalClearPartyReservations`) to modify reservation state. This is the existing pattern used by `SignalPrepareSession` at `evr_match.go:1658`.
+**Alternatives considered**: Direct write to `reservationMap` from the pipeline -- rejected because it violates the match handler's single-goroutine execution model and would race.
+**Consequences**: Two new signal opcodes. Signal handler switch gets two new cases. Signal payloads are JSON-serialized.
+**Source**: Spec section "Why signal, not direct write"
+
+---
+
+### ADR-005: Keep existing follow path as migration fallback
+
+**Context**: During a rolling deploy, old server processes do not create reservations. Followers on new servers must fall back to the old path.
+**Decision**: The `findReservation` check is placed before `TryFollowPartyLeader`. If no reservation is found, the old path executes. After stabilization, the old functions are removed.
+**Alternatives considered**: Hard cutover (remove old path immediately) -- rejected because a rollback would leave followers with no follow mechanism.
+**Consequences**: Code duplication during migration period. Functions `TryFollowPartyLeader`, `pollFollowPartyLeader`, etc. are kept but will be removed in a follow-up PR.
+**Source**: Spec "Migration Notes" section
+
+---
+
+### ADR-006: Crash handler does NOT create reconnect reservation in leader's social lobby
+
+**Context**: When a party member crashes in arena, they get a reconnect reservation in the arena match (60s). The leader may also have a social lobby reservation for them.
+**Decision**: The crash handler does NOT create a social lobby reservation. The arena reconnect reservation takes precedence. If the reconnect window expires, the player reconnects and finds the leader's existing reservation naturally.
+**Alternatives considered**: Creating both reservations -- rejected because the player should reconnect to arena first (the game is still going).
+**Consequences**: No new logic in crash handler. Existing reconnect reservation logic at `evr_match.go:807-828` unchanged.
+**Source**: Spec gap resolution #71
+
+---
+
+### ADR-007: configureParty leader wait loop uses party stream, not match presences
+
+**Context**: `configureParty` at line 386-548 waits for party members by counting presences in the dying match via `GetMatchPresences` (line 443). The test `TestExpectedFollowerCount_FromPartyStream` documents that this gives wrong counts when followers have already left.
+**Decision**: The leader wait loop should use `lobbyGroup.Size()` from the party stream, not `GetMatchPresences`. The party stream is the source of truth for who's in the party.
+**Alternatives considered**: Keep using match presences -- rejected because the race is documented and causes real bugs.
+**Consequences**: Lines 443-452 of `evr_lobby_find.go` change from `GetMatchPresences` query to `lobbyGroup.Size()` check. This is a separate fix from the reservation system and should be a separate commit.
+**Source**: Spec gap resolution #66
+
+---
+
+### ADR-008: Cancel propagates to all party members, not just the canceller
+
+**Context**: In the current implementation, `lobbyPendingSessionCancel` (`evr_pipeline_matchmaker.go:232`) only cancels the individual caller's matchmaking stream via `LeaveMatchmakingStream`. There is no party-wide cancellation. This means one member can cancel while others continue matchmaking, resulting in partial tickets or orphaned matchmaking contexts.
+**Decision**: When any party member cancels matchmaking, ALL members' matchmaking is cancelled. The cancel handler (`lobbyPendingSessionCancel`) is extended to enumerate party members and close all their matchmaking streams. The ticket is removed via `lobbyGroup.MatchmakerRemoveAll()`. This is consistent with the spec rule: "No partial tickets."
+**Alternatives considered**: (1) Cancel only the individual -- rejected because tickets are immutable and contain all party members; a partial ticket is invalid. (2) Remove the cancelling member from the party -- rejected because matchmaking is an activity, not a relationship; cancelling the activity should not end the social relationship.
+**Consequences**: `lobbyPendingSessionCancel` gains party awareness. Each member's `monitorMatchmakingStream` goroutine detects the stream closure and cancels their `lobbyFind` context. No new message types needed -- the existing stream-close mechanism propagates the cancel.
+**Source**: Spec section 4 "Cancellation Rules" rules 1-5
+
+---
+
+### ADR-009: Deferred ticket submission (15s formation period)
+
+**Context**: Currently, `lobbyMatchMakeWithFallback` (`evr_lobby_matchmake.go:143`) calls `replaceTicket` immediately upon entry (line 205). The ticket is submitted to the matchmaker before all party members have had a chance to start matchmaking. This means the ticket may not include all party members, and late-arriving members trigger a cancel-and-rebuild cycle (`cancelTicketForLateArrival` at `evr_lobby_find.go:1356`).
+**Decision**: The leader's matchmaking loop waits up to 15 seconds (the formation period) before submitting the first ticket. During this period, it monitors the matchmaking stream for all party members. Once all members are present on the stream, or the 15s timer fires, the ticket is submitted with whoever is ready. Members who are NOT on the matchmaking stream when the timer fires are excluded from the ticket but NOT removed from the party.
+**Alternatives considered**: (1) Keep immediate submission with cancel-and-rebuild -- rejected because it creates unnecessary matchmaker churn and ticket invalidation. (2) Block on all members joining before any timeout -- rejected because it could block indefinitely if a member is offline.
+**Consequences**: `lobbyMatchMakeWithFallback` gains a formation phase before the first `replaceTicket` call. `cancelTicketForLateArrival` is no longer needed for the primary path (tickets are not submitted until formation is complete), though it is kept as a safety net during migration. The 15s formation period is bounded -- it does not extend the matchmaking timeout; it is a pre-matchmaking step.
+**Source**: Spec section 4 "Phase 1 -- Party Formation" and "Phase 3 -- Matchmaking"
+
+---
+
+## Section 3: Mechanical Implementation Steps
+
+**Line number note**: All line numbers verified against current code as of commit `af4d2c276`. Multiple steps modify the same files:
+
+- `evr_lobby_find.go`: Steps 4, 4b
+- `evr_pipeline_party.go`: Steps 5, 6, 7, 9
+- `evr_match.go`: Steps 2, 8
+- `evr_pipeline_lobby.go`: Step 3
+- `evr_lobby_matchmake.go`: Step 10
+- `evr_pipeline_matchmaker.go`: Step 11
+
+When multiple steps modify the same file, implementers should either (a) apply changes **bottom-up** within each file (highest line numbers first) so earlier insertions do not shift later insertion points, or (b) use the surrounding code context (function names, comments, block descriptions) rather than raw line numbers to locate each insertion point. The `Depends on` field documents functional dependencies; it does NOT imply application order within a single file.
+
+### Step 1: Add SignalCreatePartyReservations and SignalClearPartyReservations opcodes
+
+**BACs verified**: (prerequisite for BAC-001, BAC-005, BAC-011, BAC-012)
+**Files modified**: `/home/andrew/src/nakama/server/evr_match_signals.go`
+**Depends on**: none
+
+#### Changes:
+
+1. In `evr_match_signals.go` at line 28 (after `SignalKickEntrants`):
+   - **Add**: Two new signal opcodes to the iota:
+     ```
+     SignalCreatePartyReservations
+     SignalClearPartyReservations
+     ```
+   - **Reason**: New signals for match handler to create/clear party reservations (ADR-004). Source: spec "Implementation Details" section.
+
+2. In `evr_match_signals.go` after line 105 (after `SignalReserveSlotsPayload` struct):
+   - **Add**: Two new payload types:
+
+     ```go
+     // SignalCreatePartyReservationsPayload carries the list of party members
+     // who need slot reservations in the match.
+     type SignalCreatePartyReservationsPayload struct {
+         Members []*EvrMatchPresence `json:"members"`
+     }
+
+     // SignalClearPartyReservationsPayload carries the party ID whose
+     // reservations should be removed from the match.
+     type SignalClearPartyReservationsPayload struct {
+         PartyID uuid.UUID `json:"party_id"`
+     }
+     ```
+
+   - **Reason**: Typed payloads for the new signals.
+
+#### Test:
+
+- Function: Compile check only -- constant is used by subsequent steps
+- How to run: `GOWORK=off go build ./server/...`
+
+---
+
+### Step 2: Add signal handlers in MatchSignal
+
+**BACs verified**: BAC-011, BAC-012
+**Files modified**: `/home/andrew/src/nakama/server/evr_match.go`
+**Depends on**: Step 1
+
+#### Changes:
+
+1. In `evr_match.go` at line 1847 (before the `default:` case in the `switch signal.OpCode` block):
+   - **IMPORTANT: Fall-through pattern**. The `MatchSignal` switch has mixed patterns: some cases return early (e.g., `SignalShutdown` at line 1616, `SignalGetEndpoint` at line 1639), while others fall through to `updateLabel` at line 1852 (e.g., `SignalPrepareSession`, `SignalLockSession`, `SignalPlayerUpdate`). The new reservation cases follow the **fall-through pattern** -- they modify state and let execution continue to `updateLabel` and the `SignalResponse{Success: true, ...}` return at line 1859. **Do NOT add an early return** to either case; if an implementer adds `return state, ...` inside these cases, the label update and success response will be skipped.
+   - **Add**: Two new cases:
+
+     ```go
+     // NOTE: These cases intentionally do NOT return early.
+     // They fall through to updateLabel (line 1852) and return
+     // SignalResponse{Success: true} (line 1859), following the
+     // same pattern as SignalPrepareSession, SignalLockSession,
+     // and SignalPlayerUpdate.
+     case SignalCreatePartyReservations:
+         var payload SignalCreatePartyReservationsPayload
+         if err := json.Unmarshal(signal.Payload, &payload); err != nil {
+             return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal create party reservations: %v", err)}.String()
+         }
+         created := 0
+         for _, member := range payload.Members {
+             sid := member.GetSessionId()
+             if _, exists := state.presenceMap[sid]; exists {
+                 continue // already in match
+             }
+             if _, exists := state.reservationMap[sid]; exists {
+                 continue // already reserved
+             }
+             state.reservationMap[sid] = &slotReservation{
+                 Presence: member,
+                 Expiry:   time.Now().Add(5 * time.Minute),
+             }
+             created++
+         }
+         if created > 0 {
+             state.rebuildCache()
+         }
+         logger.WithFields(map[string]any{
+             "requested": len(payload.Members),
+             "created":   created,
+         }).Info("Created party reservations via signal")
+
+     case SignalClearPartyReservations:
+         var payload SignalClearPartyReservationsPayload
+         if err := json.Unmarshal(signal.Payload, &payload); err != nil {
+             return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal clear party reservations: %v", err)}.String()
+         }
+         cleared := 0
+         for sid, r := range state.reservationMap {
+             if r.Presence.PartyID == payload.PartyID {
+                 delete(state.reservationMap, sid)
+                 cleared++
+             }
+         }
+         if cleared > 0 {
+             state.rebuildCache()
+         }
+         logger.WithFields(map[string]any{
+             "party_id": payload.PartyID.String(),
+             "cleared":  cleared,
+         }).Info("Cleared party reservations via signal")
+     ```
+
+   - **Reason**: Match handler processes reservation create/clear signals inside its single goroutine (ADR-004). Source: spec "Implementation Details" section.
+
+#### Test:
+
+- Function: `TestSignalCreatePartyReservations_SkipsDuplicates`, `TestSignalClearPartyReservations_ClearsByPartyID`
+- File: `evr_match_signal_test.go` (new file)
+- What it asserts: Create signal skips existing presences/reservations; clear signal removes only matching partyID entries
+- How to run: `GOWORK=off go test -run 'TestSignalCreatePartyReservations|TestSignalClearPartyReservations' ./server/...`
+- **Replay fixtures that must still pass**: All 7 fixtures in `server/testdata/replay/`
+
+---
+
+### Step 3: Add createPartyReservations function and wire into lobbyEntrantConnected
+
+**BACs verified**: BAC-001, BAC-013, BAC-017
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_lobby.go`
+**Depends on**: Steps 1, 2
+
+#### Changes:
+
+1. In `evr_pipeline_lobby.go` after line 144 (after `lobbyEntrantConnected` function ends, before `lobbyEntrantsRemove` at line 146):
+   - **Add**: New function `createPartyReservations`:
+     ```go
+     // createPartyReservations creates slot reservations in the given match for
+     // all party members who are not already in the match. Called from
+     // lobbyEntrantConnected when the connected entrant is the party leader.
+     //
+     // IMPORTANT: This function is dispatched as a goroutine. The caller MUST
+     // pass context.WithoutCancel(s.Context()) so that reservation creation
+     // completes even if the triggering player session disconnects. Using the
+     // raw session context would cancel the goroutine mid-creation if the
+     // player disconnects, leaving some members with reservations and others
+     // without.
+     func (p *EvrPipeline) createPartyReservations(ctx context.Context, logger *zap.Logger, matchID MatchID, leaderSessionID uuid.UUID, partyID uuid.UUID) {
+     ```
+   - The function body should:
+     a. List party members via `p.nk.tracker.ListByStream(PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: p.node}, true, true)`
+     b. For each member != leader:
+     - Check `p.nk.sessionRegistry.Get(memberSessionID)` is non-nil (skip dead sessions -- BAC-013)
+     - Build `*EvrMatchPresence` with `SessionID`, `UserID`, `Username`, `PartyID`, `RoleAlignment: evr.TeamSocial`, `Node: p.node`
+     - Load additional fields from `LoadParams(memberSession.Context())` if available: `EvrID`, `DisplayName` (matching existing pattern in `appendPartyReservationPlaceholders` at `evr_lobby_find.go:1453-1483`)
+       c. If any members were collected, send `SignalCreatePartyReservations` to the match via `SignalMatch(ctx, p.nk, matchID, SignalCreatePartyReservations, payload)`
+   - **Reason**: Primary reservation creation path for party leaders. Source: spec section 1.
+
+2. In `evr_pipeline_lobby.go` at line 92 (after `acceptedIDs = append(acceptedIDs, entrantID)` inside the entrant loop):
+   - **IMPORTANT: Variable naming in `lobbyEntrantConnected`**. The parameter `session` (line 13) is the **game server's** `*sessionWS`. The **player's** session is `s`, obtained at line 45 via `p.nk.sessionRegistry.Get(...)`. The player's context is `s.Context()` (line 52). All party and reservation logic must use `s` (the player session), not `session` (the game server session). The party enumeration is done inside `createPartyReservations` via `p.nk.tracker.ListByStream(...)`, not at the call site.
+   - **Add**: Party reservation creation call:
+     ```go
+     // Create party reservations for followers when the leader connects.
+     // NOTE: `s` is the player's session (line 45), NOT `session` (the game server).
+     if params, ok := LoadParams(s.Context()); ok && params.currentPartyID != uuid.Nil {
+         // Check if this player is the party leader via the party registry.
+         if ph, ok := p.nk.partyRegistry.Get(params.currentPartyID); ok {
+             ph.RLock()
+             leader := ph.leader
+             ph.RUnlock()
+             if leader != nil && leader.UserPresence.SessionId == presence.GetSessionId() {
+                 // This entrant is the party leader. Dispatch reservation
+                 // creation asynchronously. Use context.WithoutCancel so
+                 // reservation creation completes even if the player
+                 // disconnects mid-creation.
+                 go p.createPartyReservations(context.WithoutCancel(s.Context()), logger, matchID, uuid.FromStringOrNil(presence.GetSessionId()), params.currentPartyID)
+             }
+         }
+     }
+     ```
+   - **Reason**: `lobbyEntrantConnected` is the trigger point for reservation creation (spec section 1). The `go` keyword dispatches asynchronously to avoid blocking the entrant accept response. `context.WithoutCancel` ensures the goroutine completes even if the player session disconnects. The party member enumeration happens inside `createPartyReservations` via `p.nk.tracker.ListByStream(...)`, so no `ListByStream` call is needed at this call site.
+
+#### Test:
+
+- Function: `TestLeaderJoinsSocial_ReservationsCreated`, `TestFollowerConnected_NoReservationsCreated`, `TestReservationForOfflineMember_Skipped`
+- File: `evr_pipeline_lobby_test.go` (new file)
+- What it asserts: Reservations created only for leader; dead sessions skipped
+- How to run: `GOWORK=off go test -run 'TestLeaderJoinsSocial|TestFollowerConnected|TestReservationForOfflineMember' ./server/...`
+- **Replay fixtures that must still pass**: All 7 fixtures
+
+---
+
+### Step 4: Add findReservation function and insert in lobbyFind follower path
+
+**BACs verified**: BAC-002, BAC-003, BAC-014, BAC-020
+**Files modified**: `/home/andrew/src/nakama/server/evr_lobby_find.go`
+**Depends on**: Steps 1, 2, 3
+
+#### Changes:
+
+1. In `evr_lobby_find.go` after line 1856 (after `pollFollowPartyLeader` function, at end of file):
+   - **Add**: New function `findReservation`:
+
+     ```go
+     // findReservation checks whether the party leader's current match has a
+     // reservation for this follower. It looks up the leader's match via the
+     // leader's service stream, fetches the match label, and checks the
+     // Players slice for an entry with IsReservation == true matching this
+     // session's ID.
+     //
+     // Returns the match ID and true if a reservation is found. Returns
+     // MatchID{}, false if no reservation exists (leader not in a match,
+     // match label unreadable, or follower not reserved).
+     //
+     // This replaces the old StreamModeReservation tracker-read approach.
+     // Cost: one tracker read (leader's service stream) + one MatchLabelByID
+     // call per invocation.
+     func (p *EvrPipeline) findReservation(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyGroup *LobbyGroup) (MatchID, bool) {
+         leader := lobbyGroup.GetLeader()
+         if leader == nil {
+             return MatchID{}, false
+         }
+         leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
+         leaderUserID := uuid.FromStringOrNil(leader.UserId)
+         if leaderSessionID == session.id {
+             return MatchID{}, false // caller IS the leader
+         }
+
+         // Look up leader's current match via their service stream.
+         stream := PresenceStream{
+             Mode:    StreamModeService,
+             Subject: leaderSessionID,
+             Label:   StreamLabelMatchService,
+         }
+         presence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, stream, leaderUserID)
+         if presence == nil {
+             return MatchID{}, false // leader not in a match
+         }
+         leaderMatchID := MatchIDFromStringOrNil(presence.GetStatus())
+         if leaderMatchID.IsNil() {
+             return MatchID{}, false
+         }
+
+         // Fetch match label and check for our reservation.
+         label, err := MatchLabelByID(ctx, p.nk, leaderMatchID)
+         if err != nil || label == nil {
+             logger.Debug("Failed to get leader's match label for reservation check",
+                 zap.Error(err), zap.String("mid", leaderMatchID.String()))
+             return MatchID{}, false
+         }
+
+         // Check if our session ID appears as a reservation in the Players slice.
+         sessionIDStr := session.id.String()
+         for _, player := range label.Players {
+             if player.SessionID == sessionIDStr && player.IsReservation {
+                 logger.Debug("Found reservation in leader's match",
+                     zap.String("match_id", leaderMatchID.String()))
+                 return leaderMatchID, true
+             }
+         }
+         return MatchID{}, false
+     }
+     ```
+
+   - **Reason**: Lightweight reservation lookup for followers. One tracker read + one label fetch, replacing 4+ tracker reads in the old path. Source: spec section 2.
+
+2. In `evr_lobby_find.go` at line 114 (the start of `if !isLeader {` block, after line 113 `if lobbyGroup != nil {`):
+   - **Add** immediately after line 114 (`if !isLeader {`), before line 115 (`// Guard: if the follower is in an active Arena/Combat match`):
+     ```go
+     // Reservation-based follow: if the leader has created a reservation
+     // for this follower, join directly without tracker-read follow logic.
+     if reservationMatchID, found := p.findReservation(ctx, logger, session, lobbyGroup); found {
+         logger.Info("Found party reservation, joining directly",
+             zap.String("reservation_mid", reservationMatchID.String()))
+         if err := p.lobbyJoin(ctx, logger, session, lobbyParams, reservationMatchID); err != nil {
+             logger.Warn("Failed to join via reservation, falling through to legacy path",
+                 zap.Error(err))
+         } else {
+             // Observer: follower joined via reservation.
+             if lc := getMatchLifecycle(session); lc != nil {
+                 lc.TransitionTo(StateInMatch, "joined via party reservation", WithMatchID(reservationMatchID.String()))
+             }
+             return nil
+         }
+     }
+     ```
+   - **Reason**: This is the primary insertion point per spec section 2. If reservation is found, skip all tracker-read follow logic. If join fails, fall through to existing path (migration safety -- ADR-005). Source: spec "Modified Functions" table.
+
+#### Test:
+
+- Function: `TestFollowerFindsReservation_JoinsDirectly`, `TestMigrationFallback_OldPathStillWorks`, `TestFindReservation_Found`, `TestFindReservation_NotFound`
+- File: `evr_lobby_find_reservation_test.go` (new file)
+- What it asserts: When reservation exists, `lobbyJoin` is called with reservation match ID; when no reservation, falls through to `isFollowerInActiveMatch` etc.
+- How to run: `GOWORK=off go test -run 'TestFollowerFindsReservation|TestMigrationFallback|TestFindReservation' ./server/...`
+- **Replay fixtures that must still pass**: All 7 fixtures
+
+---
+
+### Step 4b: Insert findReservation check in lobbyFindOrCreateSocial
+
+**BACs verified**: BAC-019
+**Files modified**: `/home/andrew/src/nakama/server/evr_lobby_find.go`
+**Depends on**: Step 4
+
+#### Changes:
+
+1. In `evr_lobby_find.go` at line 791 (before the priority-1 party leader join block `if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {`), inside `lobbyFindOrCreateSocial`:
+   - **Context**: Social-mode followers reach `lobbyFindOrCreateSocial` via `lobbyFind` line 167/207. The priority-1 block at lines 791-888 uses tracker reads to find the leader's match -- this is the old TOCTOU-prone path that the reservation system replaces. The `findReservation` check must go BEFORE this block so followers with a reservation skip the tracker-read path entirely.
+   - **IMPORTANT**: The `session` parameter in `lobbyFindOrCreateSocial` is a `Session` interface (not `*sessionWS`). The `findReservation` function takes `*sessionWS`, so a type assertion is needed. The `lobbyGroup` parameter may not exist at this call site; it must be obtained from the `lobbyParams` or `JoinPartyGroup`.
+   - **Retry loop behavior**: The insertion point at line 791 is inside the retry loop that starts at line 723 (`for attempt := 0; attempt < maxAttempts; attempt++`). The `findReservation` check will be called on EACH retry iteration. This is intentional and correct: the leader may connect and create reservations asynchronously between retry attempts. On the first iteration the reservation may not exist yet; by the second or third iteration `createPartyReservations` may have completed, and `findReservation` will find it. If `findReservation` succeeds and `lobbyJoin` succeeds, the function returns immediately (no further retries). If `findReservation` succeeds but `lobbyJoin` fails, it falls through to the legacy priority join path for that iteration.
+   - **Add** before line 791:
+     ```go
+     // Reservation-based follow: if the leader has created a reservation
+     // for this follower in a social lobby, join directly without the
+     // tracker-read priority join path.
+     if ws, ok := session.(*sessionWS); ok {
+         if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
+             if lobbyGroup, _, err := JoinPartyGroup(ws, lobbyParams.PartyGroupName, lobbyParams.CurrentMatchID); err == nil && lobbyGroup != nil {
+                 if reservationMatchID, found := p.findReservation(ctx, logger, ws, lobbyGroup); found {
+                     logger.Info("Found party reservation in social lobby path, joining directly",
+                         zap.String("reservation_mid", reservationMatchID.String()))
+                     if err := p.lobbyJoin(ctx, logger, ws, lobbyParams, reservationMatchID); err != nil {
+                         logger.Warn("Failed to join via reservation in social path, falling through to legacy priority join",
+                             zap.Error(err))
+                     } else {
+                         // Observer: follower joined via reservation in social lobby path.
+                         if lc := getMatchLifecycle(ws); lc != nil {
+                             lc.TransitionTo(StateInMatch, "joined via party reservation (social)", WithMatchID(reservationMatchID.String()))
+                         }
+                         return nil
+                     }
+                 }
+             }
+         }
+     }
+     ```
+   - **Reason**: `lobbyFindOrCreateSocial` is the code path for social-mode followers (reached via `lobbyFind` line 167/207). Without this check, followers in social mode would bypass the reservation system entirely and use the old tracker-read priority join at lines 791-888. BAC-019 requires this check. Source: spec gap resolution #65.
+
+#### Test:
+
+- Function: `TestSocialLobbyFind_ReservationBeforePriorityJoin`
+- File: `evr_lobby_find_reservation_test.go`
+- What it asserts: When reservation exists in social lobby path, `lobbyJoin` is called with reservation match ID; bypasses the tracker-read priority join at lines 791-888.
+- How to run: `GOWORK=off go test -run 'TestSocialLobbyFind_ReservationBeforePriorityJoin' ./server/...`
+
+---
+
+### Step 5: Add createReservationForNewPartyMember function
+
+**BACs verified**: BAC-008, BAC-009, BAC-010
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_party.go`
+**Depends on**: Steps 1, 2
+
+#### Changes:
+
+1. In `evr_pipeline_party.go` after line 686 (after `findPartyMemberPresence` function):
+   - **Add**: New function:
+
+     ```go
+     // createReservationForNewPartyMember checks if the party leader is currently
+     // in a social match and, if so, creates a reservation for the new member.
+     // Called after a successful party join or invite acceptance.
+     func (p *EvrPipeline) createReservationForNewPartyMember(ctx context.Context, logger *zap.Logger, memberSession *sessionWS, partyID uuid.UUID) {
+         // Find the party leader.
+         ph, ok := p.nk.partyRegistry.Get(partyID)
+         if !ok {
+             return
+         }
+         ph.RLock()
+         leader := ph.leader
+         ph.RUnlock()
+         if leader == nil {
+             return
+         }
+         leaderSessionID := uuid.FromStringOrNil(leader.UserPresence.SessionId)
+         leaderUserID := uuid.FromStringOrNil(leader.UserPresence.UserId)
+         if leaderSessionID == memberSession.id {
+             return // new member IS the leader
+         }
+
+         // Look up leader's current match.
+         leaderStream := PresenceStream{
+             Mode:    StreamModeService,
+             Subject: leaderSessionID,
+             Label:   StreamLabelMatchService,
+         }
+         leaderPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+         if leaderPresence == nil {
+             return // leader not in a match
+         }
+         leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus())
+         if leaderMatchID.IsNil() {
+             return
+         }
+
+         // Check if leader is in a social match (skip arena/combat -- BAC-010).
+         label, err := MatchLabelByID(ctx, p.nk, leaderMatchID)
+         if err != nil || label == nil || !label.IsSocial() {
+             return
+         }
+
+         // Build reservation presence for the new member.
+         memberParams, ok := LoadParams(memberSession.Context())
+         if !ok {
+             logger.Warn("Failed to load params for new party member reservation")
+             return
+         }
+
+         member := &EvrMatchPresence{
+             SessionID:     memberSession.id,
+             UserID:        memberSession.userID,
+             Username:      memberSession.Username(),
+             PartyID:       partyID,
+             RoleAlignment: evr.TeamSocial,
+             Node:          p.node,
+             EvrID:         memberParams.xpID,
+             DisplayName:   memberParams.profile.GetDisplayName(),
+         }
+
+         // Signal match to create reservation.
+         payload := SignalCreatePartyReservationsPayload{Members: []*EvrMatchPresence{member}}
+         if _, err := SignalMatch(ctx, p.nk, leaderMatchID, SignalCreatePartyReservations, payload); err != nil {
+             logger.Warn("Failed to signal match for new party member reservation", zap.Error(err))
+             return
+         }
+
+         logger.Info("Created reservation for new party member",
+             zap.String("member_sid", memberSession.id.String()),
+             zap.String("leader_match_id", leaderMatchID.String()))
+     }
+     ```
+
+   - **Reason**: Late join reservation creation. Source: spec section 6.
+
+2. In `evr_pipeline_party.go` at line 314 (in `snsPartyJoinRequest`, between the `sendEVRMessageToPartyMembers` call at lines 310-313 and the `return SendEVRMessages` at line 315):
+   - **Add**:
+     ```go
+     // Create reservation for the new member if leader is in a social match.
+     go p.createReservationForNewPartyMember(context.WithoutCancel(ctx), logger, session, partyUUID)
+     ```
+   - **Reason**: After successful join, check if leader has a match to create reservation in. `context.WithoutCancel` ensures the goroutine completes even if the session disconnects. Source: behavior matrix #3.
+
+3. In `evr_pipeline_party.go` at line 613 (in `snsPartyRespondToInviteRequest`, between the `sendEVRMessageToPartyMembers` call at lines 609-612 and the `return SendEVRMessages` at line 614):
+   - **Add**:
+     ```go
+     // Create reservation for the new member if leader is in a social match.
+     go p.createReservationForNewPartyMember(context.WithoutCancel(ctx), logger, session, partyUUID)
+     ```
+   - **Reason**: Same as above but for invite acceptance. `context.WithoutCancel` for the same reason. Source: behavior matrix #5.
+
+#### Test:
+
+- Function: `TestLateJoin_ReservationCreated`, `TestLateJoin_ArenaLeader_NoReservation`, `TestInviteAccept_ReservationCreated`
+- File: `evr_pipeline_party_test.go` (new or existing)
+- What it asserts: Reservation created when leader in social; not created when leader in arena
+- How to run: `GOWORK=off go test -run 'TestLateJoin|TestInviteAccept' ./server/...`
+
+---
+
+### Step 6: Clear reservation on party leave
+
+**BACs verified**: BAC-006
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_party.go`
+**Depends on**: Steps 1, 2
+
+#### Changes:
+
+1. In `evr_pipeline_party.go` in `snsPartyLeaveRequest` (lines 322-341), insert the reservation clear call **BEFORE** `snsPartyLeaveCleanup` at line 338:
+   - **IMPORTANT: Ordering matters**. `snsPartyLeaveCleanup` (in the function body) clears `params.currentPartyID` to `uuid.Nil` and stores params. If `clearMemberReservation` runs after cleanup, it cannot read the party ID from params. The reservation clear MUST happen before the cleanup call.
+   - **Context**: At line 329, `partyUUID := params.currentPartyID` captures the party ID before any cleanup. This local variable is available for the reservation clear.
+   - Insert at line 337 (after the `sendEVRMessageToPartyMembers` call at lines 332-335, BEFORE the `snsPartyLeaveCleanup` call at line 338):
+     ```go
+     // Clear any reservation for the departing member.
+     // Must run BEFORE snsPartyLeaveCleanup, which clears params.currentPartyID.
+     p.clearMemberReservation(ctx, logger, session, partyUUID)
+     ```
+
+2. In `evr_pipeline_party.go` after the `createReservationForNewPartyMember` function:
+   - **Add**: New helper function:
+
+     ```go
+     // clearMemberReservation looks up the party leader's current match and
+     // signals it to delete the departing member's reservation slot. Called
+     // when a member leaves or is kicked from the party.
+     //
+     // The partyID parameter must be captured BEFORE snsPartyLeaveCleanup
+     // (which clears params.currentPartyID to uuid.Nil). The caller passes
+     // the local `partyUUID` variable captured at line 329.
+     func (p *EvrPipeline) clearMemberReservation(ctx context.Context, logger *zap.Logger, session *sessionWS, partyID uuid.UUID) {
+         // Find the party leader's current match.
+         ph, ok := p.nk.partyRegistry.Get(partyID)
+         if !ok {
+             return // party already disbanded
+         }
+         ph.RLock()
+         leader := ph.leader
+         ph.RUnlock()
+         if leader == nil {
+             return
+         }
+         leaderSessionID := uuid.FromStringOrNil(leader.UserPresence.SessionId)
+         leaderUserID := uuid.FromStringOrNil(leader.UserPresence.UserId)
+
+         leaderStream := PresenceStream{
+             Mode:    StreamModeService,
+             Subject: leaderSessionID,
+             Label:   StreamLabelMatchService,
+         }
+         leaderPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+         if leaderPresence == nil {
+             return // leader not in a match
+         }
+         leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus())
+         if leaderMatchID.IsNil() {
+             return
+         }
+
+         // Signal the match to delete this specific member's reservation.
+         // We use SignalClearPartyReservations with the party ID, which clears
+         // ALL reservations for this party. This is broader than needed for a
+         // single member, but it is safe: the remaining members will get new
+         // reservations when the leader's lobbyEntrantConnected fires next, or
+         // via the belt-and-suspenders appendPartyReservationPlaceholders path.
+         //
+         // Phase 2: Add SignalClearMemberReservation (by session ID) to clear
+         // only the individual member's slot without affecting others.
+         payload := SignalClearPartyReservationsPayload{PartyID: partyID}
+         if _, err := SignalMatch(ctx, p.nk, leaderMatchID, SignalClearPartyReservations, payload); err != nil {
+             logger.Warn("Failed to clear departing member's reservation",
+                 zap.Error(err),
+                 zap.String("sid", session.id.String()),
+                 zap.String("match_id", leaderMatchID.String()),
+                 zap.String("party_id", partyID.String()))
+             return
+         }
+
+         logger.Debug("Cleared reservation for departing member",
+             zap.String("sid", session.id.String()),
+             zap.String("match_id", leaderMatchID.String()),
+             zap.String("party_id", partyID.String()))
+     }
+     ```
+
+   - **Reason**: When a member leaves, their reservation should be removed so the match slot is freed. Source: spec section 3.
+
+   **AMBIGUITY-1 (RESOLVED for Phase 1)**: `SignalClearPartyReservations` clears ALL reservations for a party ID, which is too broad for single-member removal. For Phase 1, this is acceptable because remaining members will get fresh reservations from `appendPartyReservationPlaceholders`. Phase 2 should add `SignalClearMemberReservation` (by session ID) for surgical removal.
+
+#### Test:
+
+- Function: `TestMemberLeavesParty_TheirReservationCleared`
+- File: `evr_pipeline_party_test.go`
+- What it asserts: Reservation in match is cleared for leaving member
+- How to run: `GOWORK=off go test -run 'TestMemberLeavesParty' ./server/...`
+
+---
+
+### Step 7: Clear reservation on party kick
+
+**BACs verified**: BAC-007
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_party.go`
+**Depends on**: Step 6
+
+#### Changes:
+
+1. In `evr_pipeline_party.go` at line 466 (in `snsPartyKickRequest`, after `p.sendEVRMessageToPartyMembers` at lines 462-465 but before `return SendEVRMessages` at line 467):
+   - **Add**:
+     ```go
+     // Clear any reservation for the kicked member.
+     if kickedSession := p.nk.sessionRegistry.Get(uuid.FromStringOrNil(targetPresence.SessionId)); kickedSession != nil {
+         if ws, ok := kickedSession.(*sessionWS); ok {
+             p.clearMemberReservation(ctx, logger, ws, params.currentPartyID)
+         }
+     }
+     ```
+   - **Reason**: Kicked members' reservations should be cleared. The kicker's `params.currentPartyID` is valid here (kick does not call `snsPartyLeaveCleanup` for the kicker). Source: behavior matrix #8.
+
+#### Test:
+
+- Function: `TestMemberKicked_TheirReservationCleared`
+- File: `evr_pipeline_party_test.go`
+- How to run: `GOWORK=off go test -run 'TestMemberKicked' ./server/...`
+
+---
+
+### Step 8: Clear party reservations when a player leaves match (leader clears all, non-leader clears own)
+
+**BACs verified**: BAC-005
+**Files modified**: `/home/andrew/src/nakama/server/evr_match.go`
+**Depends on**: Steps 1, 2
+
+#### Changes:
+
+1. In `evr_match.go` at line 849 (inside `MatchLeave`, between the lifecycle observer block ending at line 848 and the early quit penalty block starting at line 850):
+   - **Context**: Line 830 is the START of the lifecycle observer block (`// Observer: log lifecycle transition for player leaving match.`). The observer block runs lines 830-848. The insertion point is line 849, after the observer block's closing `}`. The early quit penalty block starts at line 850 (`// If the round is not over, then add an early quit count...`).
+   - This modification happens inside the match handler goroutine, so `state.reservationMap` can be modified directly (no signal needed -- unlike external callers, `MatchLeave` already holds the match goroutine).
+   - **IMPORTANT: Leader vs non-leader distinction**. When ANY party member leaves the match, we must NOT blindly clear all party reservations. Only the leader leaving should clear all party reservations (followers should not join a match the leader has left). When a non-leader leaves, only their own reservation (if any) should be cleared -- other followers' reservations remain valid because the leader is still present.
+   - The leader check uses `nk.(*RuntimeGoNakamaModule).partyRegistry.Get(mp.PartyID)` to look up the party handler and compare `ph.leader.UserPresence.SessionId` against `mp.GetSessionId()`. This is the same `RuntimeGoNakamaModule` cast already used at line 834 in the lifecycle observer block immediately above this insertion point. It is also the same leader-check pattern used in Step 3 (`lobbyEntrantConnected`).
+   - **Add**:
+
+     ```go
+     // Clear party reservations based on whether the leaving player is the leader.
+     // Leader leaves -> clear ALL party reservations (followers should not join
+     // a match the leader has left).
+     // Non-leader leaves -> clear only THEIR OWN reservation (other followers'
+     // reservations remain valid because the leader is still present).
+     if mp.PartyID != uuid.Nil {
+         isLeader := false
+         if _nk, ok := nk.(*RuntimeGoNakamaModule); ok {
+             if ph, ok := _nk.partyRegistry.Get(mp.PartyID); ok {
+                 ph.RLock()
+                 if ph.leader != nil {
+                     isLeader = ph.leader.UserPresence.SessionId == mp.GetSessionId()
+                 }
+                 ph.RUnlock()
+             }
+             // If partyRegistry.Get fails (party already disbanded), fall through
+             // to the non-leader path: clear only this player's own reservation.
+             // This is the safe default -- clearing all reservations without
+             // confirming leadership could delete valid reservations for other
+             // members who are still expected.
+         }
+
+         cleared := 0
+         if isLeader {
+             // Leader is leaving: clear ALL reservations for this party.
+             for sid, r := range state.reservationMap {
+                 if r.Presence.PartyID == mp.PartyID {
+                     delete(state.reservationMap, sid)
+                     cleared++
+                 }
+             }
+         } else {
+             // Non-leader is leaving: clear only THEIR OWN reservation.
+             if _, exists := state.reservationMap[mp.GetSessionId()]; exists {
+                 delete(state.reservationMap, mp.GetSessionId())
+                 cleared = 1
+             }
+         }
+         if cleared > 0 {
+             state.rebuildCache()
+             logger.WithFields(map[string]any{
+                 "party_id":  mp.PartyID.String(),
+                 "is_leader": isLeader,
+                 "cleared":   cleared,
+             }).Info("Cleared party reservations for departing player")
+         }
+     }
+     ```
+
+   - **Reason**: Source: spec section 3 bullet 2 and behavior matrix #30.
+
+#### Test:
+
+- Function: `TestLeaderLeavesMatch_ReservationsCleared`, `TestNonLeaderLeavesMatch_OnlyTheirReservationCleared`
+- File: `evr_match_test.go` (existing or new)
+- What it asserts: After leader leaves, `reservationMap` has no entries with matching partyID; `Size` decremented. After non-leader leaves, only that player's reservation is removed; other party members' reservations remain.
+- How to run: `GOWORK=off go test -run 'TestLeaderLeavesMatch_ReservationsCleared|TestNonLeaderLeavesMatch_OnlyTheirReservationCleared' ./server/...`
+- **Replay fixtures that must still pass**: All 7 fixtures
+
+---
+
+### Step 9: Handle ownership transfer -- clear old reservations
+
+**BACs verified**: BAC-016
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_party.go`
+**Depends on**: Steps 1, 3
+
+#### Changes:
+
+1. In `evr_pipeline_party.go` at line 505 (in `snsPartyPassOwnershipRequest`, between `p.sendEVRMessageToPartyMembers` at lines 501-504 and `return SendEVRMessages` at line 506):
+   - **Add**:
+     ```go
+     // Clear old leader's reservations and cancel tickets.
+     // The old leader's match may still have reservations for party members.
+     oldLeaderStream := PresenceStream{
+         Mode:    StreamModeService,
+         Subject: session.id,
+         Label:   StreamLabelMatchService,
+     }
+     if oldLeaderPresence := session.tracker.GetLocalBySessionIDStreamUserID(session.id, oldLeaderStream, session.userID); oldLeaderPresence != nil {
+         oldMatchID := MatchIDFromStringOrNil(oldLeaderPresence.GetStatus())
+         if !oldMatchID.IsNil() {
+             payload := SignalClearPartyReservationsPayload{PartyID: params.currentPartyID}
+             if _, err := SignalMatch(ctx, p.nk, oldMatchID, SignalClearPartyReservations, payload); err != nil {
+                 logger.Warn("Failed to clear old leader's reservations", zap.Error(err))
+             }
+         }
+     }
+     // New leader may need to create reservations in their current match.
+     if newLeaderSession := p.nk.sessionRegistry.Get(uuid.FromStringOrNil(targetPresence.SessionId)); newLeaderSession != nil {
+         if ws, ok := newLeaderSession.(*sessionWS); ok {
+             newLeaderStream := PresenceStream{
+                 Mode:    StreamModeService,
+                 Subject: ws.id,
+                 Label:   StreamLabelMatchService,
+             }
+             if newPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(ws.id, newLeaderStream, ws.userID); newPresence != nil {
+                 newMatchID := MatchIDFromStringOrNil(newPresence.GetStatus())
+                 if !newMatchID.IsNil() {
+                     if label, err := MatchLabelByID(ctx, p.nk, newMatchID); err == nil && label != nil && label.IsSocial() {
+                         go p.createPartyReservations(context.WithoutCancel(ctx), logger, newMatchID, ws.id, params.currentPartyID)
+                     }
+                 }
+             }
+         }
+     }
+     ```
+   - **Reason**: Ownership transfer requires clearing old and creating new reservations. Source: spec section 7 and behavior matrix #9.
+
+#### Test:
+
+- Function: `TestLeaderPromotion_ReservationsRebuilt`
+- File: `evr_pipeline_party_test.go`
+- How to run: `GOWORK=off go test -run 'TestLeaderPromotion' ./server/...`
+
+---
+
+### Step 10: Defer ticket submission until after 15s formation period
+
+**BACs verified**: BAC-023, BAC-025
+**Files modified**: `/home/andrew/src/nakama/server/evr_lobby_matchmake.go`
+**Depends on**: none
+
+#### Changes:
+
+1. In `evr_lobby_matchmake.go` at lines 204-207 (inside `lobbyMatchMakeWithFallback`, the initial ticket submission block):
+   - **Context**: Currently, `replaceTicket(ticketConfig)` is called at line 205 immediately on entry. The ticket is submitted before followers have had a chance to send their own `LobbyFindSessionRequest`. The spec requires that the ticket is NOT submitted until after a 15-second formation period during which all party members can join.
+   - **Current flow** (immediate ticket submission):
+     ```go
+     // Add initial ticket
+     if err := replaceTicket(ticketConfig); err != nil {   // line 205
+         return err
+     }
+     ```
+   - **New flow** (deferred ticket submission with formation period):
+   - **IMPORTANT: Solo players skip formation.** If `lobbyGroup == nil` or `lobbyGroup.Size() <= 1`, submit the ticket immediately (existing behavior). The formation period applies only when the player is in a party with other members.
+   - **Modify** the block starting at line 204 (`// Add initial ticket`) through line 207:
+
+     ```go
+     // Formation phase: if in a party, wait up to 15 seconds for all
+     // members to start matchmaking before submitting the first ticket.
+     // Solo players or single-member parties skip this phase entirely.
+     if lobbyGroup != nil && lobbyGroup.Size() > 1 {
+         const formationTimeout = 15 * time.Second
+         formationTimer := time.NewTimer(formationTimeout)
+         defer formationTimer.Stop()
+
+         // Wait for all party members to be on the matchmaking stream,
+         // or for the formation timer to fire, or for the context to
+         // be cancelled (e.g., a member cancels matchmaking).
+         partyStream := PresenceStream{Mode: StreamModeParty, Subject: lobbyGroup.ID(), Label: session.pipeline.node}
+         formationLoop:
+         for {
+             select {
+             case <-ctx.Done():
+                 return nil // Cancelled during formation (BAC-023)
+             case <-formationTimer.C:
+                 // Formation timeout fired. Submit ticket with whoever
+                 // is ready. Members NOT on the matchmaking stream are
+                 // excluded from the ticket but remain in the party.
+                 logger.Info("Formation timeout -- submitting ticket with ready members",
+                     zap.Int("party_size", lobbyGroup.Size()))
+                 break formationLoop
+             case <-time.After(1 * time.Second):
+                 // Check if all party members are now on the matchmaking stream.
+                 partyPresences := session.tracker.ListByStream(partyStream, true, true)
+                 allReady := true
+                 for _, pp := range partyPresences {
+                     mmStream := PresenceStream{
+                         Mode:    StreamModeMatchmaking,
+                         Subject: pp.ID.SessionID,
+                     }
+                     if session.tracker.GetLocalBySessionIDStreamUserID(pp.ID.SessionID, mmStream, pp.UserID) == nil {
+                         allReady = false
+                         break
+                     }
+                 }
+                 if allReady {
+                     logger.Info("All party members ready -- submitting ticket early",
+                         zap.Int("party_size", lobbyGroup.Size()))
+                     break formationLoop
+                 }
+             }
+         }
+     }
+
+     // Add initial ticket (after formation phase for parties, immediately for solo)
+     if err := replaceTicket(ticketConfig); err != nil {
+         return err
+     }
+     ```
+
+   - **Reason**: Spec section 4 "Phase 3 -- Matchmaking" rule 1: "The ticket is submitted to the matchmaker AFTER the 15s formation period, not before." Source: ADR-009.
+   - **Note**: The formation period is separate from the matchmaking timeout (`lobbyParams.MatchmakingTimeout`). The matchmaking timeout context (`ctx`) is set at `evr_lobby_find.go:102`. The formation period runs WITHIN this context -- if the matchmaking timeout fires during formation, the context is cancelled and the function returns. The formation period does not extend the total timeout; it is a subset of it.
+
+2. **DECISION: Member removal after formation timeout (RESOLVED).** The spec has two contradictory statements: rule 3 says "removed from the party" while rule 5 says "not the party." For Phase 1, follow rule 5: exclude non-ready members from the ticket, but do NOT remove them from the party. This is consistent with BAC-022 (cancel does not remove from party).
+
+#### Test:
+
+- Function: `TestDeferredTicketSubmission_WaitsForFormation`, `TestDeferredTicketSubmission_SoloSkipsFormation`, `TestDeferredTicketSubmission_AllReadyEarly`
+- File: `evr_lobby_matchmake_test.go` (new or existing)
+- What it asserts: With party, ticket not submitted until 15s or all members ready; without party, ticket submitted immediately; early submission when all members ready before 15s.
+- How to run: `GOWORK=off go test -run 'TestDeferredTicketSubmission' ./server/...`
+
+---
+
+### Step 11: Cancel handler -- propagate cancel to all party members
+
+**BACs verified**: BAC-021, BAC-022, BAC-024
+**Files modified**: `/home/andrew/src/nakama/server/evr_pipeline_matchmaker.go`
+**Depends on**: none
+
+#### Changes:
+
+1. In `evr_pipeline_matchmaker.go` at line 232 (the `lobbyPendingSessionCancel` function body, lines 232-240):
+   - **Context**: Currently, `lobbyPendingSessionCancel` at lines 232-240 only calls `LeaveMatchmakingStream(logger, session)` for the individual caller. It has zero party awareness. When a party member cancels, only their own matchmaking stream is closed. Other party members continue matchmaking, and the ticket is now invalid (it was built with all members).
+   - **Modify** the function body:
+
+     ```go
+     func (p *EvrPipeline) lobbyPendingSessionCancel(ctx context.Context, logger *zap.Logger, session *sessionWS, in evr.Message) error {
+         // Always leave the caller's matchmaking stream first.
+         if err := LeaveMatchmakingStream(logger, session); err != nil {
+             logger.Warn("Failed to leave matchmaking stream", zap.Error(err))
+         }
+
+         // If the player is in a party, cancel matchmaking for ALL members.
+         // Per spec: "Any member cancels matchmaking -> cancel ALL members'
+         // matchmaking. Remove the ticket. No partial tickets."
+         params, ok := LoadParams(session.Context())
+         if !ok || params.currentPartyID == uuid.Nil {
+             return nil // Solo player -- already cancelled above.
+         }
+
+         // Remove any active matchmaking tickets for the party.
+         partyID := params.currentPartyID
+         if ph, ok := p.nk.partyRegistry.Get(partyID); ok {
+             lobbyGroup := &LobbyGroup{ph: ph}
+             if err := lobbyGroup.MatchmakerRemoveAll(); err != nil {
+                 logger.Warn("Failed to remove party matchmaking tickets on cancel",
+                     zap.String("party_id", partyID.String()),
+                     zap.Error(err))
+             }
+         }
+
+         // Close all party members' matchmaking streams so their
+         // monitorMatchmakingStream goroutines cancel their lobbyFind contexts.
+         partyStream := PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: p.node}
+         partyPresences := p.nk.tracker.ListByStream(partyStream, true, true)
+         for _, pp := range partyPresences {
+             if pp.ID.SessionID == session.id {
+                 continue // Already cancelled above.
+             }
+             memberSession := p.nk.sessionRegistry.Get(pp.ID.SessionID)
+             if memberSession == nil {
+                 continue
+             }
+             ws, ok := memberSession.(*sessionWS)
+             if !ok {
+                 continue
+             }
+             if err := LeaveMatchmakingStream(logger, ws); err != nil {
+                 logger.Warn("Failed to cancel party member's matchmaking stream",
+                     zap.String("member_sid", pp.ID.SessionID.String()),
+                     zap.Error(err))
+             }
+         }
+
+         logger.Info("Cancelled matchmaking for entire party",
+             zap.String("party_id", partyID.String()),
+             zap.Int("members_cancelled", len(partyPresences)))
+
+         return nil
+     }
+     ```
+
+   - **Reason**: Spec section 4 "Cancellation Rules" rule 1: "Any member cancels matchmaking -> cancel ALL members' matchmaking. Remove the ticket. No partial tickets." The existing `monitorMatchmakingStream` goroutine (at `evr_lobby_find.go:550`) already detects when the matchmaking stream is closed and cancels the `lobbyFind` context -- so closing all members' streams is the only action needed to propagate the cancel. No new message types are required. Source: ADR-008.
+   - **Cancel does NOT remove from party** (BAC-022): This function only touches matchmaking streams and tickets. It does NOT call `snsPartyLeaveCleanup` or modify `params.currentPartyID`. The party membership is preserved.
+   - **Formation vs matchmaking cancel** (BAC-023 vs BAC-024): The same mechanism works for both. During formation (Step 10), the formation loop checks `ctx.Done()` -- when the matchmaking stream is closed, `monitorMatchmakingStream` fires `cancelFn()`, which cancels the context, which terminates the formation loop. During active matchmaking, the same cancel mechanism works: the ticket is removed by `MatchmakerRemoveAll`, and the matchmaking loop exits via `ctx.Done()`.
+
+#### Test:
+
+- Function: `TestAnyCancelMatchmaking_AllMembersCancelled`, `TestCancelMatchmaking_StaysInParty`, `TestCancelDuringFormation_NoTicketSubmitted`, `TestCancelDuringMatchmaking_TicketRemoved`
+- File: `evr_pipeline_matchmaker_test.go` (new or existing)
+- What it asserts: All members' matchmaking streams closed; party membership preserved; ticket removed from matchmaker; formation loop exits cleanly
+- How to run: `GOWORK=off go test -run 'TestAnyCancelMatchmaking|TestCancelMatchmaking_StaysInParty|TestCancelDuringFormation|TestCancelDuringMatchmaking' ./server/...`
+
+---
+
+## Section 4: Already Completed Steps
+
+### COMPLETED: Defer service/guild/matchmaking streams to lobbyEntrantConnected
+
+**Commit**: `671456443`
+**What was done**: `LobbyJoinEntrants` was speculatively setting "player is in this match" state (service streams, guild group stream, matchmaking untrack) before the game server confirmed the player connected. All authoritative stream updates moved to `lobbyEntrantConnected`, which fires only after game server confirms connection. Also added `LoginSessionID` as 4th service stream subject.
+**Files changed**: `evr_lobby_joinentrant.go`, `evr_pipeline_lobby.go`
+**BACs addressed**: Prerequisite for ADR-002
+
+### COMPLETED: Route authoritative match leave through game server signal
+
+**Commit**: `f4e87462f`
+**What was done**: Pipeline's `matchLeave` was directly untracking player presences from authoritative match streams, bypassing the game server. Now sends `SignalKickEntrants` to the match handler for authoritative matches. Falls back to direct untrack for non-EchoVR matches.
+**Files changed**: `pipeline_match.go`
+**BACs addressed**: Prerequisite for BAC-005
+
+### COMPLETED: Expand lifecycle transition table and add state guards
+
+**Commit**: `522309f75`
+**What was done**: Updated legal transition table with shortcut transitions, self-transitions, and crash recovery paths. Added state guard in match leave handler (only transition to Returning/Crashed if player is still `StateInMatch`). Added state guards in lobby find (skip transitions to Holding/Matchmaking if player still `StateInMatch`).
+**Files changed**: `evr_match_lifecycle.go`, `evr_match.go`, `evr_lobby_find.go`
+**BACs addressed**: Lifecycle correctness required by all BACs
+
+### COMPLETED: Log-replay test framework
+
+**Commits**: `27465b928`, `af4d2c276`
+**What was done**: Built replay test framework with 7 test fixtures from production data. Tests verify lifecycle transitions match production behavior.
+**Files**: `evr_logreplay_test.go`, `server/testdata/replay/` (7 fixtures)
+**Fixtures**:
+
+- `bigduckii-social-lobby-join.json`
+- `bigduckii-infinite-matchmaking.json`
+- `healthy-party-follow.json`
+- `kipsotuff-crash-recovery.json`
+- `kipsotuff-full-arena-loop.json`
+- `kipsotuff-party-churn.json`
+- `lethal-zed16-stale-skip.json`
+
+---
+
+## Section 5: Functions Removed
+
+No functions are removed in this PR. Per ADR-005, all existing follower-path functions are kept as migration fallbacks. They will be removed in a follow-up PR after the reservation system is proven stable in production.
+
+Functions that will be removed in a future PR (after stabilization):
+
+| Function                         | File                              | Current Lines | Replaced by                                | Grep to verify no callers                           |
+| -------------------------------- | --------------------------------- | ------------- | ------------------------------------------ | --------------------------------------------------- |
+| `TryFollowPartyLeader`           | `evr_lobby_find.go`               | 1487-1643     | `findReservation` (Step 4)                 | `grep -rn 'TryFollowPartyLeader' server/`           |
+| `pollFollowPartyLeader`          | `evr_lobby_find.go`               | 1648-1856     | `findReservation` (Step 4)                 | `grep -rn 'pollFollowPartyLeader' server/`          |
+| `isFollowerAlreadyInLeaderMatch` | `evr_lobby_find.go`               | 1244-1291     | Reservation presence check                 | `grep -rn 'isFollowerAlreadyInLeaderMatch' server/` |
+| `isFollowerInLeaderDestination`  | `evr_lobby_find_follower_test.go` | test only     | Ambiguity eliminated by reservation system | `grep -rn 'isFollowerInLeaderDestination' server/`  |
+| `isLeaderHeadingToSocial`        | `evr_lobby_find.go`               | 1036-1084     | Mode info embedded in reservation          | `grep -rn 'isLeaderHeadingToSocial' server/`        |
+| `intendedSocialTargetMatchID`    | `evr_lobby_find.go`               | 1211-1233     | Reservation IS the target                  | `grep -rn 'intendedSocialTargetMatchID' server/`    |
+
+---
+
+## Section 6: Verification Gate
+
+### Complete BAC-to-Test Mapping
+
+| BAC     | Test Function                                                                                       | Test File                            |
+| ------- | --------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| BAC-001 | `TestLeaderJoinsSocial_ReservationsCreated`                                                         | `evr_pipeline_lobby_test.go`         |
+| BAC-002 | `TestFollowerFindsReservation_JoinsDirectly`                                                        | `evr_lobby_find_reservation_test.go` |
+| BAC-003 | `TestFollowerNoReservation_FallsThrough`                                                            | `evr_lobby_find_reservation_test.go` |
+| BAC-004 | `TestReservationConsumed`                                                                           | `evr_match_test.go`                  |
+| BAC-005 | `TestLeaderLeavesMatch_ReservationsCleared`, `TestNonLeaderLeavesMatch_OnlyTheirReservationCleared` | `evr_match_test.go`                  |
+| BAC-006 | `TestMemberLeavesParty_TheirReservationCleared`                                                     | `evr_pipeline_party_test.go`         |
+| BAC-007 | `TestMemberKicked_TheirReservationCleared`                                                          | `evr_pipeline_party_test.go`         |
+| BAC-008 | `TestLateJoin_ReservationCreated`                                                                   | `evr_pipeline_party_test.go`         |
+| BAC-009 | `TestInviteAccept_ReservationCreated`                                                               | `evr_pipeline_party_test.go`         |
+| BAC-010 | `TestLateJoin_ArenaLeader_NoReservation`                                                            | `evr_pipeline_party_test.go`         |
+| BAC-011 | `TestSignalCreatePartyReservations_SkipsDuplicates`                                                 | `evr_match_signal_test.go`           |
+| BAC-012 | `TestSignalClearPartyReservations_ClearsByPartyID`                                                  | `evr_match_signal_test.go`           |
+| BAC-013 | `TestReservationForOfflineMember_Skipped`                                                           | `evr_pipeline_lobby_test.go`         |
+| BAC-014 | `TestConcurrentLobbyFind_IdempotentReservation`                                                     | `evr_lobby_find_reservation_test.go` |
+| BAC-015 | `TestSessionIDChange_ReservationStillFound`                                                         | `evr_pipeline_party_test.go`         |
+| BAC-016 | `TestLeaderPromotion_ReservationsRebuilt`                                                           | `evr_pipeline_party_test.go`         |
+| BAC-017 | `TestFollowerConnected_NoReservationsCreated`                                                       | `evr_pipeline_lobby_test.go`         |
+| BAC-018 | Existing `appendPartyReservationPlaceholders` tests pass                                            | `evr_lobby_find_test.go` (existing)  |
+| BAC-019 | `TestSocialLobbyFind_ReservationBeforePriorityJoin`                                                 | `evr_lobby_find_reservation_test.go` |
+| BAC-020 | `TestMigrationFallback_OldPathStillWorks`                                                           | `evr_lobby_find_reservation_test.go` |
+| BAC-021 | `TestAnyCancelMatchmaking_AllMembersCancelled`                                                      | `evr_pipeline_matchmaker_test.go`    |
+| BAC-022 | `TestCancelMatchmaking_StaysInParty`                                                                | `evr_pipeline_matchmaker_test.go`    |
+| BAC-023 | `TestCancelDuringFormation_NoTicketSubmitted`                                                       | `evr_pipeline_matchmaker_test.go`    |
+| BAC-024 | `TestCancelDuringMatchmaking_TicketRemoved`                                                         | `evr_pipeline_matchmaker_test.go`    |
+| BAC-025 | `TestDeferredTicketSubmission_WaitsForFormation`                                                    | `evr_lobby_matchmake_test.go`        |
+
+### Build Command
+
+```bash
+GOWORK=off go build ./server/...
+```
+
+### Test Command (new tests)
+
+```bash
+GOWORK=off go test -race -count=1 -run 'TestLeaderJoinsSocial|TestFollowerFindsReservation|TestFollowerNoReservation|TestReservationConsumed|TestLeaderLeavesMatch|TestNonLeaderLeavesMatch|TestMemberLeavesParty|TestMemberKicked|TestLateJoin|TestInviteAccept|TestSignalCreatePartyReservations|TestSignalClearPartyReservations|TestReservationForOfflineMember|TestConcurrentLobbyFind|TestSessionIDChange|TestLeaderPromotion|TestFollowerConnected|TestSocialLobbyFind|TestMigrationFallback|TestAnyCancelMatchmaking|TestCancelMatchmaking_StaysInParty|TestCancelDuringFormation|TestCancelDuringMatchmaking|TestDeferredTicketSubmission|TestFindReservation' ./server/...
+```
+
+### Existing Tests Must Still Pass
+
+```bash
+GOWORK=off go test -race -count=1 -run 'TestFollowerSkip|TestExpectedFollowerCount|TestTryFollowPartyLeader|TestPollFollowPartyLeader' ./server/...
+```
+
+### Replay Tests Must Still Pass
+
+```bash
+GOWORK=off go test -race -count=1 -run 'TestReplay_' ./server/...
+```
+
+This runs all 7 replay test fixtures:
+
+- `TestReplay_BigDuckII_SocialLobbyJoin`
+- `TestReplay_BigDuckII_InfiniteMatchmaking`
+- `TestReplay_KipsoTuff_CrashRecovery`
+- `TestReplay_KipsoTuff_FullArenaLoop`
+- `TestReplay_KipsoTuff_PartyChurn`
+- `TestReplay_LethalZed16_StaleSkip`
+- `TestReplay_HealthyPartyFollow`
+
+### Manual Verification
+
+1. Deploy to staging.
+2. Create a party of 2 players.
+3. Leader joins a social lobby.
+4. Verify follower joins within 5 seconds (vs. 3-10 seconds with old polling).
+5. Both leave social lobby, leader queues arena.
+6. Verify both are placed by matchmaker on same ticket.
+7. Match ends. Verify both return to social lobby via reservations.
+8. One player leaves party. Verify reservation is cleaned up.
+9. New player joins party mid-match. Verify reservation is created for them.
+10. Leader queues arena. Verify ticket is NOT submitted for first 15 seconds (check matchmaker logs). Verify ticket is submitted after 15s with all ready members.
+11. Leader queues arena, all followers ready within 5 seconds. Verify ticket is submitted early (before 15s).
+12. During matchmaking, one member cancels. Verify ALL members' matchmaking is cancelled (check matchmaking stream presences). Verify ticket is removed. Verify all members remain in the party.
+13. During formation (before 15s), one member cancels. Verify no ticket was ever submitted. Verify all members back to social-ready.
+
+---
+
+## Appendix: Resolved Ambiguities
+
+### AMBIGUITY-1: Individual member reservation cleanup signal (RESOLVED)
+
+**Location**: Step 6, `clearMemberReservation` function.
+**Issue**: `SignalClearPartyReservations` clears ALL reservations for a party ID. When a single member leaves, we want to clear only their reservation.
+**Resolution for Phase 1**: Use `SignalClearPartyReservations` (clears all party reservations). Remaining members will get fresh reservations from `appendPartyReservationPlaceholders` (belt-and-suspenders) on the next join attempt.
+**Phase 2**: Add `SignalClearMemberReservation` (by session ID) for surgical single-member removal.
+
+### AMBIGUITY-2: EvrMatchPresence fields for reservation placeholders (RESOLVED)
+
+**Location**: Step 3, `createPartyReservations`.
+**Resolution**: Follow the existing pattern in `appendPartyReservationPlaceholders` (`evr_lobby_find.go:1453-1483`), which creates presences with `SessionID`, `UserID`, `Username`, `PartyID`, `RoleAlignment`, and `Node`. Additional fields (`EvrID`, `DisplayName`) loaded from `LoadParams` if the session is available.
+
+### AMBIGUITY-3: StreamModeReservation (RESOLVED -- DROPPED)
+
+**Resolution**: `StreamModeReservation` is not needed. Reservations are discovered via `PlayerInfo.IsReservation` in the match label's `Players` slice. The `findReservation` function looks up the leader's match via the leader's service stream, calls `MatchLabelByID`, and checks the `Players` slice. No stream tracking or untracking needed.
+
+### AMBIGUITY-4: Formation timeout -- remove non-ready members from party? (RESOLVED)
+
+**Location**: Step 10.
+**Issue**: Spec rule 3 says "removed from the party" while rule 5 says "not the party." These contradict.
+**Resolution**: Follow rule 5 -- exclude non-ready members from the ticket, but do NOT remove them from the party. Consistent with BAC-022 (cancel does not remove from party) and the principle that matchmaking is an activity, not a relationship.
+
+### DECISION NEEDED-1: configureParty wait loop replacement (DEFERRED)
+
+**Location**: ADR-007, `evr_lobby_find.go` lines 443-452.
+**Issue**: Use `lobbyGroup.Size()` instead of `GetMatchPresences` for party member counting.
+**Resolution**: This is a correctness fix independent of the reservation system. Should be a separate commit/PR to keep this plan atomic.

--- a/docs/spec-log-replay-phase2.md
+++ b/docs/spec-log-replay-phase2.md
@@ -1,0 +1,713 @@
+# Log-Replay Testing Phase 2: Pipeline Outcome Verification
+
+## 1. What Phase 2 Tests Verify That Phase 1 Does Not
+
+Phase 1 replays lifecycle state transitions through `PlayerMatchLifecycle` in
+isolation. It proves the state machine accepts the same transition sequence as
+production. But it cannot catch the class of bugs where the pipeline silently
+drops a player: `lobbyFind` returns nil (no error), no `LobbySessionSuccess` is
+sent, and the player is stuck in limbo with a clean state machine history.
+
+Phase 2 feeds actual messages through the pipeline handlers and verifies
+**outcomes**:
+
+| Check                                          | Phase 1 | Phase 2 |
+| ---------------------------------------------- | ------- | ------- |
+| Lifecycle transition sequence matches          | Yes     | Yes     |
+| `LobbySessionSuccess` sent to client           | No      | Yes     |
+| Player placed in a match (JoinAttempt called)  | No      | Yes     |
+| `lobbyFind` returned nil vs error vs success   | No      | Yes     |
+| Follower follow-path entered an infinite loop  | No      | Yes     |
+| Player stuck with no response for >30 seconds  | No      | Yes     |
+| Reservation created for party follower         | No      | Yes     |
+| Follower redirected to social when appropriate | No      | Yes     |
+
+The bigduckii bug is the canonical example: Phase 1 shows the illegal
+`Matchmaking -> SocialReady` transitions (the symptom), but does not test
+whether the player _ever received a `LobbySessionSuccess`_. Phase 2 replays
+the `LobbyFindSessionRequest` through `lobbyFind` and asserts the player
+ends up in a match.
+
+---
+
+## 2. Test Architecture: Option Evaluation
+
+### Option A: Mock at the boundary of `lobbyFind`
+
+Feed `lobbyFind` a `*sessionWS`, `*LobbySessionParameters`, and verify the
+return value and side effects (messages sent, matches joined).
+
+**Dependencies that must be mocked or stubbed:**
+
+| Dependency                         | Current access path                                      | Existing mock?                                         |
+| ---------------------------------- | -------------------------------------------------------- | ------------------------------------------------------ |
+| `session.pipeline.tracker`         | `p.nk.tracker` via `session.pipeline.tracker`            | Yes: `mockMatchmakingTracker` (full Track/Untrack/Get) |
+| `p.nk.matchRegistry`               | `p.nk.matchRegistry.JoinAttempt`, `GetMatch`             | Yes: `mockFollowMatchRegistry` (GetMatch only)         |
+| `p.nk.sessionRegistry`             | `p.nk.sessionRegistry.Get(sid)` for session lookups      | Partial: `testSessionRegistry` (exists, returns nil)   |
+| `p.nk.tracker`                     | direct tracker reads (`GetLocalBySessionIDStreamUserID`) | Same as above                                          |
+| `session.SendEvr` / `session.Send` | sends `LobbySessionSuccess` to client                    | No: needs capture mock on `sessionWS`                  |
+| `p.nk.metrics`                     | `CustomCounter`, `CustomTimer`                           | No: panics on nil; needs no-op stub                    |
+| `p.lobbyAuthorize`                 | guild authorization                                      | Needs stub (return nil)                                |
+| `p.LobbyJoinEntrants`              | match join + session success send                        | Needs mock (record join attempts)                      |
+| `p.guildGroupRegistry`             | guild lookups                                            | No: needs stub                                         |
+| `p.appBot`                         | audit logging                                            | No: needs stub                                         |
+| `MatchLabelByID`                   | label lookup via `p.nk`                                  | Via `mockFollowMatchRegistry.GetMatch`                 |
+| `PrepareEntrantPresences`          | session registry lookups                                 | Needs mock session registry that returns test sessions |
+| `globalAppBot`, `globalMatchmaker` | global singletons                                        | Must be set during test init                           |
+
+**Pros:** Tests the exact function that dropped bigduckii. Moderate mock
+surface. Existing `followTestEnv` provides 80% of the scaffolding.
+
+**Cons:** `lobbyFind` is 400+ lines with many branches. Mocking everything
+it touches is substantial work. Some branches (matchmaker ticket submission,
+social lobby find-or-create) call deeply into subsystems that are hard to
+mock at this level.
+
+### Option B: Mock at the boundary of `lobbySessionRequest`
+
+Feed `lobbySessionRequest` an `evr.LobbyFindSessionRequest` message and
+verify the full pipeline including `NewLobbyParametersFromRequest` ->
+`handleLobbySessionRequest` -> `lobbyFind`.
+
+**Additional dependencies beyond Option A:**
+
+| Dependency                      | Why                                             |
+| ------------------------------- | ----------------------------------------------- |
+| `NewLobbyParametersFromRequest` | Reads user profile, guild membership, ping data |
+| `p.db` (SQL database)           | Profile lookups, group membership checks        |
+| `LoadParams` / context values   | Login session, lobby params from auth pipeline  |
+
+**Pros:** Tests parameter construction (a real bug surface -- wrong mode
+detection, wrong group ID). Tests error handling and `LobbySessionFailure`
+responses.
+
+**Cons:** Requires a database mock or an in-memory SQLite. The parameter
+construction calls `CheckSystemGroupMembership`, reads storage objects,
+queries guilds. Mock surface roughly doubles. Not worth the coverage gain
+for the specific bugs we are targeting.
+
+### Option C: Full pipeline replay via `processRequest`
+
+Create a real `EvrPipeline` with mock backends and feed raw binary messages
+through `ProcessRequestEVR`.
+
+**Additional dependencies beyond Option B:**
+
+| Dependency                          | Why                                         |
+| ----------------------------------- | ------------------------------------------- |
+| `EvrPipeline` constructor           | Requires ~20 parameters including runtime   |
+| `Runtime` / `RuntimeGoNakamaModule` | The full Nakama runtime                     |
+| Login/auth pipeline                 | `ProcessRequestEVR` checks auth state first |
+| WebSocket framing                   | Message deserialization from binary         |
+
+**Pros:** Tests the complete path from network to outcome. Catches bugs in
+the dispatch table and auth checks.
+
+**Cons:** Mock complexity is extreme. The `NewEvrPipeline` constructor
+initializes Discord bots, guild registries, XP tables, global settings.
+Standing this up for tests is a multi-week project. The Phase 1 spec
+estimated this as Phase 5; it remains premature.
+
+### Recommendation: Option A with selective boundary adjustments
+
+Option A is the clear winner. It tests the function that contains the bug
+(`lobbyFind`) with manageable mock complexity. The existing
+`followTestEnv` pattern provides the template: create a minimal
+`EvrPipeline` struct with mock tracker and registry, wire up the session,
+call the function under test, assert side effects.
+
+The boundary adjustment: instead of testing `lobbyFind` as a pure function
+call, wrap it in a thin test harness (`replayTestEnv`) that:
+
+1. Constructs `LobbySessionParameters` from the fixture (bypassing
+   `NewLobbyParametersFromRequest` which needs the DB).
+2. Creates `sessionWS` instances with message capture buffers (instead of
+   real WebSocket connections).
+3. Provides a `mockMatchRegistry` that supports `JoinAttempt` (extending
+   the existing `mockFollowMatchRegistry`).
+4. Provides a `mockSessionRegistry` that returns the test sessions.
+5. Provides no-op stubs for metrics, appBot, guildGroupRegistry.
+6. Calls `lobbyFind` and captures:
+   - Return value (nil = success, error = failure)
+   - Messages sent to the session (via captured `SendEvr` calls)
+   - Match join attempts (via `mockMatchRegistry.JoinAttempt` recording)
+   - Lifecycle transitions (via `getMatchLifecycle(session).History()`)
+
+---
+
+## 3. Test Harness Design: `replayTestEnv`
+
+### 3.1 Structure
+
+```go
+type replayTestEnv struct {
+    t *testing.T
+
+    // Pipeline under test
+    pipeline *EvrPipeline
+
+    // Sessions keyed by fixture player identifier (e.g., "player_A")
+    sessions map[string]*mockReplaySession
+
+    // Mock components
+    tracker       *mockMatchmakingTracker       // existing
+    matchRegistry *mockReplayMatchRegistry       // extends mockFollowMatchRegistry
+    sessionReg    *mockReplaySessionRegistry     // returns test sessions by SID
+    metrics       *noopMetrics                   // no-op counter/timer
+
+    // Recorded outcomes
+    joinAttempts  []recordedJoinAttempt
+    sentMessages  map[string][]evr.Message  // playerID -> messages sent
+}
+```
+
+### 3.2 Mock Session Requirements
+
+The existing `sessionWS` struct is used directly in `lobbyFind` (not via an
+interface). This means Phase 2 tests must construct real `sessionWS`
+instances, but with a mock `conn` that captures outbound messages instead
+of writing to a WebSocket.
+
+Approach: inject a `sendOverride` hook on `sessionWS` that captures calls
+to `SendEvr`. This requires a small, backward-compatible change to
+`sessionWS`:
+
+```go
+// In session_ws.go, add to sessionWS struct:
+sendEvrHook func(messages ...evr.Message) error // nil in production; test-only
+
+// In SendEvr, check the hook:
+func (s *sessionWS) SendEvr(messages ...evr.Message) error {
+    if s.sendEvrHook != nil {
+        return s.sendEvrHook(messages...)
+    }
+    // existing implementation...
+}
+```
+
+This is the minimal refactoring needed. The hook is nil in production code.
+
+### 3.3 Mock Match Registry Extension
+
+The existing `mockFollowMatchRegistry` implements `GetMatch` but panics on
+`JoinAttempt`. Phase 2 needs `JoinAttempt` to work:
+
+```go
+type mockReplayMatchRegistry struct {
+    mockFollowMatchRegistry
+    joinAttempts []recordedJoinAttempt
+}
+
+type recordedJoinAttempt struct {
+    MatchID   MatchID
+    UserID    uuid.UUID
+    SessionID uuid.UUID
+    Username  string
+    Metadata  map[string]string
+}
+
+func (r *mockReplayMatchRegistry) JoinAttempt(...) (bool, bool, bool, string, string, []*MatchPresence) {
+    // Record the attempt
+    r.joinAttempts = append(r.joinAttempts, recordedJoinAttempt{...})
+    // Return success: found=true, allowed=true, isNew=true
+    // Return the presence JSON in reason field (matches production behavior)
+    return true, true, true, presenceJSON, labelJSON, nil
+}
+```
+
+### 3.4 Mock Session Registry
+
+`PrepareEntrantPresences` calls `sessionRegistry.Get(sid)` for each party
+member. The mock must return the test sessions:
+
+```go
+type mockReplaySessionRegistry struct {
+    testSessionRegistry // embed existing stub
+    sessions map[uuid.UUID]Session
+}
+
+func (r *mockReplaySessionRegistry) Get(sessionID uuid.UUID) Session {
+    return r.sessions[sessionID]
+}
+```
+
+### 3.5 Global Singletons
+
+`lobbyFind` accesses:
+
+- `globalAppBot.Load()` in `LobbyJoinEntrants` for suspension enforcement
+- `globalMatchmaker.Load()` in matchmaker ticket submission
+- `ServiceSettings()` for encoder flags
+
+Tests must set these to safe defaults before running:
+
+```go
+globalAppBot.Store(nil) // skips enforceJoinSuspension
+// globalMatchmaker only needed if testing matchmaker ticket path
+```
+
+---
+
+## 4. Fixture Format for Phase 2
+
+### 4.1 Structure
+
+```json
+{
+  "name": "bigduckii-follower-social-convergence",
+  "description": "Follower in duo party joins social lobby via reservation system",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T20:14:45Z/2026-06-18T20:23:18Z",
+  "phase": 2,
+
+  "config": {
+    "matchmaking_timeout_secs": 600,
+    "reservation_expiry_secs": 15,
+    "crash_reconnect_window_secs": 27
+  },
+
+  "players": {
+    "player_A": {
+      "uid": "uid-00001",
+      "sid": "sid-00001",
+      "evr_id": "OVR-ORG-10001",
+      "username": "player_A",
+      "is_pcvr": false
+    },
+    "player_B": {
+      "uid": "uid-00002",
+      "sid": "sid-00002",
+      "evr_id": "OVR-ORG-10002",
+      "username": "player_B",
+      "is_pcvr": false
+    }
+  },
+
+  "party": {
+    "id": "party-00001",
+    "leader": "player_B",
+    "members": ["player_A", "player_B"],
+    "group_name": "code noodle"
+  },
+
+  "matches": {
+    "match-00001": {
+      "mode": "echo_arena",
+      "open": false,
+      "player_limit": 8,
+      "players": ["player_A", "player_B"]
+    },
+    "match-00002": {
+      "mode": "social_2.0",
+      "open": true,
+      "player_limit": 12,
+      "players": []
+    }
+  },
+
+  "initial_state": {
+    "player_A": {
+      "current_match": "match-00001",
+      "lifecycle_state": "InMatch"
+    },
+    "player_B": {
+      "current_match": "match-00001",
+      "lifecycle_state": "InMatch",
+      "is_matchmaking": false
+    }
+  },
+
+  "messages": [
+    {
+      "ts": "2026-06-18T20:14:45.210Z",
+      "player": "player_A",
+      "type": "LobbyFindSessionRequest",
+      "fields": {
+        "mode": "social_2.0",
+        "level": "0xffffffffffffffff",
+        "group_id": "group-00001",
+        "role": -1
+      }
+    },
+    {
+      "ts": "2026-06-18T20:14:45.253Z",
+      "player": "player_A",
+      "type": "GameServerPlayerRemoved",
+      "fields": {
+        "match_id": "match-00001",
+        "reason": 3
+      }
+    }
+  ],
+
+  "expected_outcomes": {
+    "player_A": {
+      "final_match": "match-00002",
+      "received_lobby_session_success": true,
+      "lobby_find_returned_nil": true,
+      "stuck_duration_max_secs": 5,
+      "lifecycle_transitions": [
+        {
+          "from": "InMatch",
+          "to": "Holding",
+          "reason": "waiting for leader's ticket"
+        },
+        {
+          "from": "Holding",
+          "to": "SocialReady",
+          "reason": "joined social lobby"
+        }
+      ]
+    }
+  }
+}
+```
+
+### 4.2 Key Differences from Phase 1 Fixtures
+
+| Aspect              | Phase 1             | Phase 2                                         |
+| ------------------- | ------------------- | ----------------------------------------------- |
+| What's replayed     | State transitions   | Client messages through pipeline handlers       |
+| Players             | Single player       | Multi-player (party members)                    |
+| Initial state       | Implicit (Idle)     | Explicit: current match, lifecycle state, party |
+| Match state         | Not tracked         | Pre-configured match labels with player lists   |
+| Expected output     | Transition sequence | Outcomes: match placement, messages sent        |
+| Party configuration | Not needed          | Leader, members, group name                     |
+| Config values       | Not needed          | Timeouts, reservation expiry                    |
+
+### 4.3 Field Semantics
+
+- **`messages`**: The client-to-server messages to feed through the pipeline,
+  in chronological order. Each message is reconstructed into an `evr.Message`
+  before being passed to `lobbyFind`.
+
+- **`expected_outcomes`**: Per-player assertions. `final_match` is the match ID
+  the player should end up in (verified via the service stream tracker
+  presence). `received_lobby_session_success` asserts that `SendEvr` was
+  called with a `LobbySessionSuccessv5`. `stuck_duration_max_secs` asserts
+  the pipeline returned within that time (catches infinite loops).
+
+- **`matches`**: Pre-configured match state. The test harness loads these
+  into the mock match registry before replay starts. Match labels can be
+  mutated during replay (e.g., a match closes mid-scenario).
+
+---
+
+## 5. The BigDuckII Test Case
+
+### 5.1 Scenario Reconstruction
+
+**Timeline** (anonymized, timestamps preserved):
+
+```
+20:14:45.210  player_A (bigduckii, follower) sends LobbyFindSessionRequest (social_2.0)
+20:14:45.210  player_A joins party group (party_size=2, is_leader=false, leader=player_B)
+20:14:45.253  player_A leaves match-00001 (arena, reason=3)
+
+             The follower is now in the follow path inside lobbyFind.
+             In the OLD code:
+               - TryFollowPartyLeader returns false (leader matchmaking)
+               - headingToSocial=true, so follower goes to lobbyFindOrCreateSocial
+               - But the leader's matchmaking presence causes "falling through"
+               - 8 iterations of Matchmaking -> SocialReady -> Matchmaking
+
+             In the NEW code (with reservations):
+               - findReservation checks leader's match for a reservation
+               - If reservation found: direct join to leader's lobby
+               - If not: follower goes to lobbyFindOrCreateSocial independently
+               - Party reservations ensure convergence without polling
+```
+
+### 5.2 Test Structure
+
+```go
+func TestPhase2_BigDuckII_FollowerConverges(t *testing.T) {
+    fix := loadPhase2Fixture(t, "testdata/replay/phase2-bigduckii-follower.json")
+    env := newReplayTestEnv(t, fix)
+
+    // Feed the LobbyFindSessionRequest for player_A through lobbyFind.
+    err := env.RunLobbyFind("player_A")
+
+    // OUTCOME 1: lobbyFind returned nil (no error = player was placed)
+    require.NoError(t, err, "lobbyFind should return nil for follower convergence")
+
+    // OUTCOME 2: Player received LobbySessionSuccess
+    successMsgs := env.SentMessagesOfType("player_A", "*evr.LobbySessionSuccessv5")
+    assert.GreaterOrEqual(t, len(successMsgs), 1,
+        "follower should receive LobbySessionSuccess")
+
+    // OUTCOME 3: Player ended up in a social lobby
+    finalMatch := env.CurrentMatch("player_A")
+    assert.NotNil(t, finalMatch, "follower should be in a match")
+    if finalMatch != nil {
+        assert.Equal(t, evr.ModeSocialPublic, finalMatch.Mode,
+            "follower should end up in a social lobby")
+    }
+
+    // OUTCOME 4: No infinite loop (test completed within timeout)
+    // The test framework enforces a timeout via t.Deadline() or context.
+
+    // OUTCOME 5: Lifecycle transitions are clean
+    lc := env.GetLifecycle("player_A")
+    history := lc.History()
+    for _, tr := range history {
+        if tr.From == StateMatchmaking && tr.To == StateSocialReady {
+            t.Error("NEW CODE BUG: follower still bouncing Matchmaking->SocialReady")
+        }
+    }
+}
+```
+
+### 5.3 What Must Be Set Up
+
+1. **Party state**: `PartyHandler` with player_B as leader, player_A as
+   follower, in party "code noodle".
+
+2. **Match state**: `match-00001` (arena, closed, both players listed).
+   A social lobby (`match-00002`) must be available or creatable.
+
+3. **Tracker state**: Both players have service streams pointing to
+   `match-00001`. Player_B may or may not be on the matchmaking stream
+   (depends on the exact moment in the scenario).
+
+4. **Reservation state**: In the new code, when the leader joined a social
+   lobby, the reservation system should have created a placeholder for
+   player_A. The mock match registry must have this reservation in the
+   match label's `Players` slice.
+
+5. **Session registry**: Both sessions must be retrievable by SID.
+
+---
+
+## 6. Practical Assessment: What Needs Refactoring
+
+### 6.1 Dependencies and Their Mock Status
+
+| Dependency                  | Current mock              | What Phase 2 needs          | Gap      |
+| --------------------------- | ------------------------- | --------------------------- | -------- |
+| `Tracker`                   | `mockMatchmakingTracker`  | Same (fully functional)     | None     |
+| `MatchRegistry.GetMatch`    | `mockFollowMatchRegistry` | Same                        | None     |
+| `MatchRegistry.JoinAttempt` | Panics                    | Record + return success     | **New**  |
+| `SessionRegistry.Get`       | Returns nil               | Returns test sessions       | **New**  |
+| `session.SendEvr`           | Real WebSocket write      | Capture buffer              | **New**  |
+| `session.Send`              | Real WebSocket write      | Capture buffer              | **New**  |
+| `p.nk.metrics`              | Nil (panics)              | No-op stub                  | **New**  |
+| `p.appBot`                  | Nil (panics on log call)  | No-op stub                  | **New**  |
+| `p.guildGroupRegistry`      | Nil                       | No-op stub                  | **New**  |
+| `p.lobbyAuthorize`          | Not mockable (method)     | Needs override or bypass    | **New**  |
+| `globalAppBot`              | Nil                       | Must set to nil before test | Trivial  |
+| `globalMatchmaker`          | Nil                       | Only if testing ticket path | Deferred |
+| `createLobbyMu`             | Global mutex              | Works as-is                 | None     |
+
+### 6.2 Required Refactoring
+
+**Refactoring 1: `sessionWS.sendEvrHook` (small)**
+
+Add a test-only hook to `sessionWS` that intercepts `SendEvr` calls. This
+is the same pattern used in `evr_pipeline_test.go` where `SessionMeta` is
+set (line 25). The hook is nil in production; test code sets it to capture
+messages.
+
+Scope: ~10 lines in `session_ws.go`. Backward-compatible.
+
+**Refactoring 2: `mockReplayMatchRegistry` (small)**
+
+Extend `mockFollowMatchRegistry` with a `JoinAttempt` implementation that
+records calls and returns configurable success/failure. The existing struct
+already has the `matches` map and `getMatchCalls` counter; add a similar
+pattern for join attempts.
+
+Scope: ~50 lines in a test file. No production code changes.
+
+**Refactoring 3: `mockReplaySessionRegistry` (small)**
+
+Create a session registry mock that returns pre-configured sessions by SID.
+The existing `testSessionRegistry` returns nil for everything; Phase 2 needs
+it to return the test `sessionWS` instances so `PrepareEntrantPresences`
+can resolve party members.
+
+Scope: ~30 lines in a test file. No production code changes.
+
+**Refactoring 4: No-op metrics (small)**
+
+The existing `testMetrics` struct (used in `evr_lobby_find_test.go` line 39)
+may already satisfy this. If not, add `CustomCounter` and `CustomTimer`
+methods that do nothing.
+
+Scope: ~10 lines. No production code changes.
+
+**Refactoring 5: `lobbyAuthorize` bypass (small)**
+
+`lobbyAuthorize` checks guild membership and feature flags. In tests, it
+should be a no-op. Options:
+
+A. Make `lobbyAuthorize` a field on `EvrPipeline` (function pointer).
+Tests set it to `func(...) error { return nil }`.
+
+B. Check for a nil `guildGroupRegistry` at the top of `lobbyAuthorize`
+and return nil early. This is already partially true -- several paths
+check for nil components.
+
+Option B is simpler and already partially implemented. Verify the existing
+nil checks cover the test path.
+
+Scope: 0-5 lines in production code.
+
+### 6.3 No Refactoring Needed
+
+The following can be handled without production code changes:
+
+- **`p.appBot`**: Set to nil on the test `EvrPipeline`. The `appBot.LogUserErrorMessage`
+  call in `lobbySessionRequest` is in the error path; if `lobbyFind` succeeds,
+  `appBot` is never accessed. For error-path tests, guard with `if p.appBot != nil`.
+
+- **`p.nk` construction**: Create a minimal `RuntimeGoNakamaModule` with just
+  `tracker`, `matchRegistry`, `sessionRegistry`, and `metrics` fields set.
+  Other fields (DB, runtime, storage) are only accessed in code paths not
+  exercised by Phase 2 tests.
+
+- **`globalMatchmaker`**: Only needed if testing the `lobbyMatchMakeWithFallback`
+  path. Phase 2 focuses on the follow path and social lobby convergence,
+  which do not submit matchmaker tickets. Defer matchmaker replay to Phase 3.
+
+### 6.4 Risk Assessment
+
+| Risk                                                      | Severity | Mitigation                                        |
+| --------------------------------------------------------- | -------- | ------------------------------------------------- |
+| `sessionWS` constructor requires fields not easily mocked | Medium   | Use the `newFollowTestEnv` pattern (partial init) |
+| `lobbyFindOrCreateSocial` calls `ListMatchStates`         | Medium   | Mock `MatchRegistry.ListMatches` in the registry  |
+| `PrepareEntrantPresences` reads session context values    | Medium   | Set `ctxLobbyParametersKey` on session context    |
+| Race conditions from goroutines in `lobbyFind`            | Low      | Run with `-race`; existing tests handle this      |
+| `createLobbyMu` global lock contention                    | Low      | Tests are sequential per fixture                  |
+
+---
+
+## 7. Implementation Build Order
+
+### Phase 2a: Harness scaffolding (2-3 days)
+
+1. Add `sendEvrHook` to `sessionWS` (Refactoring 1).
+2. Create `mockReplayMatchRegistry` with `JoinAttempt` (Refactoring 2).
+3. Create `mockReplaySessionRegistry` (Refactoring 3).
+4. Verify `testMetrics` has the needed methods (Refactoring 4).
+5. Verify `lobbyAuthorize` nil-safety (Refactoring 5).
+6. Build `replayTestEnv` constructor that wires everything together.
+7. Write one smoke test: solo player `LobbyFindSessionRequest` for social
+   mode -> `lobbyFind` -> `lobbyFindOrCreateSocial` -> verify
+   `LobbySessionSuccess` sent.
+
+### Phase 2b: Duo party follow tests (2-3 days)
+
+1. Load the bigduckii Phase 2 fixture.
+2. Set up party state (leader + follower).
+3. Set up tracker state (both in arena match, leader matchmaking or not).
+4. Call `lobbyFind` for the follower.
+5. Assert: follower receives `LobbySessionSuccess`, ends up in social lobby.
+6. Assert: no `Matchmaking -> SocialReady` bounce loop.
+7. Assert: `lobbyFind` returns nil within 10 seconds.
+
+### Phase 2c: Negative / regression tests (1-2 days)
+
+1. Replay the old-code scenario: verify the loop IS reproduced when the
+   reservation system is not wired up (baseline regression).
+2. Replay lethal_zed16: follower with stale match reference.
+3. Replay newfishkeep: duplicate authorization.
+
+### Phase 2d: Additional coverage (1-2 days)
+
+1. Healthy party: leader + follower both converge to social lobby.
+2. Solo player: lobby find for social, arena (matchmaker path -- deferred
+   unless matchmaker mock is ready).
+3. Leader in arena match: follower redirected to social lobby (not stuck
+   in poll).
+
+---
+
+## 8. Fixture Extraction from Production Logs
+
+Phase 2 fixtures require more data than Phase 1. The extractor must capture:
+
+### 8.1 Additional Fields
+
+- **Message type and structured payload**: For `LobbyFindSessionRequest`,
+  capture `mode`, `level`, `group_id`, `role`. For `GameServerPlayerRemoved`,
+  capture `match_id`, `reason`.
+
+- **Party state at event time**: `party_id`, `party_size`, `is_leader`,
+  `leader_sid`, `leader_uid`. Captured from `"Joined party group"` log
+  entries.
+
+- **Match state snapshots**: When a player joins or leaves a match, capture
+  the match label (mode, open, player_count, player_limit). Captured from
+  `"Joined entrant."` and `"Player leaving the match."` entries.
+
+- **Decision-path messages**: `"Leader is currently matchmaking, falling
+through"`, `"Follower already in leader's match"`, etc. These are not fed
+  to the replay engine but stored as the expected decision sequence for
+  comparison.
+
+### 8.2 Multi-Player Trace Merging
+
+Party scenarios require merged traces from all party members. The extractor:
+
+1. Finds the party ID from the target player's trace.
+2. Finds all session IDs in that party (from `"Joined party group"` entries).
+3. Extracts each member's trace.
+4. Merges by timestamp.
+5. Captures the game server's perspective (match joins/leaves from the
+   match handler logs, keyed by match ID).
+
+### 8.3 Fixture Validation
+
+Before a fixture is committed, validate:
+
+- All referenced match IDs have corresponding match state entries.
+- All party members have player entries.
+- The `initial_state` is consistent with the first events in the trace
+  (e.g., if a player is listed as InMatch at match-00001, the first event
+  should not be a `LobbyFindSessionRequest` from a different match).
+- The `expected_outcomes` are manually verified against the production logs.
+
+---
+
+## 9. What Phase 2 Does NOT Cover
+
+Phase 2 focuses on the `lobbyFind` follow path and social lobby convergence.
+It does NOT cover:
+
+- **Matchmaker ticket submission and matching.** The matchmaker is a Nakama
+  internal system (`LocalMatchmaker`) with complex state. Mocking it for
+  replay would require either (a) replaying matchmaker events from logs
+  (which don't contain enough internal state), or (b) running a real
+  matchmaker with seeded inputs. Both are Phase 3+ scope.
+
+- **Game server simulation.** Phase 2 does not inject `GameServerJoinAttempt`
+  or verify the game server's response to `JoinAttempt`. The mock match
+  registry accepts all joins. Game server integration replay is Phase 3.
+
+- **Login / authentication pipeline.** Phase 2 bypasses `lobbySessionRequest`
+  and feeds `lobbyFind` directly with pre-constructed parameters.
+
+- **Network-layer issues.** WebSocket disconnects, reconnects, message
+  ordering. These require the full `ProcessRequestEVR` path (Option C).
+
+---
+
+## 10. Success Criteria
+
+Phase 2 is complete when:
+
+1. The bigduckii scenario produces a `LobbySessionSuccess` for the follower
+   (player_A) within 10 seconds of the `LobbyFindSessionRequest`.
+
+2. The same fixture, run against old code (pre-reservation), reproduces the
+   infinite `Matchmaking -> SocialReady` loop (baseline regression).
+
+3. At least 3 additional fixtures pass: healthy party convergence,
+   lethal_zed16 stale skip, and solo social lobby join.
+
+4. All tests run in CI via `go test ./server/ -run TestPhase2` in under
+   30 seconds total.
+
+5. No production code changes beyond the `sendEvrHook` addition to
+   `sessionWS` (all other mocking is in test files).

--- a/docs/spec-log-replay-testing.md
+++ b/docs/spec-log-replay-testing.md
@@ -1,0 +1,896 @@
+# Log-Replay Testing Framework
+
+## Purpose
+
+Use production log traces to create deterministic system tests that verify the
+party/matchmaking/lifecycle state machine behaves correctly after refactoring.
+A divergence between production behavior and replay behavior means the refactoring
+changed semantics.
+
+---
+
+## 1. Log Format Reference
+
+Production logs live at `/var/log/nakama-logs/`. Each file is newline-delimited
+JSON, ~1 GB, covering roughly 24 hours. The files relevant to the known bug cases
+(2026-06-18) are:
+
+- `nakama-2026-06-18T18-20-01.575.log` (Jun 17 19:37 -- Jun 18 18:20)
+- `nakama-2026-06-19T17-48-09.533.log` (Jun 18 18:20 -- Jun 19 17:48)
+
+### 1.1 Common Fields
+
+Every log line contains:
+
+```json
+{
+  "level": "debug|info|warn|error",
+  "ts": "2026-06-18T20:14:45.210Z",
+  "caller": "server/<file>.go:<line>",
+  "msg": "<human-readable message>"
+}
+```
+
+### 1.2 Identity Fields
+
+| Field                    | Meaning                             | Example                                |
+| ------------------------ | ----------------------------------- | -------------------------------------- |
+| `uid`                    | Nakama user ID                      | `ecc390b5-2cc9-48c8-9f4a-876425a494a2` |
+| `sid`                    | WebSocket session ID                | `530a6a81-6b42-11f1-8d31-383ec87527a1` |
+| `login_sid` / `loginsid` | Login session (parent auth session) | UUID                                   |
+| `evrid`                  | EchoVR platform ID                  | `OVR-ORG-18764`                        |
+| `username`               | Display name                        | `bigduckii`                            |
+| `mid`                    | Match ID (short)                    | UUID                                   |
+| `match_id`               | Match ID (with node)                | `<uuid>.nakama2_us-east`               |
+| `party_id`               | Party ID (with node)                | `<uuid>.nakama2_us-east`               |
+| `operator_id`            | Game server operator UID            | UUID                                   |
+| `server_id`              | Game server numeric ID              | uint64 as string                       |
+
+Note: `login_sid` and `loginsid` are used inconsistently across log sites.
+The extractor must normalize to one form.
+
+### 1.3 Message Types of Interest
+
+The following message types form the replay-relevant event stream for a single
+player session. Grouped by source direction:
+
+**Client --> Server (received):**
+
+| `msg` value          | `request_type`                      | Source file         |
+| -------------------- | ----------------------------------- | ------------------- |
+| `"Received message"` | `*evr.LobbyFindSessionRequest`      | `session_ws.go:470` |
+| `"Received message"` | `*evr.LobbyMatchmakerStatusRequest` | `session_ws.go:470` |
+| `"Received message"` | `*evr.LobbyPingResponse`            | `session_ws.go:470` |
+| `"Received message"` | `*evr.LobbyPendingSessionCancel`    | `session_ws.go:470` |
+| `"Received message"` | `*evr.LoginRequest`                 | `session_ws.go:470` |
+| `"Received message"` | `*evr.SNSParty*Request`             | `session_ws.go:470` |
+
+**Server --> Client (sent):**
+
+| `msg` value                                    | Key fields                                | Source file                      |
+| ---------------------------------------------- | ----------------------------------------- | -------------------------------- |
+| `"Sending messages."`                          | `message: ["*evr.LobbySessionSuccessv5"]` | `evr_pipeline_matchmaker.go:202` |
+| `"Sending *evr.LobbyMatchmakerStatus message"` |                                           | `session_ws.go`                  |
+| `"Sending *evr.LobbyEntrantsV3 message"`       | `team_index`, `entrant_id`                | `session_ws.go:694`              |
+| `"Sending *evr.LobbyPingRequest message"`      |                                           | `session_ws.go`                  |
+
+**Game server --> Nakama:**
+
+| `msg` value          | `request_type`                 | Source file         |
+| -------------------- | ------------------------------ | ------------------- |
+| `"Received message"` | `*evr.GameServerJoinAttempt`   | `session_ws.go:470` |
+| `"Received message"` | `*evr.GameServerPlayerRemoved` | `session_ws.go:470` |
+
+**Internal state transitions:**
+
+| `msg` value                                   | Key fields                                                   | Source file                    |
+| --------------------------------------------- | ------------------------------------------------------------ | ------------------------------ |
+| `"Player match lifecycle transition"`         | `from`, `to`, `reason`, `legal`                              | `evr_match_lifecycle.go:238`   |
+| `"Illegal player match lifecycle transition"` | `from`, `to`, `reason`, `legal`, `anomaly`                   | `evr_match_lifecycle.go:247`   |
+| `"Player match lifecycle reset"`              | `from`                                                       | `evr_match_lifecycle.go`       |
+| `"Player joining the match."`                 | `uid`, `sid`, `role`                                         | `evr_match.go:623`             |
+| `"Player leaving the match."`                 | `uid`, `sid`, `reason`, `duration`                           | `evr_match.go:687`             |
+| `"Joined party group"`                        | `party_id`, `party_size`, `is_leader`, `leader_sid`          | `evr_lobby_find.go:398`        |
+| `"Party is ready"`                            | `leader`, `size`, `members`                                  | `evr_lobby_find.go:514`        |
+| `"Lobby find complete"`                       | `mode`, `party_size`, `duration`                             | `evr_lobby_find.go:300`        |
+| `"Matchmaking ticket added"`                  | `ticket`, `query`, `string_properties`, `numeric_properties` | `evr_lobby_matchmake.go:363`   |
+| `"Social lobby search"`                       | `candidates`, `query`                                        | `evr_lobby_find.go:747`        |
+| `"Authorized access to lobby session"`        | `gid`, `display_name`                                        | `evr_lobby_joinentrant.go:621` |
+| `"Joined entrant."`                           | `mid`, `role`                                                | `evr_lobby_joinentrant.go:324` |
+
+**Decision-path messages (critical for bug reproduction):**
+
+| `msg` value                                                                     | Source file              |
+| ------------------------------------------------------------------------------- | ------------------------ |
+| `"Leader is currently matchmaking, falling through"`                            | `evr_lobby_find.go:1507` |
+| `"Follower already in leader's match, skipping follow path"`                    | `evr_lobby_find.go:73`   |
+| `"Already in leader's match"`                                                   | `evr_lobby_find.go:1538` |
+| `"Follower and leader share the match being left, not skipping"`                | `evr_lobby_find.go:1277` |
+| `"Failed to fetch leader's match label for priority join"`                      | `evr_lobby_find.go`      |
+| `"Social lobby guard: current lobby differs from intended target, not a no-op"` | `evr_lobby_find.go`      |
+
+### 1.4 Connection Lifecycle
+
+```json
+// Connect:
+{"msg": "New WebSocket session connected", "sid": "<uuid>", "client_ip": "..."}
+// Disconnect:
+{"msg": "Closed client connection", "sid": "<uuid>"}
+```
+
+---
+
+## 2. Lifecycle State Machine
+
+9 states, no terminal state (the lifecycle loops):
+
+```
+Idle(0) --> SocialConverging(1) --> SocialReady(2) --> Holding(3) --> Matchmaking(4)
+                                                   \-> Matchmaking(4)
+Matchmaking(4) --> Joining(5) --> InMatch(6) --> Returning(7) --> SocialReady(2)
+                                             \-> Crashed(8) --> InMatch(6) [reconnect]
+                                                            \-> Idle(0) [timeout]
+```
+
+### 2.1 Legal Transitions
+
+```
+Idle            --> SocialConverging
+SocialConverging --> SocialReady
+SocialReady     --> Holding           (non-leader sent LobbyFindSessionRequest)
+SocialReady     --> Matchmaking       (leader submits ticket)
+SocialReady     --> Idle              (left party)
+Holding         --> Matchmaking       (leader's ticket includes this member)
+Holding         --> SocialReady       (matchmaking cancelled)
+Matchmaking     --> Joining           (match found)
+Matchmaking     --> SocialReady       (ticket cancelled / late arrival rebuild)
+Joining         --> InMatch           (connected to game server)
+Joining         --> SocialReady       (join failed)
+InMatch         --> Returning         (match ended naturally)
+InMatch         --> Crashed           (client disconnected)
+Returning       --> SocialReady       (back in social lobby)
+Crashed         --> InMatch           (reconnected within 27s)
+Crashed         --> Idle              (reconnect failed)
+```
+
+### 2.2 Observer Mode
+
+Currently (Issue #456), illegal transitions are logged at WARN level with
+`anomaly: "transition not in legal set"` but are **applied anyway**. The replay
+framework must replicate this behavior -- capture all transitions including
+illegal ones, and compare the full sequence.
+
+Production stats from one 24-hour log file: **35,958 illegal** transitions vs
+**23,658 legal** transitions. The high illegal count is the signal the lifecycle
+enforcement is needed, and the bug cases are drawn from these.
+
+---
+
+## 3. Log Extraction
+
+### 3.1 Single-Player Trace
+
+Extract all log lines for a single user within a time window:
+
+```bash
+# By username (case-insensitive, covers all log messages):
+grep -i 'bigduckii' nakama-2026-06-19T17-48-09.533.log \
+  | grep -E '2026-06-18T20:1[4-9]|2026-06-18T20:2[0-3]' \
+  > traces/bigduckii-raw.jsonl
+
+# By UID (catches match-side events that log uid but not username):
+grep 'ecc390b5-2cc9-48c8-9f4a-876425a494a2' nakama-2026-06-19T17-48-09.533.log \
+  | grep -E '2026-06-18T20:1[4-9]|2026-06-18T20:2[0-3]' \
+  >> traces/bigduckii-raw.jsonl
+
+# By session ID (catches WebSocket-level events):
+grep '2f5cca32-6b58-11f1-8d31-383ec87527a1' nakama-2026-06-19T17-48-09.533.log \
+  | grep -E '2026-06-18T20:1[4-9]|2026-06-18T20:2[0-3]' \
+  >> traces/bigduckii-raw.jsonl
+
+# Deduplicate and sort by timestamp:
+sort -t'"' -k4 traces/bigduckii-raw.jsonl | uniq > traces/bigduckii-sorted.jsonl
+```
+
+### 3.2 Multi-Player Trace (Party Scenarios)
+
+Party scenarios require traces from all party members plus the game server.
+The party ID links them:
+
+```bash
+# Find all sessions in a party:
+grep 'party_id.*<party-uuid>' <logfile> | jq -r '.sid' | sort -u
+
+# Extract each member's trace using the session IDs found above.
+# Merge and sort by timestamp for the complete party timeline.
+```
+
+### 3.3 Fields to Capture Per Event
+
+The extractor produces a normalized `TraceEvent` for each log line:
+
+```go
+type TraceEvent struct {
+    Timestamp   time.Time          `json:"ts"`
+    Level       string             `json:"level"`
+    Caller      string             `json:"caller"`
+    Message     string             `json:"msg"`
+    Direction   string             `json:"direction"`   // "in", "out", "internal"
+    MessageType string             `json:"message_type"` // e.g. "LobbyFindSessionRequest"
+
+    // Identity
+    UID         string             `json:"uid,omitempty"`
+    SID         string             `json:"sid,omitempty"`
+    LoginSID    string             `json:"login_sid,omitempty"`
+    EvrID       string             `json:"evrid,omitempty"`
+    Username    string             `json:"username,omitempty"`
+
+    // Match/Party context
+    MatchID     string             `json:"match_id,omitempty"`
+    PartyID     string             `json:"party_id,omitempty"`
+
+    // Lifecycle-specific
+    FromState   string             `json:"from,omitempty"`
+    ToState     string             `json:"to,omitempty"`
+    Reason      string             `json:"reason,omitempty"`
+    Legal       *bool              `json:"legal,omitempty"`
+
+    // Raw fields for anything not captured above
+    Raw         map[string]any     `json:"raw,omitempty"`
+}
+```
+
+### 3.4 Identifying the Known Bug Cases
+
+**BigDuckII** (2026-06-18 20:14-20:22 UTC):
+
+- Grep: `bigduckii` in `nakama-2026-06-19T17-48-09.533.log`
+- Time window: `20:14` through `20:23`
+- Key signature: 8 iterations of `"Leader is currently matchmaking, falling through"`
+  with `"Social lobby guard"` bounces between lobbies ca27e8ca, 4183e88a, c5f97f5c, 7d87b3b7
+- Party leader: `the_noodle_of_doom` (uid `411f8903`)
+
+**lethal_zed16** (2026-06-18 20:15-20:17 UTC):
+
+- Grep: `lethal_zed16` in same log file
+- Time window: `20:15` through `20:17`
+- Key signature: `"Follower already in leader's match, skipping follow path"` at
+  `evr_lobby_find.go:73` referencing match `61e81b72` that the player already left
+  34 seconds earlier
+
+**newfishkeep** (2026-06-18 22:22 UTC):
+
+- Grep: `newfishkeep` in same log file
+- Time window: `22:22` through `22:23`
+- Key signature: Two `"Authorized access to lobby session"` events 9 seconds apart
+  for the same match `693b9651`, both followed by `"Already in leader's match"`
+
+**Healthy case**: Any party session where the lifecycle transitions follow the
+happy path: `Idle -> SocialConverging -> SocialReady -> Matchmaking -> Joining
+-> InMatch -> Returning -> SocialReady`. Grep for a user who has only legal
+transitions in a time window.
+
+---
+
+## 4. Anonymization
+
+### 4.1 Fields Requiring Anonymization
+
+| Field                               | Strategy                                                            |
+| ----------------------------------- | ------------------------------------------------------------------- |
+| `uid`                               | Deterministic hash map: same UID always maps to the same fake UUID  |
+| `sid`                               | Deterministic hash map                                              |
+| `login_sid` / `loginsid`            | Deterministic hash map                                              |
+| `evrid`                             | Map `OVR-ORG-<N>` to `OVR-ORG-<sequential>` (e.g., `OVR-ORG-10001`) |
+| `username`                          | Map to `player_A`, `player_B`, etc.                                 |
+| `match_id` / `mid`                  | Deterministic hash map (preserve `.nakama2_us-east` suffix)         |
+| `party_id`                          | Deterministic hash map (preserve `.nakama2_us-east` suffix)         |
+| `operator_id`                       | Deterministic hash map                                              |
+| `server_id`                         | Map to sequential integers                                          |
+| `client_ip`                         | Replace with `10.0.0.<N>`                                           |
+| `display_name` (in message strings) | Replace inline using the username map                               |
+| Discord IDs                         | Strip entirely                                                      |
+| `ticket` (matchmaker ticket UUID)   | Deterministic hash map                                              |
+
+### 4.2 Deterministic Mapping
+
+```go
+type Anonymizer struct {
+    mu       sync.Mutex
+    maps     map[string]map[string]string // field_type -> original -> fake
+    counters map[string]int               // field_type -> next sequential value
+}
+
+func (a *Anonymizer) Anonymize(fieldType, original string) string {
+    a.mu.Lock()
+    defer a.mu.Unlock()
+    m := a.maps[fieldType]
+    if fake, ok := m[original]; ok {
+        return fake
+    }
+    a.counters[fieldType]++
+    fake := fmt.Sprintf("%s-%05d", fieldType, a.counters[fieldType])
+    m[original] = fake
+    return fake
+}
+```
+
+The key property: if `bigduckii`'s UID appears 200 times across 200 log lines,
+all 200 get the same fake UUID. If `the_noodle_of_doom` appears as `leader_uid`
+in BigDuckII's trace, it maps to the same fake UUID as in noodle's own trace.
+
+### 4.3 What to Preserve
+
+- Timestamps (exact, not shifted -- timing matters for bug reproduction)
+- Message types and `msg` values
+- Lifecycle states (`from`, `to`)
+- Game modes (`social_2.0`, `echo_arena`)
+- Team assignments (`team_index`, `role`)
+- `caller` source locations
+- Boolean/numeric fields (`legal`, `party_size`, `is_leader`, `attempt`, `candidates`)
+- Matchmaker properties (`rating_mu`, `rating_sigma`, `division`, `min_team_size`, etc.)
+
+### 4.4 Inline String Anonymization
+
+Some fields embed identity data in Go `String()` output:
+
+```
+"LobbyFindSessionRequest{Mode: echo_arena, Entrants: [Entrant(evr_id=OVR-ORG-18764, ...)]}"
+```
+
+The anonymizer must regex-replace known patterns within these strings:
+
+- `OVR-ORG-<digits>` and `DMO-<digits>`
+- UUIDs in standard format
+- Known display names (from the username map)
+
+---
+
+## 5. Replay Engine
+
+### 5.1 Architecture Decision: Go Test, Not Standalone Tool
+
+The replay engine runs as `go test` in `server/`:
+
+```
+server/
+  evr_replay_test.go          -- test harness, TestReplay* functions
+  evr_replay_engine.go        -- ReplayEngine struct, event feeding, state capture
+  evr_replay_fixtures_test.go -- fixture loading from testdata/
+  testdata/
+    replay/
+      bigduckii-infinite-matchmaking.jsonl
+      lethal-zed16-stale-fastpath.jsonl
+      newfishkeep-duplicate-join.jsonl
+      healthy-party-arena.jsonl
+```
+
+Rationale:
+
+- Runs in CI with `go test ./server/ -run TestReplay`
+- Direct access to all server types and interfaces -- no IPC boundary
+- Follows the project's existing pattern of 148 EVR test files in `server/`
+- Can use testify assertions and table-driven test patterns already established
+- Can be run against both old and new code by checking out different commits
+
+### 5.2 What to Mock vs What Runs Real
+
+**Runs real (the code under test):**
+
+- `EvrPipeline.ProcessRequestEVR` -- the full message dispatch
+- `EvrPipeline.lobbySessionRequest` -- lobby find logic
+- `PlayerMatchLifecycle` -- the state machine itself
+- `MatchLabel` / `EvrMatch` -- match join/leave handling
+- `isLegalTransition` -- transition validation
+
+**Must be mocked:**
+
+| Component               | Interface                                          | Mock behavior                                                                       |
+| ----------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `Session`               | `Session` (interface in `session_registry.go`)     | Returns canned identity fields (UID, SID, Username, EvrID). Captures sent messages. |
+| `SessionRegistry`       | `SessionRegistry`                                  | Stores mock sessions. `Get(sid)` returns them.                                      |
+| `Tracker`               | `Tracker` (interface in `tracker.go`)              | In-memory presence tracking. Tracks join/leave without a real match registry.       |
+| `MatchRegistry`         | `MatchRegistry` (interface in `match_registry.go`) | Returns pre-configured `MatchLabel` instances for known match IDs.                  |
+| `Database`              | `*sql.DB`                                          | No-op or in-memory (SQLite). Most replay paths don't hit the DB.                    |
+| `RuntimeGoNakamaModule` | `nk` runtime                                       | Stub for storage/leaderboard/notification calls.                                    |
+| `WebSocket send`        | `session.Send()`                                   | Captures messages into a buffer for later assertion.                                |
+
+### 5.3 Event Feeding
+
+The `ReplayEngine` processes trace events sequentially:
+
+```go
+type ReplayEngine struct {
+    pipeline    *EvrPipeline
+    sessions    map[string]*MockSession  // sid -> mock session
+    matches     map[string]*MatchLabel   // match_id -> match state
+    transitions []LifecycleTransition    // captured transitions
+    sentMsgs    []SentMessage            // captured outbound messages
+    clock       time.Time                // current replay time
+}
+
+func (r *ReplayEngine) Feed(event TraceEvent) error {
+    r.clock = event.Timestamp
+
+    switch {
+    case event.Direction == "in":
+        // Deserialize the message from the trace and feed it to the pipeline
+        msg := r.deserializeMessage(event)
+        session := r.getOrCreateSession(event.SID, event)
+        r.pipeline.ProcessRequestEVR(session.Logger(), session, msg)
+
+    case event.Message == "Player match lifecycle transition" ||
+         event.Message == "Illegal player match lifecycle transition":
+        // Don't feed -- this is an output event. Capture it for comparison.
+        r.transitions = append(r.transitions, LifecycleTransition{
+            Timestamp: event.Timestamp,
+            From:      event.FromState,
+            To:        event.ToState,
+            Reason:    event.Reason,
+            Legal:     event.Legal,
+        })
+
+    case event.Direction == "out":
+        // Outbound messages from game server (GameServerJoinAttempt, etc.)
+        // These simulate game server behavior -- feed as if received from server session
+        r.feedGameServerEvent(event)
+    }
+    return nil
+}
+```
+
+### 5.4 Message Deserialization
+
+The trace stores the Go `String()` representation of messages, not their binary
+encoding. The replay engine needs a parser that reconstructs `evr.Message`
+instances from these strings, OR the extractor should store enough structured
+fields to reconstruct the message:
+
+**Option A: Structured extraction (recommended).** The extractor parses the
+`request` string and stores structured fields:
+
+```json
+{
+  "msg": "Received message",
+  "message_type": "LobbyFindSessionRequest",
+  "structured": {
+    "mode": "echo_arena",
+    "level": "0xffffffffffffffff",
+    "channel": "<group-uuid>",
+    "entrants": [{ "evr_id": "OVR-ORG-10001", "role": -1 }]
+  }
+}
+```
+
+**Option B: Binary recording.** Instrument production to also log the raw
+hex-encoded binary alongside the `String()` form. More accurate but requires
+a production code change.
+
+Start with Option A. The structured fields for each message type are well-defined
+in the `evr` package. If edge cases emerge where the `String()` representation
+loses information, switch to Option B for those message types.
+
+### 5.5 Game Server Simulation
+
+Game server messages (`GameServerJoinAttempt`, `GameServerPlayerRemoved`,
+`GameServerJoinAllowed`) appear in the production logs with their own session IDs.
+The replay engine handles them by:
+
+1. **Injecting from the trace.** When the trace contains a `GameServerJoinAttempt`,
+   the engine feeds it through a mock game-server session. The response
+   (`GameServerJoinAllowed`) is captured and compared against the trace.
+
+2. **Not simulating.** The engine does not run a real game server. It replays
+   the exact game-server messages from the production trace at the recorded
+   timestamps. This means the replay tests the Nakama server's response to
+   a known game-server event sequence, not the game server itself.
+
+### 5.6 Replay Speed
+
+As fast as possible. No `time.Sleep`. The clock is set from trace timestamps
+but execution is not gated to wall time. For timeout-dependent behavior
+(e.g., 27-second crash reconnect window, 15-second reservation expiry),
+the mock clock must be injectable so time-sensitive code uses the replay
+clock rather than `time.Now()`.
+
+```go
+type ReplayClock struct {
+    now time.Time
+}
+
+func (c *ReplayClock) Now() time.Time { return c.now }
+func (c *ReplayClock) Set(t time.Time) { c.now = t }
+```
+
+This requires the production code to accept a `Clock` interface for
+`time.Now()` calls in timeout paths. This is a small, safe refactoring
+prerequisite.
+
+---
+
+## 6. State Comparison
+
+### 6.1 Primary Comparison: Lifecycle Transitions
+
+The replay engine captures lifecycle transitions from the `PlayerMatchLifecycle`
+instance. The trace extractor captures them from the log. Compare:
+
+```go
+type LifecycleTransition struct {
+    From   string
+    To     string
+    Reason string
+    Legal  bool
+}
+
+func CompareTransitions(production, replay []LifecycleTransition) []Divergence {
+    var divergences []Divergence
+    maxLen := max(len(production), len(replay))
+
+    for i := 0; i < maxLen; i++ {
+        if i >= len(production) {
+            divergences = append(divergences, Divergence{
+                Index:   i,
+                Type:    "extra_replay",
+                Replay:  replay[i],
+            })
+        } else if i >= len(replay) {
+            divergences = append(divergences, Divergence{
+                Index:      i,
+                Type:       "missing_replay",
+                Production: production[i],
+            })
+        } else if production[i] != replay[i] {
+            divergences = append(divergences, Divergence{
+                Index:      i,
+                Type:       "mismatch",
+                Production: production[i],
+                Replay:     replay[i],
+            })
+        }
+    }
+    return divergences
+}
+```
+
+### 6.2 What Constitutes a Pass
+
+**Regression test (same code version):** Exact match. Every transition in the
+production trace must appear in the same order in the replay. Zero divergences.
+
+**Refactoring validation (new code version):** The test specifies expected
+behavior changes:
+
+```go
+func TestReplay_BigDuckII_NewCode(t *testing.T) {
+    trace := loadFixture(t, "bigduckii-infinite-matchmaking.jsonl")
+    engine := NewReplayEngine(t)
+    result := engine.Replay(trace)
+
+    // The old code produced 8 iterations of Matchmaking -> SocialReady -> Matchmaking
+    // The new code should produce Matchmaking -> Joining -> InMatch (no loop)
+    assert.Equal(t, 0, countTransitions(result, "Matchmaking", "SocialReady"),
+        "new code should not bounce followers back to SocialReady during leader matchmaking")
+    assert.GreaterOrEqual(t, countTransitions(result, "Matchmaking", "Joining"), 1,
+        "follower should eventually transition to Joining")
+}
+```
+
+### 6.3 Divergence Report
+
+```
+DIVERGENCE at transition #3:
+  Production: Matchmaking -> SocialReady (reason: "leader matchmaking, falling through") [legal=false]
+  Replay:     Matchmaking -> Joining     (reason: "match found")                          [legal=true]
+  Context:    ts=2026-06-18T20:16:38.218Z, sid=player_A-00001, match_id=match-00003
+
+SUMMARY: 5 divergences in 23 transitions
+  3x mismatch (transitions #3, #5, #7)
+  2x missing_replay (transitions #19, #21 -- the loop iterations that no longer happen)
+```
+
+### 6.4 Secondary Comparisons
+
+Beyond lifecycle transitions, optionally compare:
+
+- **Sent messages**: Did the server send the same `LobbySessionSuccessv5` / `LobbyEntrantsV3` messages?
+- **Match joins/leaves**: Did the player join/leave the same matches in the same order?
+- **Decision-path messages**: Did the server hit the same code paths (same `caller` locations)?
+
+These are informational, not pass/fail. The lifecycle transitions are the
+ground truth for behavioral equivalence.
+
+---
+
+## 7. Known Bug Case Fixtures
+
+### 7.1 BigDuckII: Infinite Matchmaking Loop
+
+**Time window:** 2026-06-18 20:14:45 -- 20:23:08 UTC
+**Players:** bigduckii (follower), the_noodle_of_doom (leader)
+**Bug:** Follower bounces between social lobbies while leader is matchmaking
+
+**Production lifecycle transitions (bigduckii):**
+
+```
+InMatch       -> Returning       (match ended)               legal
+Returning     -> SocialReady     (back in social lobby)       legal
+SocialReady   -> Matchmaking     (lobby find triggered)       -- but then:
+Matchmaking   -> SocialReady     (leader matchmaking, fall through) illegal
+  [repeat 8 times -- the infinite loop]
+SocialReady   -> Matchmaking     (lobby find triggered)
+Matchmaking   -> SocialReady     (leader matchmaking, fall through)
+  ...
+  [client disconnects and reconnects]
+SocialReady   -> Matchmaking     (leader submits ticket)      legal
+Matchmaking   -> Joining         (match found)                legal
+Joining       -> InMatch         (connected)                  legal
+```
+
+**Anonymized fixture sample** (`testdata/replay/bigduckii-infinite-matchmaking.jsonl`):
+
+```json
+{"ts":"2026-06-18T20:14:45.210Z","level":"debug","caller":"evr_lobby_find.go:398","msg":"Joined party group","sid":"sid-00001","uid":"uid-00001","username":"player_A","evrid":"OVR-ORG-10001","party_id":"party-00001.nakama2_us-east","party_size":2,"is_leader":false,"leader_sid":"sid-00002","leader_uid":"uid-00002"}
+{"ts":"2026-06-18T20:14:45.253Z","level":"info","caller":"evr_match.go:687","msg":"Player leaving the match.","mid":"match-00001","uid":"uid-00001","sid":"sid-00001","reason":3,"duration":"312.5s","username":"player_A"}
+{"ts":"2026-06-18T20:14:49.083Z","level":"debug","caller":"evr_lobby_find.go:747","msg":"Social lobby search","sid":"sid-00001","uid":"uid-00001","username":"player_A","attempt":0,"candidates":3}
+{"ts":"2026-06-18T20:14:49.150Z","level":"debug","caller":"evr_lobby_joinentrant.go:324","msg":"Joined entrant.","sid":"sid-00001","uid":"uid-00001","mid":"match-00002","role":3}
+{"ts":"2026-06-18T20:16:38.218Z","level":"debug","caller":"evr_lobby_find.go:398","msg":"Joined party group","sid":"sid-00001","uid":"uid-00001","username":"player_A","party_id":"party-00001.nakama2_us-east","party_size":2,"is_leader":false,"leader_sid":"sid-00002","leader_uid":"uid-00002"}
+{"ts":"2026-06-18T20:16:38.220Z","level":"debug","caller":"evr_lobby_find.go:83","msg":"Leader is heading to a social lobby, forcing social mode for follower","sid":"sid-00001"}
+{"ts":"2026-06-18T20:16:38.221Z","level":"debug","caller":"evr_lobby_find.go:1489","msg":"User is member of party, attempting to follow leader","sid":"sid-00001"}
+{"ts":"2026-06-18T20:16:38.222Z","level":"debug","caller":"evr_lobby_find.go:1507","msg":"Leader is currently matchmaking, falling through","sid":"sid-00001"}
+{"ts":"2026-06-18T20:16:38.223Z","level":"debug","caller":"evr_lobby_find.go:197","msg":"Follower in social mode, finding social lobby independently (party reservations will converge)","sid":"sid-00001"}
+{"ts":"2026-06-18T20:16:38.300Z","level":"warn","caller":"evr_match_lifecycle.go:247","msg":"Illegal player match lifecycle transition","sid":"sid-00001","from":"Matchmaking","to":"SocialReady","reason":"leader matchmaking, falling through","legal":false,"anomaly":"transition not in legal set"}
+```
+
+**Test structure:**
+
+```go
+func TestReplay_BigDuckII_InfiniteMatchmaking(t *testing.T) {
+    trace := loadFixture(t, "replay/bigduckii-infinite-matchmaking.jsonl")
+    engine := NewReplayEngine(t)
+
+    // Replay against current (old) code -- should reproduce the bug
+    result := engine.Replay(trace)
+
+    // Verify the loop exists in the replay (regression baseline)
+    loopCount := countTransitionPairs(result.Transitions, "Matchmaking", "SocialReady")
+    assert.GreaterOrEqual(t, loopCount, 5,
+        "old code should produce the infinite matchmaking loop")
+
+    illegalCount := countIllegalTransitions(result.Transitions)
+    assert.Greater(t, illegalCount, 0,
+        "old code produces illegal transitions during the loop")
+}
+```
+
+### 7.2 lethal_zed16: Stale Fast-Path Skip
+
+**Time window:** 2026-06-18 20:15:06 -- 20:17:13 UTC
+**Bug:** `"Follower already in leader's match, skipping follow path"` fires with a
+match ID the player left 34 seconds earlier
+
+**Key transition sequence:**
+
+```
+InMatch       -> Returning       (early quit from match-00005)
+  -- 34 seconds pass --
+SocialReady   -> [no transition] (fast-path fires: "already in leader's match" for match-00005)
+```
+
+The server short-circuits the lobby find because it thinks the player is still in
+match-00005, but the player already left. No lifecycle transition is emitted because
+the fast-path returns early before reaching the transition logic.
+
+### 7.3 newfishkeep: Duplicate Authorization
+
+**Time window:** 2026-06-18 22:22:04 -- 22:23:17 UTC
+**Bug:** `"Authorized access to lobby session"` fires twice for the same match,
+9 seconds apart
+
+**Key event sequence:**
+
+```
+22:22:04  LobbyFindSessionRequest -> "Authorized access" -> "Already in leader's match"
+22:22:13  LobbyFindSessionRequest -> "Authorized access" -> "Already in leader's match"  [DUPLICATE]
+22:23:08  Matchmaker builds new match -> player joins normally
+22:23:17  Player leaves the old match (late cleanup)
+```
+
+### 7.4 Healthy Case: Clean Party Arena Session
+
+Extract from any party session with only legal transitions:
+
+```bash
+# Find sessions with zero illegal transitions in a time window:
+grep 'lifecycle transition' <logfile> \
+  | grep -v 'Illegal' \
+  | jq -r '.sid' \
+  | sort | uniq -c | sort -rn \
+  | head -20
+# Pick one with a high count (many transitions = full lifecycle)
+# Cross-reference to verify no illegal transitions for that sid:
+grep '<chosen-sid>' <logfile> | grep 'Illegal' | wc -l  # should be 0
+```
+
+The healthy fixture should show the complete happy path:
+`Idle -> SocialConverging -> SocialReady -> Matchmaking -> Joining -> InMatch
+-> Returning -> SocialReady` and the replay should produce an exact match.
+
+---
+
+## 8. Practical Considerations
+
+### 8.1 Log Volume
+
+A single player generates 200-500 log lines per session (login through disconnect).
+The bug case traces are 100-300 lines for the relevant time window. Fixtures are
+manageable at this scale -- each is a few KB of JSONL.
+
+**Trimming strategy:** The extractor filters to only replay-relevant message types
+(Section 1.3). Internal debug logging (e.g., Discord updates, stat tracking,
+remote logs) is excluded.
+
+### 8.2 Multi-Player Coordination
+
+Party scenarios need synchronized traces from 2+ players. The replay engine
+must handle interleaved events from multiple sessions:
+
+```go
+func (r *ReplayEngine) ReplayMulti(traces map[string][]TraceEvent) *ReplayResult {
+    // Merge all traces into a single timeline, sorted by timestamp
+    merged := mergeTraces(traces)
+    for _, event := range merged {
+        r.Feed(event)
+    }
+    return r.Result()
+}
+```
+
+The merged timeline preserves causal ordering because production timestamps
+are monotonic from a single server. For the BigDuckII case, both bigduckii's
+and the_noodle_of_doom's events interleave naturally by timestamp.
+
+### 8.3 Game Server Simulation
+
+The replay engine does **not** simulate a game server. Instead:
+
+1. Game server registration (`BroadcasterRegistrationRequest`) is pre-configured
+   in the mock match registry -- the game server "exists" at replay start.
+2. `GameServerJoinAttempt` events from the trace are injected through a mock
+   game-server session. The server's response (`GameServerJoinAllowed`) is
+   captured and compared.
+3. `GameServerPlayerRemoved` events are injected at the recorded timestamps.
+4. Match state updates (`Received match update message`) are injected to
+   advance game clock if needed.
+
+This means the tests verify Nakama's behavior given a known game-server event
+sequence, not the game server's behavior itself.
+
+### 8.4 Determinism
+
+**Timestamps:** Preserved from production. The injectable `ReplayClock` ensures
+time-dependent code (reservation expiry, crash reconnect window) uses the trace
+clock.
+
+**UUIDs:** The production code generates UUIDs for `EntrantID`, session IDs, etc.
+For comparison purposes, UUID generation should be injectable:
+
+```go
+type ReplayUUIDGenerator struct {
+    counter uint64
+}
+
+func (g *ReplayUUIDGenerator) New() uuid.UUID {
+    g.counter++
+    return uuid.FromBytes(binary.BigEndian.AppendUint64(
+        make([]byte, 8), g.counter,
+    ))
+}
+```
+
+This makes replays produce the same UUIDs on every run. Comparison ignores
+generated UUIDs and focuses on structural equivalence (same transitions,
+same code paths, same accept/reject decisions).
+
+**Random selection:** Social lobby search picks from candidates. If the selection
+is random, inject a seeded `math/rand` source.
+
+### 8.5 Incremental Build Order
+
+**Phase 1: Single-player social lobby** (1-2 days)
+
+- Mock Session, SessionRegistry, Tracker
+- Feed a single `LobbyFindSessionRequest` for `social_2.0`
+- Capture the lifecycle transition and compare
+- Test: healthy social lobby join produces `Idle -> SocialConverging -> SocialReady`
+
+**Phase 2: Single-player lifecycle loop** (1-2 days)
+
+- Add MatchJoin/MatchLeave handling
+- Feed a complete single-player lifecycle (login -> social -> arena -> social)
+- Test: healthy player produces the full legal transition loop
+
+**Phase 3: Party follow path** (2-3 days)
+
+- Add multi-session support (leader + follower)
+- Mock party tracking (leader session lookup, `current_match_id`)
+- Replay the BigDuckII trace -- verify the loop is reproduced
+- This is the first real regression test
+
+**Phase 4: Game server integration** (1-2 days)
+
+- Add mock game server session
+- Inject `GameServerJoinAttempt` / `GameServerPlayerRemoved` from traces
+- Complete the lethal_zed16 and newfishkeep test cases
+
+**Phase 5: Extraction tooling** (1 day)
+
+- Build `cmd/logreplay/extract.go` -- reads raw logs, outputs anonymized JSONL fixtures
+- Build `cmd/logreplay/anonymize.go` -- standalone anonymizer
+- Document the workflow for adding new fixtures from future production issues
+
+### 8.6 Prerequisites (Small Refactorings)
+
+Before the replay engine works, two small changes to production code:
+
+1. **Clock interface.** Wrap `time.Now()` calls in reservation-expiry and
+   crash-reconnect-window code behind a `Clock` interface. Default
+   implementation returns `time.Now()`. Replay injects `ReplayClock`.
+
+2. **UUID generator interface.** Wrap `uuid.Must(uuid.NewV4())` calls behind
+   a `UUIDGenerator` interface. Default uses real random UUIDs. Replay
+   injects deterministic generator.
+
+Both are backward-compatible -- existing code behavior is unchanged. The
+interfaces are added alongside the existing calls.
+
+---
+
+## 9. File Layout
+
+```
+server/
+  evr_replay_engine.go            -- ReplayEngine, event feeding, state capture
+  evr_replay_engine_test.go       -- TestReplay_* functions
+  evr_replay_extractor.go         -- TraceEvent struct, log line parser
+  evr_replay_anonymizer.go        -- Anonymizer, field mapping
+  evr_replay_comparison.go        -- CompareTransitions, Divergence report
+  evr_replay_mocks_test.go        -- MockSession, MockTracker, MockMatchRegistry
+  testdata/
+    replay/
+      bigduckii-infinite-matchmaking.jsonl
+      lethal-zed16-stale-fastpath.jsonl
+      newfishkeep-duplicate-join.jsonl
+      healthy-party-arena.jsonl
+
+cmd/
+  logreplay/
+    main.go                        -- CLI: extract, anonymize, replay
+```
+
+---
+
+## 10. Open Questions
+
+1. **String() reconstruction accuracy.** The log `request` field is a Go
+   `String()` representation, not the original binary. Some fields may be
+   lossy (e.g., `Level: 0xffffffffffffffff`). Need to verify that all
+   replay-relevant fields survive the `String()` round-trip for each message
+   type, or add structured logging to production.
+
+2. **Matchmaker state.** The matchmaker itself (ticket submission, matching
+   algorithm, match building) is a Nakama-internal system. Replaying
+   `LobbyFindSessionRequest` will submit a real matchmaker ticket, which
+   needs a matchmaker mock that produces the same match assignments as
+   production. Alternative: treat match assignments as injected events
+   (from the trace) rather than computed.
+
+3. **Tracker consistency.** The `Tracker` tracks presences across all matches.
+   A full mock must handle presence joins/leaves for multiple simultaneous
+   matches. The mock complexity scales with the number of concurrent matches
+   in the trace.
+
+4. **Config values.** Reservation timeout (15s/5min), crash reconnect window
+   (27s/60s), matchmaker priority threshold -- these affect behavior and must
+   match the production config at the time of the log capture. Include a
+   config snapshot in the fixture.

--- a/docs/spec-party-reservation-system.md
+++ b/docs/spec-party-reservation-system.md
@@ -1,0 +1,726 @@
+# Spec: Reservation-Based Party System
+
+## Problem
+
+The current party follow system uses tracker stream reads to determine where the leader is, then followers poll/chase the leader. The tracker streams can be stale, ambiguous (can't distinguish "leaving" from "staying"), and race-prone. This has caused:
+
+- Infinite matchmaking (BigDuckII 2026-06-18)
+- False-positive convergence (players told they're "already in leader's match" when they're not)
+- Failed production deploy attempting to fix the above
+
+The `isFollowerInLeaderDestination` pure function and its skipped test (`evr_lobby_find_follower_test.go:57`) document the exact ambiguity: when `followerMatchID == leaderMatchID == currentMatchID`, the system cannot distinguish "leaving this match" from "already in this match."
+
+## Principle
+
+**Reservations, not tracker reads.** The leader explicitly reserves slots for party members. Followers search for their reservation, not the leader's location. No ambiguity, no stale data, no race conditions.
+
+**Game server is the authority.** "Player is in match" is true only when the game server confirms it (via `lobbyEntrantConnected`). All state flows from game server events.
+
+---
+
+## Existing Infrastructure -- Ground Truth
+
+### Reservation Data Structures
+
+**`slotReservation`** (`evr_match_label.go:22-25`):
+
+```go
+type slotReservation struct {
+    Presence *EvrMatchPresence
+    Expiry   time.Time
+}
+```
+
+**`reconnectReservation`** (`evr_match_label.go:27-32`):
+
+```go
+type reconnectReservation struct {
+    Presence     *EvrMatchPresence
+    Expiry       time.Time
+    UserID       string
+    DeferPenalty bool
+}
+```
+
+**`EvrMatchPresence`** (`evr_match_presence.go:17-41`) -- the presence stored in reservations contains: `SessionID`, `UserID`, `EvrID`, `PartyID`, `RoleAlignment`, `Username`, `DisplayName`, `Node`, `SupportedFeatures`, and more.
+
+**`EntrantMetadata`** (`evr_match.go:209-212`):
+
+```go
+type EntrantMetadata struct {
+    Presence     *EvrMatchPresence
+    Reservations []*EvrMatchPresence
+}
+```
+
+- `Presences()` method (`evr_match.go:218-220`) returns `[primary, ...reservations]`.
+- `ToMatchMetadata()` (`evr_match.go:222-233`) serializes to `map[string]string{"entrants": "<json>"}` for `MatchRegistry.JoinAttempt`.
+
+### Storage Location
+
+Reservations live on `MatchLabel` (the match's authoritative in-memory state), not in any external store:
+
+- `reservationMap map[string]*slotReservation` -- keyed by **session ID** (`evr_match_label.go:67`)
+- `reconnectReservations map[string]*reconnectReservation` -- keyed by **user ID** (`evr_match_label.go:68`)
+- Both initialized in `MatchInit` (`evr_match.go:166-167`)
+
+### Size Computation -- Reservations Already Counted
+
+`rebuildCache()` (`evr_match_label.go:381-596`) computes `Size` as:
+
+```
+Size = len(actual presences) + len(active slot reservations) + len(active reconnect reservations)
+```
+
+- **Line 424**: `s.Size = len(presences)` where `presences` includes all three categories.
+- **`PlayerCount`** (lines 430-435) counts only actual presences from `presenceMap` (not reservations). This is intentional: search queries show real occupancy, while `Size` reflects reserved capacity.
+- **`OpenSlots()`** (`evr_match_label.go:234-236`): `MaxSize - Size` -- automatically reduces available slots when reservations exist.
+- **`Players` slice** includes reservation presences with `IsReservation: true` flag (line 469).
+
+### Reservation Consumption in MatchJoinAttempt
+
+`MatchJoinAttempt` (`evr_match.go:243-578`) processes reservations in this order:
+
+1. **Line 272**: `rebuildCache()` -- clean expired reservations before any decisions.
+2. **Lines 349-361**: Remove reservations for party members already in the match.
+3. **Lines 408-428**: **Consume slot reservation BEFORE capacity check** -- `LoadAndDeleteReservationRaw(sessionID)` (line 416), fallback to `LoadAndDeleteReservationByUserIDRaw(userID)` (line 419). If found, inherits `PartyID` and `RoleAlignment` from the reservation.
+4. **Lines 430-438**: Define `restoreSlotReservation()` closure for rollback on failure.
+5. **Lines 441-455**: Capacity check against `OpenSlots()`. If over capacity despite a valid reservation, returns `ErrJoinRejectReasonReservationViolated` and restores the reservation.
+6. **Lines 519-538**: Create new slot reservations for `meta.Reservations` entries:
+   - 15-second expiry for arena/combat (`time.Second * 15`)
+   - 5-minute expiry for social lobbies (`time.Minute * 5`)
+
+### Reservation Expiry
+
+Two expiry paths:
+
+1. **`MatchLoop`** (`evr_match.go:1243-1281`): Every tick, iterates both maps and deletes expired entries. For `reconnectReservation` with `DeferPenalty`, applies early quit penalty on expiry.
+2. **`rebuildCache()`** (`evr_match_label.go:403-421`): Inline cleanup of expired entries during cache rebuild.
+
+### Existing Reservation Lookup Methods
+
+All on `MatchLabel` (`evr_match_label.go:81-147`):
+
+| Method                                        | Key          | Returns                   | Used By                                |
+| --------------------------------------------- | ------------ | ------------------------- | -------------------------------------- |
+| `LoadAndDeleteReservation(sessionID)`         | session ID   | `*EvrMatchPresence, bool` | Not currently used in MatchJoinAttempt |
+| `LoadAndDeleteReservationByUserID(userID)`    | user ID scan | `*EvrMatchPresence, bool` | Not currently used in MatchJoinAttempt |
+| `LoadAndDeleteReservationRaw(sessionID)`      | session ID   | `*slotReservation, bool`  | `MatchJoinAttempt` line 416            |
+| `LoadAndDeleteReservationByUserIDRaw(userID)` | user ID scan | `*slotReservation, bool`  | `MatchJoinAttempt` line 419            |
+
+All four delete the entry on hit and call `rebuildCache()`.
+
+### How Reservations Are Currently Created
+
+Three creation paths exist today:
+
+1. **`LobbyJoinEntrants`** (`evr_lobby_joinentrant.go:78-81`): `entrants[0]` is the primary; `entrants[1:]` become `EntrantMetadata.Reservations`. These are processed by `MatchJoinAttempt` at lines 519-538. Reservations get 15s expiry (arena) or 5min expiry (social).
+
+2. **`appendPartyReservationPlaceholders`** (`evr_lobby_find.go:1439-1475`): For social lobbies only, adds placeholder `EvrMatchPresence` entries for online party members not yet in the entrants list. Called at `evr_lobby_find.go:279` during the leader's `lobbyFind`. These placeholders flow through `LobbyJoinEntrants` as reservations.
+
+3. **Match signal handler** (`evr_match.go:1768-1774`): When a match is configured via `SignalPrepareSession`, `settings.Reservations` are stored directly into `reservationMap`. Used for matchmaker-placed matches and post-match social lobby allocation (`evr_match.go:2188-2189`, 5-minute lifetime).
+
+### `lobbyEntrantConnected` -- Current State
+
+`evr_pipeline_lobby.go:13-144`. This is the game server's "player connected" confirmation. **Currently has zero party logic.** It:
+
+1. Looks up each entrant's presence by entrant ID (line 36)
+2. Updates four service stream presences (SessionID, LoginSessionID, UserID, EvrID) with the match ID as status (lines 57-59)
+3. Updates guild group stream and removes matchmaking stream presences (lines 62-68)
+4. Tracks on the match authoritative stream to trigger `MatchJoin` (lines 72-78)
+5. Transitions lifecycle to `StateInMatch` for non-social matches (lines 86-89)
+6. Sends accept/reject messages to the game server (lines 95-143)
+
+No party member lookup, no reservation creation, no follower pulling.
+
+### Current Follower Path -- What Gets Replaced
+
+The follower path in `lobbyFind` (`evr_lobby_find.go:113-250`) currently:
+
+1. **`isFollowerInActiveMatch`** (line 119, defined at 1090-1112): Checks if follower is in an arena/combat match via tracker. Returns early to prevent yanking them out.
+
+2. **Lifecycle transition to `StateHolding`** (lines 125-127): Observer-only, no actual blocking.
+
+3. **Late arrival ticket cancellation** (lines 141-145): If party has an active ticket without this session, cancels it.
+
+4. **`isLeaderInArenaCombatMatch`** (line 154, defined at 1295-1337): If leader is in arena/combat, redirects follower to social. Uses tracker reads (matchmaking stream + service stream + MatchLabelByID).
+
+5. **`TryFollowPartyLeader`** (line 168, defined at 1481-1637): The primary follow attempt. Uses 5 separate tracker reads to find leader's match, check if follower is already there, validate the match label. Only works for `ModeSocialPublic` matches (defense-in-depth at line 1601).
+
+6. **`pollFollowPartyLeader`** (line 214, defined at 1640-1848): 3-second polling loop with an inner `isFollowerInLeaderMatch` closure that makes 2 tracker reads per iteration plus optional `MatchLabelByID`. Has `maxNonJoinableCycles = 3` timeout for non-social matches.
+
+**All of these functions read the leader's tracker presence to determine where the leader is.** This is the exact pattern this spec eliminates.
+
+### Party Management
+
+- **`LobbyGroup`** (`evr_lobby_group.go:11-14`): Wraps `PartyHandler`. Methods: `ID()`, `GetLeader()`, `List()`, `Size()`.
+- **Leader determination**: `lobbyGroup.GetLeader()` returns `*rtapi.UserPresence`. Leader is `PartyHandler.leader` (read under `RLock`), fallback to `expectedInitialLeader`.
+- **Party join**: `JoinPartyGroup` (`evr_lobby_group.go:121-204`) calls `partyRegistry.GetOrCreateByGroupName`, joins if not member, tracks on party stream. Sets `lobbyParams.PartyID` from `lobbyGroup.ID()`.
+- **Party stream**: `PresenceStream{Mode: StreamModeParty, Subject: partyUUID, Label: node}`. Enumerating members: `tracker.ListByStream(stream, true, true)`.
+- **`params.currentPartyID`**: Set in `snsPartyTrackAndJoin` (`evr_pipeline_party.go:169`). Stored in `SessionParameters`. Cleared in `snsPartyLeaveCleanup` (`evr_pipeline_party.go:182-183`).
+- **Sending messages to party**: `sendEVRMessageToPartyMembers` (`evr_pipeline_party.go:129`) lists stream presences and sends to each.
+
+### Match Lifecycle States
+
+`evr_match_lifecycle.go:20-49`:
+
+```
+StateIdle -> StateSocialConverging -> StateSocialReady -> StateHolding -> StateMatchmaking -> StateJoining -> StateInMatch -> StateReturning -> StateSocialReady (loop)
+                                                                                                             |
+                                                                                                       StateCrashed -> StateInMatch (reconnect) or StateIdle
+```
+
+Legal transitions are defined in `legalTransitions` (lines 86-121). Observer mode only -- illegal transitions are logged but applied.
+
+---
+
+## Design
+
+### 0. Reservation Lifecycle — Event-Driven, No Polling
+
+Reservations are created and cleared by concrete events, never by polling:
+
+| Event                                    | Action                                                                                                                                        |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Player joins party                       | Create reservation in leader's current match (if leader is in one)                                                                            |
+| Leader's game server confirms connection | Create reservations for all party members not yet in the match                                                                                |
+| Player's game server confirms connection | Reservation consumed (`LoadAndDeleteReservation` in `MatchJoinAttempt`)                                                                       |
+| Player leaves party                      | Clear their reservation from leader's match                                                                                                   |
+| Player disconnects/crashes               | Crash handler clears their reservation (same path as solo player crash reservations via `MatchLoop` expiry or `reconnectReservation` cleanup) |
+| Leader leaves match                      | All party reservations in that match cleared                                                                                                  |
+| Leader leaves party                      | All party reservations in leader's match cleared                                                                                              |
+
+No event requires polling. Every state change is triggered by something that already happens in the system.
+
+### 1. Leader Joins a Match -> Creates Reservations
+
+**Trigger point**: `lobbyEntrantConnected` (`evr_pipeline_lobby.go:13`).
+
+When the game server confirms a player is connected:
+
+1. Look up the player's `SessionParameters` via `LoadParams(s.Context())` to get `currentPartyID`.
+2. If `currentPartyID != uuid.Nil`, check if this player is the party leader via the party stream.
+3. If leader, enumerate party members via `tracker.ListByStream(partyStream, true, true)`.
+4. For each party member (excluding the leader):
+   a. Check if the member has a `StreamModeMatchmaking` presence (they are currently matchmaking). If yes: they are waiting -- create a reservation AND signal them via `MatchSignal` or direct join. They will be pulled in by the matchmaker or pick up the reservation on their next find attempt.
+   b. If the member is NOT matchmaking: create a reservation in this match for them. Their next `LobbyFindSessionRequest` will find it.
+5. Reservations are created by calling `MatchSignal` with the list of member presences, which inserts them into `state.reservationMap` inside the match handler (single-threaded, no races).
+
+**New function** -- add to `evr_pipeline_lobby.go`:
+
+```
+func (p *EvrPipeline) createPartyReservations(ctx context.Context, logger *zap.Logger, matchID MatchID, leaderSessionID uuid.UUID, partyID uuid.UUID)
+```
+
+- Enumerates party members from the party stream
+- Builds `[]*EvrMatchPresence` placeholders for each non-leader member
+- Sends a new `SignalCreatePartyReservations` signal to the match with the member list
+- The match handler inserts them into `reservationMap` with 5-minute expiry
+
+**New signal** -- add to `evr_match.go` signal handler:
+
+```
+case SignalCreatePartyReservations:
+    // Receives list of EvrMatchPresence, creates slotReservation for each
+```
+
+**Why signal, not direct write**: `MatchLabel` is the match handler's state, accessed only within the match goroutine. External code must use `MatchSignal` to modify it safely. This is the existing pattern (`evr_match.go:1768-1774`).
+
+### 2. Follower Matchmakes -> Searches for Reservation
+
+**Trigger point**: `lobbyFind` (`evr_lobby_find.go:31`), early in the follower path (before line 113).
+
+When a follower sends `LobbyFindSessionRequest`:
+
+1. Before any of the current follower logic (`isFollowerInActiveMatch`, `TryFollowPartyLeader`, `pollFollowPartyLeader`), check: does a reservation exist for this player in any match?
+2. **New function** -- add to `evr_lobby_find.go`:
+
+```
+func (p *EvrPipeline) findReservation(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyParams *LobbySessionParameters) (MatchID, bool)
+```
+
+This function queries for a reservation matching this session ID or user ID. Implementation options:
+
+- **Option A -- Tracker-based**: The leader's `lobbyEntrantConnected` stores a "reservation pointer" on a new stream mode for the reserved player (e.g., `StreamModeReservation` with `Subject: memberSessionID`). The follower reads this stream to find their reservation match ID. Lightweight, no match registry scan.
+- **Option B -- Signal-based scan**: Query the match registry for the leader's current match (from the leader's service stream), then check that specific match for a reservation. This is a targeted lookup, not a broad scan.
+
+**Recommended**: Option A. Create a new stream mode `StreamModeReservation`. When `createPartyReservations` creates a reservation, it also tracks a presence for each reserved member on `PresenceStream{Mode: StreamModeReservation, Subject: memberSessionID}` with the match ID as status. The follower reads this single stream entry to find where their reservation is. When the reservation is consumed or cleared, untrack the stream.
+
+3. If reservation found -> join that match directly via `lobbyJoin` (bypass all follow/poll logic).
+4. If no reservation found -> enter a simplified hold state. The `lobbyEntrantConnected` handler will create one when the leader joins, and the follower will find it on the next poll cycle (or can be pushed via a notification if implemented).
+
+The follower **never reads the leader's tracker service stream** to figure out where the leader is. The reservation IS the signal.
+
+### 3. Social Lobby Reservations Persist
+
+**Already partially implemented.** Current behavior:
+
+- `appendPartyReservationPlaceholders` (`evr_lobby_find.go:1439-1475`) creates placeholder presences for party members when the leader joins a social lobby.
+- These flow through `LobbyJoinEntrants` -> `MatchJoinAttempt` and get 5-minute expiry (`evr_match.go:532-534`).
+- `rebuildCache()` includes them in `Size`, so `OpenSlots()` is reduced.
+
+**What changes**:
+
+1. Reservation creation for social lobbies also moves to `lobbyEntrantConnected`, but `appendPartyReservationPlaceholders` remains as a **belt-and-suspenders** for the initial join (before the game server confirms). The `lobbyEntrantConnected` reservations replace/refresh them once the game server confirms.
+
+2. Reservation clearing rules (already partially handled by expiry):
+   - **Reserved player joins** -> consumed by `LoadAndDeleteReservationRaw` in `MatchJoinAttempt` (already works).
+   - **Leader leaves the lobby** -> `MatchLeave` already fires, but does not currently clear slot reservations for party members. **New behavior needed**: when the leader leaves, clear all `reservationMap` entries whose `Presence.PartyID` matches the leader's party ID. Also untrack `StreamModeReservation` for those members.
+   - **Leader leaves the party** -> `snsPartyLeaveCleanup` (`evr_pipeline_party.go:175`). **New behavior**: look up leader's current match, signal it to clear party reservations.
+   - **Reserved player leaves the party** -> `snsPartyLeaveCleanup`. **New behavior**: look up the match where their reservation exists (via `StreamModeReservation`), signal it to clear that specific reservation.
+
+3. **Lobby full -> relocation**: If the social lobby is genuinely full and the leader starts matchmaking, the leader + party members who are matchmaking get a new lobby. Reservations for non-matchmaking members are created in the new lobby. This is already handled by the leader's `lobbyFind` path -- `newLobby` creates a new social lobby with `settings.Reservations` containing all entrants (`evr_lobby_find.go:604-611`).
+
+### 4. Three-Phase Timeout Model
+
+The current system uses a single long `MatchmakingTimeout` (30-420s) for everything — party formation, lobby convergence, AND finding opponents. This conflates local operations (your party members are online) with pool-dependent operations (finding opponents). The result: followers hold for minutes when they should resolve in seconds.
+
+**Phase 1 — Party Formation (15 seconds)**
+
+When the leader starts matchmaking:
+
+1. Party members have 15 seconds to start matchmaking (send their own `LobbyFindSessionRequest`).
+2. Members who are matchmaking within the timeout are included in the ticket.
+3. Members who are NOT matchmaking when the timeout fires are **excluded from the ticket** (not removed from the party). The leader proceeds without them on the ticket. They stay in the party group and in their social lobby.
+4. This is a hard cutoff — if you're not ready in 15 seconds, the ticket goes without you.
+
+**Phase 2 — Social Lobby Convergence (10 seconds)**
+
+When the leader joins a social lobby:
+
+1. Party members have 10 seconds to find their reservation and join the lobby.
+2. If the lobby is full, the leader relocates to a new lobby within this window. Reservations for orphaned members are created in the new lobby.
+3. Members who don't arrive within 10 seconds remain in the party but are not blocking anything — the reservation persists until expiry (5 minutes for social) or until they join.
+
+**Phase 3 — Matchmaking (existing timeout)**
+
+Once the party is formed (Phase 1 complete) and all matchmaking members are on the ticket:
+
+1. The ticket is submitted to the matchmaker AFTER the 15s formation period, not before.
+2. The normal matchmaker timeout applies. This is "finding opponents," not "assembling the party."
+
+**Cancellation Rules**
+
+1. **Any member cancels matchmaking** → cancel ALL members' matchmaking. Remove the ticket. No partial tickets. This is simple because there's no polling — cancel is a single operation.
+2. **Cancel does NOT remove from party.** The party is the social relationship. Matchmaking is the activity. Cancelling the activity doesn't end the relationship. The cancelled members stay in the party group and in the social lobby.
+3. **Cancel during formation (before ticket submitted)** → same as above. Formation stops. Everyone goes back to social-ready state.
+4. **Cancel during matchmaking (after ticket submitted)** → ticket removed from matchmaker. Everyone goes back to social-ready state.
+5. **Party membership vs matchmaking membership:** Players join the PARTY GROUP when they set the group name in-game (social relationship). They join the TICKET when they queue for arena/combat (matchmaking activity). The 15s formation timeout removes them from the ticket, not the party. Cancel removes everyone from the ticket, not the party.
+6. The matchmaker timeout is appropriately long because it depends on the player pool.
+
+**Key principle**: party formation and convergence timeouts are SHORT (10-15s) because they're local operations between online players. Matchmaking timeout is LONG because it depends on external factors. These are three distinct phases, not one combined timeout.
+
+### 5. Follower Matchmakes Before Leader
+
+**Trigger**: Follower sends `LobbyFindSessionRequest`, `findReservation` returns false.
+
+1. No reservation exists → follower enters `StateHolding`.
+2. **Simplified hold**: poll the `StreamModeReservation` stream on a simple interval (much cheaper than the current 4+ tracker reads per iteration).
+3. When the leader joins a match, `lobbyEntrantConnected` fires → `createPartyReservations` creates a reservation → the follower's poll finds it → joins.
+4. **Bounded by Phase 1 timeout (15s)**: if no reservation appears within the party formation timeout, the follower is excluded from the ticket and matchmakes independently. They stay in the party group.
+
+### 6. Party Member Not Matchmaking With Leader
+
+When the leader starts matchmaking (arena/combat):
+
+1. The Phase 1 formation timeout (15s) starts.
+2. Members who are in an active arena/combat match will not start matchmaking within 15 seconds.
+3. When the formation timeout fires, these members are **excluded from the ticket** (not removed from the party). The ticket goes without them.
+4. When their match ends, they can rejoin the party fresh (late join flow → finds reservation if leader has created one).
+
+This replaces the current `isFollowerInActiveMatch` skip-but-stay behavior. Removing them is cleaner — the party membership always reflects who is actually participating.
+
+### 7. Late Join
+
+**Trigger**: New member joins party via `snsPartyJoinRequest` (`evr_pipeline_party.go:253`) or `snsPartyRespondToInviteRequest` (`evr_pipeline_party.go:510`) while leader is already in a match.
+
+1. After `snsPartyTrackAndJoin` succeeds, look up the leader's current match via the leader's `StreamModeService` presence.
+2. If leader is in a match: signal the match to create a reservation for the new member. Track `StreamModeReservation` for the new member.
+3. New member's next `LobbyFindSessionRequest` -> `findReservation` finds it -> joins.
+
+**New code in `snsPartyJoinRequest`** and `snsPartyRespondToInviteRequest`:
+
+```
+func (p *EvrPipeline) createReservationForNewPartyMember(ctx context.Context, logger *zap.Logger, memberSession *sessionWS, partyID uuid.UUID)
+```
+
+- Find the party leader from the party stream
+- Read leader's `StreamModeService` presence to get match ID
+- If leader is in a social match, signal the match to create a reservation
+- Track `StreamModeReservation` for the new member
+
+### 8. Party Leader Removal
+
+The leader must be removed from the party (not just demoted) when:
+
+1. **Leader disconnects** -- session gone, can't lead. A new leader is elected from remaining members. The new leader inherits responsibility for reservations: clear the old leader's reservations, create new ones based on the new leader's current match (if any).
+2. **Leader is kicked/suspended** -- enforcement action. Same as disconnect: remove, elect, re-reserve.
+3. **Leader's match is terminated** (game server crash, server shutdown) -- leader is no longer in a match. Reservations in that match are now invalid. Clear them. The leader returns to matchmaking and the cycle restarts.
+
+### 9. Party Membership Changes -> Cancel Matchmaking
+
+**Any change to party membership MUST cancel all active matchmaking tickets AND update reservations.**
+
+Matchmaking tickets are immutable -- they contain the exact set of players. Reservations reflect the current party. Both must stay in sync with membership.
+
+Triggers and actions:
+
+- **Member joins the party** -> cancel ticket, rebuild with new member. Add reservation for new member in leader's current match (if any).
+- **Member leaves the party** -> cancel ticket, rebuild without them. Delete their reservation from leader's current match (if any). The slot opens for other players.
+- **Member is kicked from the party** -> same as leave.
+- **Leader changes** (disconnect, kick, promotion) -> cancel ticket, new leader rebuilds. Clear old leader's reservations. New leader creates reservations based on their current match.
+
+The invariant: the set of reservations in the leader's current match ALWAYS equals the set of party members who are not yet in that match. No stale reservations, no missing reservations. Every party change updates both the ticket and the reservations atomically.
+
+This is already partially implemented (`cancelTicketForLateArrival` in `evr_lobby_find.go:1350`, `MatchmakerRemoveAll` on `LobbyGroup` at `evr_lobby_group.go:69`, `SignalTicketRebuild` at `evr_lobby_group.go:99`). The reservation system makes this cleaner: the leader always owns the ticket and the reservations. When membership changes, the leader cancels and recreates both.
+
+---
+
+## Gap Resolutions (from behavior matrix review)
+
+Decisions on the 8 gaps flagged in `party-behavior-matrix.md`:
+
+**#64 — Reverse follow (leader joins follower's social lobby):** No-op. If the leader joins a lobby the follower is already in, the follower is already there. No reservation needed.
+
+**#65 — `lobbyFindOrCreateSocial` tracker-read priority join:** Replace with `findReservation`. The secondary tracker-read path in `lobbyFindOrCreateSocial` (lines 785-888) should use the reservation system, not read the leader's service stream.
+
+**#66 — Leader wait loop counting match presences:** Remove the match-presence counting entirely. The leader operates off party membership (`lobbyGroup.Size()`) only. The party stream is the source of truth for who's in the party. The match's `GetMatchPresences` gives wrong counts when followers have already left (documented in `TestExpectedFollowerCount_FromPartyStream`).
+
+**#68 — `monitorMatchmakingStream` goroutine for followers:** Whatever is most elegant. Followers using `findReservation` may not need the matchmaking stream monitor — the reservation check is their cancel/proceed mechanism.
+
+**#69 — `lobbyEntrantConnected` accessing `currentPartyID`:** Reuse existing code. The session lookup chain (`sessionRegistry.Get(sessionID)` → `LoadParams(s.Context())` → `currentPartyID`) already has precedent in the party handlers. No new patterns needed.
+
+**#70 — Post-match social lobby allocation interaction:** No-op or reservation refresh. `allocatePostMatchSocialLobby` already creates reservations before anyone joins. `lobbyEntrantConnected` just refreshes/extends them when the leader connects. No conflict.
+
+**#71 — Crash interaction with party reservations:** The crash handler should NOT create a reconnect reservation in the current (dying) match. The goal is to get to the leader, not stay in the match. The leader's social lobby reservation is the right destination. If the party member crashes and the leader has already created a reservation for them in the social lobby, that reservation persists. When the crash reconnect window expires, the player reconnects and finds the leader's reservation.
+
+---
+
+## Match Label Size Reporting
+
+**Change from current behavior.** Currently `rebuildCache()` includes reservations in `Size` implicitly. This hides information — consumers can't tell if `Size = 8` means 8 real players or 5 players + 3 reservations.
+
+**New explicit fields:**
+
+- `PlayerCount` — real players connected to the game server (already exists, `evr_match_label.go:430-435`)
+- `ReservationCount` — slots held for party members not yet arrived (new field)
+- `OpenSlots()` = `MaxSize - PlayerCount - ReservationCount` (modified)
+
+Consumers:
+
+- "Can someone join?" → check `OpenSlots()`
+- "How many people are playing?" → `PlayerCount`
+- "Total committed capacity?" → `PlayerCount + ReservationCount`
+- Search queries for backfill → use `PlayerCount` (real occupancy)
+- Join gate → use `OpenSlots()` (real + reserved)
+
+`Size` should equal `PlayerCount` only. Reservations are separate. No implicit math.
+
+---
+
+## Implementation Details
+
+### New Stream Mode
+
+Add `StreamModeReservation` to the stream mode constants (likely in `evr_pipeline.go` or wherever `StreamModeService`, `StreamModeMatchmaking`, etc. are defined).
+
+```
+StreamModeReservation = <next available uint8>
+```
+
+**Presence format**:
+
+- Stream: `PresenceStream{Mode: StreamModeReservation, Subject: memberSessionID, Label: StreamLabelMatchService}`
+- Status: match ID string (same format as service stream)
+- Tracked by: the pipeline on behalf of the leader
+- Untracked when: reservation consumed, cleared, or expired
+
+### New Signal: SignalCreatePartyReservations
+
+Add `SignalCreatePartyReservations` to signal opcodes (defined with other `Signal*` constants).
+
+Signal payload: JSON array of `*EvrMatchPresence` entries for reservation.
+
+In the match signal handler (`evr_match.go`, within the existing `switch` on signal opcode):
+
+```
+case SignalCreatePartyReservations:
+    var members []*EvrMatchPresence
+    // unmarshal from signal data
+    for _, m := range members {
+        if _, exists := state.presenceMap[m.GetSessionId()]; exists {
+            continue // already in match
+        }
+        if _, exists := state.reservationMap[m.GetSessionId()]; exists {
+            continue // already reserved
+        }
+        state.reservationMap[m.GetSessionId()] = &slotReservation{
+            Presence: m,
+            Expiry:   time.Now().Add(5 * time.Minute),
+        }
+    }
+    state.rebuildCache()
+```
+
+### New Signal: SignalClearPartyReservations
+
+Add `SignalClearPartyReservations` for cleanup scenarios.
+
+Signal payload: party ID (uuid string).
+
+```
+case SignalClearPartyReservations:
+    partyID := uuid.FromStringOrNil(signalData)
+    for sid, r := range state.reservationMap {
+        if r.Presence.PartyID == partyID {
+            delete(state.reservationMap, sid)
+        }
+    }
+    state.rebuildCache()
+```
+
+### Modified Functions
+
+| Function                         | File:Line                     | Change                                                                              |
+| -------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------- |
+| `lobbyEntrantConnected`          | `evr_pipeline_lobby.go:13`    | After accepting entrants, call `createPartyReservations` for leader entrants        |
+| `lobbyFind` (follower branch)    | `evr_lobby_find.go:113-250`   | Add `findReservation` check before existing follower logic; if found, join directly |
+| `snsPartyJoinRequest`            | `evr_pipeline_party.go:253`   | After successful join, call `createReservationForNewPartyMember`                    |
+| `snsPartyRespondToInviteRequest` | `evr_pipeline_party.go:510`   | Same as above                                                                       |
+| `snsPartyLeaveRequest`           | `evr_pipeline_party.go:322`   | Clear reservation for departing member                                              |
+| `snsPartyKickRequest`            | `evr_pipeline_party.go:430`   | Clear reservation for kicked member                                                 |
+| `MatchLeave`                     | `evr_match.go:660+`           | When leader leaves, clear all party reservations                                    |
+| `MatchSignal`                    | `evr_match.go` signal handler | Add `SignalCreatePartyReservations` and `SignalClearPartyReservations` cases        |
+
+### Functions That Become Unnecessary
+
+These functions exist solely to support the tracker-read follow pattern. With reservations as the coordination mechanism, they are no longer needed for the primary flow. They can be **deprecated and eventually removed** once the reservation path is proven stable.
+
+| Function                         | File:Line                             | Reason                                                 |
+| -------------------------------- | ------------------------------------- | ------------------------------------------------------ |
+| `TryFollowPartyLeader`           | `evr_lobby_find.go:1481-1637`         | Replaced by `findReservation`                          |
+| `pollFollowPartyLeader`          | `evr_lobby_find.go:1640-1848`         | Replaced by simple reservation poll                    |
+| `isFollowerAlreadyInLeaderMatch` | `evr_lobby_find.go:1238-1285`         | Reservation presence check is authoritative            |
+| `isFollowerInLeaderDestination`  | `evr_lobby_find_follower_test.go:199` | The ambiguity it documents is eliminated               |
+| `isLeaderHeadingToSocial`        | `evr_lobby_find.go:1030-1078`         | Mode info can be embedded in reservation stream status |
+| `intendedSocialTargetMatchID`    | `evr_lobby_find.go:1205-1227`         | Reservation IS the intended target                     |
+
+### Functions That Stay
+
+| Function                              | File:Line                     | Reason                                                    |
+| ------------------------------------- | ----------------------------- | --------------------------------------------------------- |
+| `cancelTicketForLateArrival`          | `evr_lobby_find.go:1350-1401` | Still needed for ticket immutability                      |
+| `appendPartyReservationPlaceholders`  | `evr_lobby_find.go:1439-1475` | Keep as belt-and-suspenders for initial social lobby join |
+| `currentSocialLobbyForSession`        | `evr_lobby_find.go:1139-1197` | Fast-path no-op detection for re-sent requests            |
+| `LoadAndDeleteReservationRaw`         | `evr_match_label.go:118-127`  | Core reservation consumption in MatchJoinAttempt          |
+| `LoadAndDeleteReservationByUserIDRaw` | `evr_match_label.go:133-147`  | Fallback for session ID changes                           |
+
+**Removed from "keep" list:**
+
+- `isFollowerInActiveMatch` — replaced by the Phase 1 formation timeout (15s). Members not matchmaking within the timeout are excluded from the ticket (not the party). No need to check if they're in an active match.
+- `isLeaderInArenaCombatMatch` — the reservation system handles this: leader joins arena → creates reservations → followers find them. The mode information is in the reservation, not a separate tracker check.
+
+**Also removed (per #66 gap resolution):**
+
+- Leader wait loop using `GetMatchPresences` to count followers — replaced by `lobbyGroup.Size()` from the party stream. The party stream is the source of truth for who's in the party.
+
+---
+
+## Edge Cases
+
+### 1. Session ID Change (Follower Disconnects and Reconnects)
+
+A follower may disconnect and reconnect with a new session ID. The reservation in the match is keyed by the old session ID.
+
+**Already handled**: `LoadAndDeleteReservationByUserIDRaw` (`evr_match_label.go:133-147`) scans by user ID as a fallback. However, the `StreamModeReservation` presence is also keyed by the old session ID. When the follower reconnects, the pipeline must re-track the reservation stream with the new session ID, OR the reservation lookup must also check by user ID.
+
+**Recommendation**: When a player reconnects and re-joins the party, `snsPartyTrackAndJoin` fires. At that point, check if a reservation exists for their user ID (via `StreamModeReservation` on the old session ID tracked by the leader). If so, update the stream to the new session ID.
+
+### 2. Leader Leaves Match Before Followers Arrive
+
+Leader joins social lobby -> reservations created -> leader leaves before followers arrive.
+
+**Current behavior**: Reservations expire (5-minute timeout). Followers attempting to join get rejected (match may have new players occupying the reserved slots if expiry ran).
+
+**With reservation system**: When the leader leaves, `MatchLeave` fires. If the leader has party members with active reservations, signal the match to clear those reservations (`SignalClearPartyReservations`). Untrack `StreamModeReservation` for those members. Followers' `findReservation` will return false, and they will enter the hold state. When the leader joins a new match, the cycle restarts.
+
+### 3. Multiple Leaders (Leader Promotion Mid-Flow)
+
+If the leader is promoted to a different player mid-matchmaking (via `snsPartyPassOwnershipRequest` at `evr_pipeline_party.go:471`):
+
+1. Old leader's reservations should be cleared in their current match.
+2. New leader needs to create reservations in THEIR current match (if they have one).
+3. Active matchmaking tickets must be cancelled (already handled by ticket rebuild).
+
+### 4. Race: Follower Joins Before `lobbyEntrantConnected` Fires
+
+Timeline:
+
+1. Leader calls `LobbyJoinEntrants` -> match handler adds leader + creates initial reservations via `EntrantMetadata.Reservations`.
+2. Follower's `findReservation` runs before `lobbyEntrantConnected` fires.
+
+**Not a problem**: Reservations are already created in step 1 via `MatchJoinAttempt` (lines 519-538). The `lobbyEntrantConnected`-based reservation creation is an additional/refresh path for members who were NOT included in the initial `LobbyJoinEntrants` call (e.g., they were not matchmaking yet when the leader joined). The `StreamModeReservation` tracking happens at that point.
+
+For the initial join, `appendPartyReservationPlaceholders` (`evr_lobby_find.go:1439-1475`) already creates placeholder reservations in the entrants list. These flow through `MatchJoinAttempt` and create reservations immediately, before `lobbyEntrantConnected` fires.
+
+### 5. Game Server Crash
+
+If the game server crashes:
+
+1. Match ends -> all presences removed, reservations destroyed.
+2. Service stream presences for all players become stale until untracked.
+3. `StreamModeReservation` presences become stale.
+
+**Solution**: When a player's match terminates (detected by `MatchLeave` or session disconnect handling), untrack their `StreamModeReservation` entries. The follower's `findReservation` will return false, and they will re-enter the hold state.
+
+### 6. Party Size > Available Slots
+
+If the party has 4 members but the social lobby only has 2 open slots:
+
+- Current behavior: `TryFollowPartyLeader` checks `OpenPlayerSlots() < requiredSlots` and either gives up or polls.
+- With reservations: `createPartyReservations` should only create reservations for members that fit. If the lobby is full, the leader should initiate relocation to a new lobby. This is already handled by `lobbyFind`'s social lobby path -- when the leader matchmakes from a full lobby, `newLobby` creates a new social lobby with all entrants.
+
+### 7. Reservation Created for Offline Member
+
+If a party member's session has died but they have not been cleaned up from the party stream yet:
+
+- `createPartyReservations` will create a reservation for a dead session.
+- The reservation will expire (5 minutes) without being consumed.
+- **Mitigation**: Before creating a reservation, check `sessionRegistry.Get(memberSessionID)` returns a live session. If nil, skip that member.
+
+### 8. Concurrent lobbyFind Calls
+
+The follower's client may re-send `LobbyFindSessionRequest` while a previous `lobbyFind` is still running (this happens on the client's normal message cycle). Currently handled by `isFollowerAlreadyInLeaderMatch` fast-path at line 72.
+
+With reservations: `findReservation` is idempotent (read-only query). If a reservation is found, `lobbyJoin` will either succeed (first call) or be rejected as `ErrJoinRejectReasonDuplicateJoin` and treated as a no-op (`evr_lobby_joinentrant.go:95-97`).
+
+---
+
+## Migration Notes
+
+### In-Flight Parties During Deploy
+
+During a rolling deploy:
+
+1. **Old server processes**: Will continue using the tracker-read follow pattern. No `StreamModeReservation` presences exist.
+2. **New server processes**: Will try `findReservation` first, find nothing (old leaders don't create reservation streams), and fall through to the existing follow path (which should be preserved as fallback during the transition period).
+
+**Strategy**: Keep the existing follow path (`TryFollowPartyLeader`, `pollFollowPartyLeader`) as a fallback behind the `findReservation` check. During deploy:
+
+```go
+if matchID, found := p.findReservation(ctx, logger, session, lobbyParams); found {
+    // New path: join via reservation
+    return p.lobbyJoin(ctx, logger, session, lobbyParams, matchID)
+}
+// Fallback: old tracker-read path (remove after stabilization)
+if p.TryFollowPartyLeader(ctx, logger, session, lobbyParams, lobbyGroup) {
+    return nil
+}
+```
+
+### Rollback Safety
+
+If the reservation system causes issues:
+
+1. Remove the `findReservation` check from `lobbyFind`.
+2. Remove the `createPartyReservations` call from `lobbyEntrantConnected`.
+3. The existing follow path remains intact.
+4. `StreamModeReservation` presences will expire naturally (session disconnect cleanup).
+5. Match signal handlers for new signals are no-ops if never called.
+
+No data migration needed -- all state is in-memory (tracker streams, match labels).
+
+---
+
+## Testing
+
+Each scenario above is a test case. Tests must exercise the actual reservation flow, not isolated functions with mocks.
+
+### Existing Test Coverage
+
+| Test File                             | What It Covers                                                                                                                               | Status                                       |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `evr_lobby_follow_test.go`            | `TryFollowPartyLeader` and `pollFollowPartyLeader` -- 40+ tests covering every early return path, timeout, leadership change, duo desync bug | **Covers the OLD path being replaced**       |
+| `evr_lobby_find_follower_test.go`     | `isFollowerInLeaderDestination` -- 8 tests documenting the TOCTOU ambiguity, including the skipped test at line 57                           | **Documents the problem this spec solves**   |
+| `evr_lobby_configure_party_test.go`   | `configureParty` -- follower not on matchmaking stream, party stream cleanup                                                                 | **Relevant, needs expansion**                |
+| `evr_reservation_integration_test.go` | Reservation lifecycle with classification, cleanup, preemption, no-show auto-vacate                                                          | **Covers match-level reservation mechanics** |
+| `evr_matchmaker_reservation_test.go`  | Matchmaker-level reservation building and assembly                                                                                           | **Covers matchmaker integration**            |
+| `evr_party_system_test.go`            | Party handler creation, join, leave, matchmaker integration                                                                                  | **Covers party mechanics**                   |
+| `evr_lobby_capacity_test.go`          | Lobby capacity and slot calculations                                                                                                         | **Covers capacity math**                     |
+
+### New Test Cases
+
+1. **Leader joins social -> reservations created for all party members -> follower finds reservation -> joins**
+   - Create party with leader + 2 followers
+   - Leader calls `lobbyFind` -> enters social lobby
+   - Verify `lobbyEntrantConnected` creates reservations (check `reservationMap` and `StreamModeReservation`)
+   - Follower calls `lobbyFind` -> `findReservation` returns true -> joins directly
+   - Verify no tracker-read follow path is entered
+
+2. **Leader joins arena (via matchmaker) -> party members on ticket placed by matchmaker -> reservations for non-matchmaking members**
+   - Leader + follower in party, both matchmaking
+   - Matchmaker places both on same ticket
+   - Verify matchmaker handles party grouping (existing behavior)
+   - If a third member joins party late (not on ticket), verify reservation is created for them
+
+3. **Follower matchmakes before leader -> holds -> leader joins -> reservation created -> follower finds it**
+   - Create party
+   - Follower sends `LobbyFindSessionRequest` before leader
+   - Verify follower enters `StateHolding`
+   - Leader sends `LobbyFindSessionRequest` -> joins social lobby
+   - Verify `lobbyEntrantConnected` creates reservation for follower
+   - Verify follower picks up reservation and joins
+
+4. **Late join -> reservation created -> follower joins**
+   - Leader in social lobby
+   - New member joins party via `snsPartyJoinRequest`
+   - Verify reservation created in leader's lobby for new member
+   - New member's `lobbyFind` finds reservation -> joins
+
+5. **Lobby full -> leader + members move to new lobby with reservations**
+   - Fill a social lobby to capacity
+   - Leader starts matchmaking -> `newLobby` creates a new lobby
+   - Verify reservations for non-matchmaking party members in new lobby
+
+6. **Leader leaves party -> reservations cleared**
+   - Leader in social lobby with reservations for 2 followers
+   - Leader calls `snsPartyLeaveRequest`
+   - Verify all party reservations in the match are cleared
+   - Verify `StreamModeReservation` untracked for followers
+
+7. **Reserved player leaves party -> their reservation cleared**
+   - Leader in social lobby with reservations
+   - One follower calls `snsPartyLeaveRequest`
+   - Verify only that follower's reservation is cleared
+   - Other follower's reservation remains
+
+8. **Member in active arena match when leader queues -> skipped (not kicked)**
+   - Leader + follower in party
+   - Follower in active arena match
+   - Leader matchmakes
+   - Verify follower is skipped (`isFollowerInActiveMatch` returns true)
+   - No reservation created for follower in leader's arena match
+
+9. **Session ID change -> reservation still found via user ID fallback**
+   - Leader in social lobby with reservation for follower (session A)
+   - Follower disconnects and reconnects with session B
+   - Follower's `findReservation` uses user ID fallback
+   - Verify join succeeds
+
+10. **Leader disconnect -> new leader -> reservations rebuilt**
+    - Leader in social lobby with reservations
+    - Leader disconnects
+    - New leader elected
+    - Old reservations cleared
+    - New leader's `lobbyEntrantConnected` creates new reservations (if new leader is in a match)
+
+---
+
+## Notes
+
+- This codebase uses zap (not slog) and predates the Go addendum -- new code follows addendum principles within existing project conventions (e.g., `%w` error wrapping, context as first param, functional options, no `interface{}`).
+- The `isFollowerInActiveMatch`, `TryFollowPartyLeader`, `pollFollowPartyLeader`, and `isFollowerAlreadyInLeaderMatch` functions become largely unnecessary once reservations are the coordination mechanism. Keep them as fallback during migration, remove after stabilization.
+- The `isFollowerInLeaderDestination` pure function and its skipped test document the exact ambiguity this design eliminates.
+- The documented SMELL at `evr_lobby_find.go:50-56` (race between leader's match-join and deferred matchmaking stream untrack) is eliminated: followers no longer read the leader's matchmaking stream to determine intent.
+- All match state modifications (reservation creation/deletion) go through `MatchSignal`, respecting the match handler's single-goroutine execution model. No direct writes to `MatchLabel` from external goroutines.
+- `StreamModeReservation` presences are a lightweight notification mechanism -- they do not carry the full reservation data, just the match ID. The actual reservation lives in the match's `reservationMap`.

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -112,6 +112,26 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 
 	if lobbyGroup != nil {
 		if !isLeader {
+			// Reservation-based follow: if the leader has created a reservation
+			// for this follower, join directly without tracker-read follow logic.
+			if reservationMatchID, found := p.findReservation(ctx, logger, session, lobbyGroup); found {
+				logger.Info("Found party reservation, joining directly",
+					zap.String("reservation_mid", reservationMatchID.String()))
+				if err := p.lobbyJoin(ctx, logger, session, lobbyParams, reservationMatchID); err != nil {
+					logger.Warn("Failed to join via reservation, falling through to legacy path",
+						zap.Error(err))
+				} else {
+					// Observer: follower joined via reservation. Transition to StateJoining
+					// (not StateInMatch) — lobbyEntrantConnected will promote to StateInMatch
+					// when the game server confirms the join. This keeps the crash-detection
+					// window active during the join handshake.
+					if lc := getMatchLifecycle(session); lc != nil {
+						lc.TransitionTo(StateJoining, "reservation found, joining", WithMatchID(reservationMatchID.String()))
+					}
+					return nil
+				}
+			}
+
 			// Guard: if the follower is in an active Arena/Combat match,
 			// do not process the party follow. Let them finish their match.
 			// The party will pick them up when they return to social.
@@ -122,7 +142,9 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 			}
 
 			// Observer: non-leader entering holding pattern, waiting for leader's ticket.
-			if lc := getMatchLifecycle(session); lc != nil {
+			// Guard: skip if the player is still InMatch — the match leave
+			// hasn't fired yet; transitioning to Holding would be premature.
+			if lc := getMatchLifecycle(session); lc != nil && lc.State() != StateInMatch {
 				lc.Transition(StateHolding, "waiting for leader's ticket")
 			}
 
@@ -514,7 +536,9 @@ func (p *EvrPipeline) configureParty(ctx context.Context, logger *zap.Logger, se
 		logger.Debug("Party is ready", zap.String("leader", session.id.String()), zap.Int("size", partySize), zap.Strings("members", memberUsernames))
 
 		// Observer: leader submitting matchmaking ticket.
-		if lc := getMatchLifecycle(session); lc != nil {
+		// Guard: skip if the player is still InMatch — the match leave
+		// hasn't fired yet; transitioning to Matchmaking would be premature.
+		if lc := getMatchLifecycle(session); lc != nil && lc.State() != StateInMatch {
 			lc.TransitionTo(StateMatchmaking, "leader submitted ticket", WithIsLeader(true))
 		}
 
@@ -528,9 +552,11 @@ func (p *EvrPipeline) configureParty(ctx context.Context, logger *zap.Logger, se
 			continue
 		}
 		// Observer: party member included on leader's ticket.
+		// Guard: skip if the member is still InMatch — their match leave
+		// hasn't fired yet; transitioning to Matchmaking would be premature.
 		if memberSession := p.nk.sessionRegistry.Get(uuid.FromStringOrNil(member.Presence.GetSessionId())); memberSession != nil {
 			if ws, ok := memberSession.(*sessionWS); ok {
-				if lc := getMatchLifecycle(ws); lc != nil {
+				if lc := getMatchLifecycle(ws); lc != nil && lc.State() != StateInMatch {
 					lc.Transition(StateMatchmaking, "included on leader's ticket")
 				}
 			}
@@ -779,6 +805,33 @@ func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.L
 				}
 			}
 			p.prewarmEntrantPings(ctx, logger, entrants, endpoints)
+		}
+
+		// Reservation-based follow: if the leader has created a reservation
+		// for this follower in a social lobby, join directly without the
+		// tracker-read priority join path.
+		if ws, ok := session.(*sessionWS); ok {
+			if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
+				if lobbyGroup, _, err := JoinPartyGroup(ws, lobbyParams.PartyGroupName, lobbyParams.CurrentMatchID); err == nil && lobbyGroup != nil {
+					if reservationMatchID, found := p.findReservation(ctx, logger, ws, lobbyGroup); found {
+						logger.Info("Found party reservation in social lobby path, joining directly",
+							zap.String("reservation_mid", reservationMatchID.String()))
+						if err := p.lobbyJoin(ctx, logger, ws, lobbyParams, reservationMatchID); err != nil {
+							logger.Warn("Failed to join via reservation in social path, falling through to legacy priority join",
+								zap.Error(err))
+						} else {
+							// Observer: follower joined via reservation in social lobby path.
+							// Transition to StateJoining (not StateInMatch) — lobbyEntrantConnected
+							// will promote to StateInMatch when the game server confirms. This keeps
+							// the crash-detection window active during the join handshake.
+							if lc := getMatchLifecycle(ws); lc != nil {
+								lc.TransitionTo(StateJoining, "reservation found, joining", WithMatchID(reservationMatchID.String()))
+							}
+							return nil
+						}
+					}
+				}
+			}
 		}
 
 		// Priority 1: If we're in a party, try to find the leader's specific lobby first.
@@ -1395,7 +1448,9 @@ func (p *EvrPipeline) cancelTicketForLateArrival(_ context.Context, logger *zap.
 	lobbyGroup.SignalTicketRebuild()
 
 	// Observer: ticket cancelled due to late arrival.
-	if lc := getMatchLifecycle(session); lc != nil {
+	// Guard: skip if the player is still InMatch — the match leave
+	// hasn't fired yet; transitioning to Holding would be premature.
+	if lc := getMatchLifecycle(session); lc != nil && lc.State() != StateInMatch {
 		lc.Transition(StateHolding, "ticket cancelled for late arrival, rebuilding")
 	}
 }
@@ -1845,4 +1900,71 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 		}
 		return true
 	}
+}
+
+// findReservation checks whether the party leader's current match has a
+// reservation for this follower. It looks up the leader's match via the
+// leader's service stream, fetches the match label, and checks the
+// Players slice for an entry with IsReservation == true matching this
+// session's ID.
+//
+// Returns the match ID and true if a reservation is found. Returns
+// MatchID{}, false if no reservation exists (leader not in a match,
+// match label unreadable, or follower not reserved).
+//
+// This replaces the old StreamModeReservation tracker-read approach.
+// Cost: one tracker read (leader's service stream) + one MatchLabelByID
+// call per invocation.
+func (p *EvrPipeline) findReservation(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyGroup *LobbyGroup) (MatchID, bool) {
+	leader := lobbyGroup.GetLeader()
+	if leader == nil {
+		return MatchID{}, false
+	}
+	leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
+	leaderUserID := uuid.FromStringOrNil(leader.UserId)
+	if leaderSessionID == session.id {
+		return MatchID{}, false // caller IS the leader
+	}
+
+	// Look up leader's current match via their service stream.
+	stream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: leaderSessionID,
+		Label:   StreamLabelMatchService,
+	}
+	presence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, stream, leaderUserID)
+	if presence == nil {
+		return MatchID{}, false // leader not in a match
+	}
+	leaderMatchID := MatchIDFromStringOrNil(presence.GetStatus())
+	if leaderMatchID.IsNil() {
+		return MatchID{}, false
+	}
+
+	// Fetch match label and check for our reservation.
+	label, err := MatchLabelByID(ctx, p.nk, leaderMatchID)
+	if err != nil || label == nil {
+		logger.Debug("Failed to get leader's match label for reservation check",
+			zap.Error(err), zap.String("mid", leaderMatchID.String()))
+		return MatchID{}, false
+	}
+
+	// Check if our session ID appears as a reservation in the Players slice.
+	//
+	// Known benign race: the reservation may not be in the label yet because
+	// updateLabel hasn't run since createPartyReservations signalled the match.
+	// In that case findReservation returns false and the caller falls through
+	// to the legacy tracker-read follow path, which converges correctly.
+	sessionIDStr := session.id.String()
+	for _, player := range label.Players {
+		if player.SessionID == sessionIDStr && player.IsReservation {
+			logger.Debug("Found reservation in leader's match",
+				zap.String("match_id", leaderMatchID.String()))
+			return leaderMatchID, true
+		}
+	}
+	logger.Debug("No reservation found in leader's match label (may be label publication lag)",
+		zap.String("match_id", leaderMatchID.String()),
+		zap.String("session_id", sessionIDStr))
+	return MatchID{}, false
 }

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -200,55 +200,9 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 		}
 	}
 
-	// Wait before tracking, but respect context cancellation.
-	select {
-	case <-sessionCtx.Done():
-		return fmt.Errorf("session closed before stream tracking: %w", sessionCtx.Err())
-	case <-time.After(1 * time.Second):
-	}
-
-	matchIDStr := label.ID.String()
-
-	guildGroupStream := PresenceStream{Mode: StreamModeGuildGroup, Subject: label.GetGroupID(), Label: label.Mode.String()}
-
-	ops := []*TrackerOp{
-		{
-			guildGroupStream,
-			PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: matchIDStr, Hidden: false},
-		},
-		{
-			PresenceStream{Mode: StreamModeService, Subject: e.SessionID, Label: StreamLabelMatchService},
-			PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: matchIDStr, Hidden: false},
-		},
-		{
-			PresenceStream{Mode: StreamModeService, Subject: e.LoginSessionID, Label: StreamLabelMatchService},
-			PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: matchIDStr, Hidden: false},
-		},
-		{
-			PresenceStream{Mode: StreamModeService, Subject: e.UserID, Label: StreamLabelMatchService},
-			PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: matchIDStr, Hidden: false},
-		},
-		{
-			PresenceStream{Mode: StreamModeService, Subject: e.EvrID.UUID(), Label: StreamLabelMatchService},
-			PresenceMeta{Format: SessionFormatEVR, Username: e.Username, Status: matchIDStr, Hidden: false},
-		},
-	}
-
-	// Update the statuses with retry logic to handle transient session state issues.
-	// This is looked up by the pipeline when the game server sends the new entrant message,
-	// and also by the IGP (In-Game Panel) to find players in matches.
-	const maxRetries = 3
-	const retryDelay = 100 * time.Millisecond
-
-	for _, op := range ops {
-		if ok := tracker.Update(sessionCtx, e.SessionID, op.Stream, e.UserID, op.Meta); !ok {
-			logger.Warn("Failed to track stream", zap.Any("stream", op.Stream), zap.String("uid", e.UserID.String()))
-			return ErrFailedToTrackSessionID
-		}
-	}
-
-	// Leave any other lobby group stream.
-	tracker.UntrackLocalByModes(session.ID(), map[uint8]struct{}{StreamModeMatchmaking: {}, StreamModeGuildGroup: {}}, guildGroupStream)
+	// Service stream updates, guild group stream, and matchmaking untrack are
+	// deferred to lobbyEntrantConnected — they should only be set once the game
+	// server confirms the player actually connected.
 
 	connectionSettings := label.GetEntrantConnectMessage(e.RoleAlignment, e.DisableEncryption, e.DisableMAC)
 

--- a/server/evr_lobby_matchmake.go
+++ b/server/evr_lobby_matchmake.go
@@ -201,7 +201,56 @@ func (p *EvrPipeline) lobbyMatchMakeWithFallback(ctx context.Context, logger *za
 		return nil
 	}
 
-	// Add initial ticket
+	// Formation phase: if in a party, wait up to 15 seconds for all
+	// members to start matchmaking before submitting the first ticket.
+	// Solo players or single-member parties skip this phase entirely.
+	if lobbyGroup != nil && lobbyGroup.Size() > 1 {
+		const formationTimeout = 15 * time.Second
+		formationTimer := time.NewTimer(formationTimeout)
+		defer formationTimer.Stop()
+
+		// Poll ticker for checking party readiness. Using a ticker (instead of
+		// time.After per iteration) avoids leaking a timer channel on every loop tick.
+		pollTicker := time.NewTicker(1 * time.Second)
+		defer pollTicker.Stop()
+
+		// Wait for all party members to be on the matchmaking stream,
+		// or for the formation timer to fire, or for the context to
+		// be cancelled (e.g., a member cancels matchmaking).
+		partyStream := PresenceStream{Mode: StreamModeParty, Subject: lobbyGroup.ID(), Label: session.pipeline.node}
+		mmStream := lobbyParams.MatchmakingStream()
+	formationLoop:
+		for {
+			select {
+			case <-ctx.Done():
+				return nil // Cancelled during formation (BAC-023)
+			case <-formationTimer.C:
+				// Formation timeout fired. Submit ticket with whoever
+				// is ready. Members NOT on the matchmaking stream are
+				// excluded from the ticket but remain in the party.
+				logger.Info("Formation timeout -- submitting ticket with ready members",
+					zap.Int("party_size", lobbyGroup.Size()))
+				break formationLoop
+			case <-pollTicker.C:
+				// Check if all party members are now on the matchmaking stream.
+				partyPresences := session.tracker.ListByStream(partyStream, true, true)
+				allReady := true
+				for _, pp := range partyPresences {
+					if session.tracker.GetLocalBySessionIDStreamUserID(pp.ID.SessionID, mmStream, pp.UserID) == nil {
+						allReady = false
+						break
+					}
+				}
+				if allReady {
+					logger.Info("All party members ready -- submitting ticket early",
+						zap.Int("party_size", lobbyGroup.Size()))
+					break formationLoop
+				}
+			}
+		}
+	}
+
+	// Add initial ticket (after formation phase for parties, immediately for solo)
 	if err := replaceTicket(ticketConfig); err != nil {
 		return err
 	}

--- a/server/evr_logreplay_pipeline_test.go
+++ b/server/evr_logreplay_pipeline_test.go
@@ -1,0 +1,576 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/rtapi"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// ---------------------------------------------------------------------------
+// recordedJoinAttempt captures calls to MatchRegistry.JoinAttempt for
+// assertion in tests.
+// ---------------------------------------------------------------------------
+
+type recordedJoinAttempt struct {
+	MatchID   uuid.UUID
+	Node      string
+	UserID    uuid.UUID
+	SessionID uuid.UUID
+	Username  string
+}
+
+// ---------------------------------------------------------------------------
+// mockReplayMatchRegistry — extends mockFollowMatchRegistry with:
+//   - JoinAttempt recording (returns success)
+//   - ListMatches stub (returns empty, no panic)
+// ---------------------------------------------------------------------------
+
+type mockReplayMatchRegistry struct {
+	mockFollowMatchRegistry
+	mu           sync.Mutex
+	joinAttempts []recordedJoinAttempt
+}
+
+func newMockReplayMatchRegistry() *mockReplayMatchRegistry {
+	return &mockReplayMatchRegistry{
+		mockFollowMatchRegistry: mockFollowMatchRegistry{
+			matches: make(map[string]*MatchLabel),
+		},
+	}
+}
+
+func (r *mockReplayMatchRegistry) JoinAttempt(
+	_ context.Context, id uuid.UUID, node string,
+	userID, sessionID uuid.UUID, username string,
+	_ int64, _ map[string]string, _, _, _ string,
+	_ map[string]string,
+) (bool, bool, bool, string, string, []*MatchPresence) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.joinAttempts = append(r.joinAttempts, recordedJoinAttempt{
+		MatchID:   id,
+		Node:      node,
+		UserID:    userID,
+		SessionID: sessionID,
+		Username:  username,
+	})
+
+	// Look up the label for this match so we can return it as the label string
+	// (matches LobbyJoinEntrants expectations).
+	r.mockFollowMatchRegistry.mu.RLock()
+	matchKey := id.String() + "." + node
+	label, ok := r.mockFollowMatchRegistry.matches[matchKey]
+	r.mockFollowMatchRegistry.mu.RUnlock()
+	var labelStr string
+	if ok {
+		data, _ := json.Marshal(label)
+		labelStr = string(data)
+	} else {
+		labelStr = "{}"
+	}
+	return true, true, true, "", labelStr, nil
+}
+
+func (r *mockReplayMatchRegistry) ListMatches(
+	_ context.Context, _ int, _ *wrapperspb.BoolValue,
+	_ *wrapperspb.StringValue, _ *wrapperspb.Int32Value,
+	_ *wrapperspb.Int32Value, _ *wrapperspb.StringValue,
+	_ *wrapperspb.StringValue,
+) ([]*api.Match, []string, error) {
+	return nil, nil, nil
+}
+
+// getJoinAttempts returns a snapshot of recorded join attempts.
+func (r *mockReplayMatchRegistry) getJoinAttempts() []recordedJoinAttempt {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]recordedJoinAttempt, len(r.joinAttempts))
+	copy(out, r.joinAttempts)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// mockReplaySessionRegistry — extends testSessionRegistry with a Get that
+// returns pre-registered sessions.
+// ---------------------------------------------------------------------------
+
+type mockReplaySessionRegistry struct {
+	testSessionRegistry
+	mu       sync.RWMutex
+	sessions map[uuid.UUID]Session
+}
+
+func newMockReplaySessionRegistry() *mockReplaySessionRegistry {
+	return &mockReplaySessionRegistry{
+		sessions: make(map[uuid.UUID]Session),
+	}
+}
+
+func (r *mockReplaySessionRegistry) Get(sessionID uuid.UUID) Session {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if s, ok := r.sessions[sessionID]; ok {
+		return s
+	}
+	return nil
+}
+
+func (r *mockReplaySessionRegistry) Add(session Session) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessions[session.ID()] = session
+}
+
+// ---------------------------------------------------------------------------
+// replayTestEnv — test harness for log-replay pipeline tests
+// ---------------------------------------------------------------------------
+
+type replayTestEnv struct {
+	t *testing.T
+
+	pipeline        *EvrPipeline
+	tracker         *mockMatchmakingTracker
+	matchRegistry   *mockReplayMatchRegistry
+	sessionRegistry *mockReplaySessionRegistry
+
+	sessions         map[string]*sessionWS        // keyed by player name
+	capturedMessages map[uuid.UUID][]evr.Message   // keyed by session ID
+	mu               sync.Mutex                    // protects capturedMessages
+}
+
+func newReplayTestEnv(t *testing.T) *replayTestEnv {
+	t.Helper()
+
+	tracker := newMockMatchmakingTracker()
+	matchRegistry := newMockReplayMatchRegistry()
+	sessionRegistry := newMockReplaySessionRegistry()
+
+	nk := &RuntimeGoNakamaModule{
+		matchRegistry:   matchRegistry,
+		tracker:         tracker,
+		sessionRegistry: sessionRegistry,
+		metrics:         &testMetrics{},
+		node:            "testnode",
+	}
+
+	pipeline := &EvrPipeline{
+		node:   "testnode",
+		nk:     nk,
+		logger: zap.NewNop(),
+	}
+
+	// Prevent panics in LobbyJoinEntrants when checking globalAppBot.
+	globalAppBot.Store(nil)
+
+	return &replayTestEnv{
+		t:                t,
+		pipeline:         pipeline,
+		tracker:          tracker,
+		matchRegistry:    matchRegistry,
+		sessionRegistry:  sessionRegistry,
+		sessions:         make(map[string]*sessionWS),
+		capturedMessages: make(map[uuid.UUID][]evr.Message),
+	}
+}
+
+// newTestSession creates a *sessionWS with the minimum fields needed for
+// findReservation, lobbyFind helpers, and sendEvrHook capture.
+func (env *replayTestEnv) newTestSession(name string, userID, sessionID uuid.UUID) *sessionWS {
+	env.t.Helper()
+
+	logger := zap.NewNop()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Set up session parameters in context so LoadParams works.
+	paramsPtr := &atomic.Pointer[SessionParameters]{}
+	params := &SessionParameters{
+		node:           "testnode",
+		MatchLifecycle: NewPlayerMatchLifecycle(logger),
+	}
+	paramsPtr.Store(params)
+	ctx = context.WithValue(ctx, ctxSessionParametersKey{}, paramsPtr)
+
+	username := atomic.NewString(name)
+
+	s := &sessionWS{
+		id:          sessionID,
+		userID:      userID,
+		logger:      logger,
+		username:    username,
+		ctx:         ctx,
+		ctxCancelFn: cancel,
+		pipeline:    &Pipeline{node: "testnode", tracker: env.tracker},
+		evrPipeline: env.pipeline,
+	}
+
+	// Wire up sendEvrHook to capture messages.
+	s.sendEvrHook = func(messages []evr.Message) {
+		env.mu.Lock()
+		defer env.mu.Unlock()
+		env.capturedMessages[sessionID] = append(env.capturedMessages[sessionID], messages...)
+	}
+
+	// Register in session registry so sessionRegistry.Get works.
+	env.sessionRegistry.Add(s)
+
+	// Store by name for test convenience.
+	env.sessions[name] = s
+
+	env.t.Cleanup(func() { cancel() })
+	return s
+}
+
+// getCapturedMessages returns a copy of the captured messages for a session.
+func (env *replayTestEnv) getCapturedMessages(sessionID uuid.UUID) []evr.Message {
+	env.mu.Lock()
+	defer env.mu.Unlock()
+	msgs := env.capturedMessages[sessionID]
+	out := make([]evr.Message, len(msgs))
+	copy(out, msgs)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2a: Smoke test — verify the harness works
+// ---------------------------------------------------------------------------
+
+// TestPipelineReplay_SoloSocialJoin verifies the sendEvrHook capture mechanism
+// and the replayTestEnv harness with a solo player scenario. The full lobbyFind
+// end-to-end path is blocked by configureParty (needs PartyRegistry) and
+// lobbyAuthorize (needs GuildGroupRegistry) — both require infrastructure that
+// is not mockable without additional production changes. This test proves the
+// harness captures messages correctly, which is the foundation for all Phase 2
+// pipeline tests.
+//
+// Blockers for full lobbyFind end-to-end:
+//   - configureParty: calls JoinPartyGroup which needs PartyRegistry (server runtime)
+//   - lobbyAuthorize: needs GuildGroupRegistry.Get (concrete type, not mockable)
+//   - CheckServerPing: needs StreamUserList (full Nakama runtime)
+//   - JoinMatchmakingStream: needs s.matchmaker (Matchmaker interface)
+func TestPipelineReplay_SoloSocialJoin(t *testing.T) {
+	env := newReplayTestEnv(t)
+	playerUID := uuid.Must(uuid.NewV4())
+	playerSID := uuid.Must(uuid.NewV4())
+	session := env.newTestSession("solo_player", playerUID, playerSID)
+
+	// SendEvr will fail on marshal/send (no websocket) but the hook fires
+	// before any of that. Call the hook directly to be safe.
+	testMessages := []evr.Message{
+		evr.NewSTcpConnectionUnrequireEvent(),
+	}
+	session.sendEvrHook(testMessages)
+
+	captured := env.getCapturedMessages(playerSID)
+	require.Len(t, captured, 1, "Expected exactly 1 captured message")
+	assert.IsType(t, &evr.STcpConnectionUnrequireEvent{}, captured[0])
+}
+
+// TestPipelineReplay_FindReservation_SoloNoParty verifies that findReservation
+// returns false for a solo player (no lobby group / no leader).
+func TestPipelineReplay_FindReservation_SoloNoParty(t *testing.T) {
+	env := newReplayTestEnv(t)
+	playerUID := uuid.Must(uuid.NewV4())
+	playerSID := uuid.Must(uuid.NewV4())
+	session := env.newTestSession("solo", playerUID, playerSID)
+
+	// No party group → findReservation should return (nil, false) because
+	// lobbyGroup.GetLeader() returns nil.
+	lobbyGroup := &LobbyGroup{ph: &PartyHandler{}}
+	matchID, found := env.pipeline.findReservation(context.Background(), zap.NewNop(), session, lobbyGroup)
+	assert.False(t, found, "Solo player should not find a reservation")
+	assert.True(t, matchID.IsNil(), "MatchID should be nil for solo player")
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2b: BigDuckII duo party follow — reservation-based convergence
+// ---------------------------------------------------------------------------
+
+// TestPipelineReplay_BigDuckII_FollowerNotStuck reproduces the bigduckii
+// infinite matchmaking bug and verifies the new reservation system prevents it.
+//
+// Setup:
+//   - Two players: player_A (follower/bigduckii) and player_B (leader/the_noodle_of_doom)
+//   - Both in party "code_noodle"
+//   - Both were in arena match (match-00001); leader has already transitioned to social
+//   - Leader's service stream points to a social lobby (match-00002)
+//   - Player_A's service stream still points to the arena match (stale — the bug trigger)
+//   - The social lobby has a reservation for player_A (created by leader's lobbyEntrantConnected)
+//
+// Test:
+//   1. findReservation for player_A finds the reservation in the social lobby
+//   2. isFollowerInActiveMatch reports whether the follower is "stuck" in arena
+//
+// Assert:
+//   - findReservation returns the social lobby match ID (not the arena match)
+//   - The follower would be directed to the social lobby via the reservation path
+//
+// Note: Full lobbyFind end-to-end is blocked by configureParty (needs party
+// registry) and lobbyAuthorize (needs GuildGroupRegistry). These are documented
+// blockers. The test exercises the critical code path (findReservation) that
+// prevents the infinite matchmaking loop.
+func TestPipelineReplay_BigDuckII_FollowerNotStuck(t *testing.T) {
+	env := newReplayTestEnv(t)
+
+	// Player identities — anonymized from production logs.
+	leaderUID := uuid.Must(uuid.NewV4())  // the_noodle_of_doom
+	leaderSID := uuid.Must(uuid.NewV4())
+	followerUID := uuid.Must(uuid.NewV4()) // bigduckii
+	followerSID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	_ = env.newTestSession("player_B", leaderUID, leaderSID)
+	followerSession := env.newTestSession("player_A", followerUID, followerSID)
+
+	// --- Tracker state ---
+
+	// Leader's service stream → social lobby (leader already transitioned).
+	env.tracker.Track(context.Background(), leaderSID,
+		PresenceStream{Mode: StreamModeService, Subject: leaderSID, Label: StreamLabelMatchService},
+		leaderUID,
+		PresenceMeta{Status: socialMatchID.String()},
+	)
+
+	// Follower's service stream → arena match (STALE — the bug trigger).
+	env.tracker.Track(context.Background(), followerSID,
+		PresenceStream{Mode: StreamModeService, Subject: followerSID, Label: StreamLabelMatchService},
+		followerUID,
+		PresenceMeta{Status: arenaMatchID.String()},
+	)
+
+	// --- Match registry ---
+
+	// Arena match: closed, both players listed.
+	arenaLabel := &MatchLabel{
+		ID:          arenaMatchID,
+		Open:        false,
+		Mode:        evr.ModeArenaPublic,
+		PlayerLimit: 8,
+		Players: []PlayerInfo{
+			{UserID: leaderUID.String(), SessionID: leaderSID.String()},
+			{UserID: followerUID.String(), SessionID: followerSID.String()},
+		},
+		GroupID: &groupID,
+	}
+	env.matchRegistry.SetMatch(arenaMatchID, arenaLabel)
+
+	// Social lobby: open, leader present, follower has a RESERVATION.
+	socialLabel := &MatchLabel{
+		ID:          socialMatchID,
+		Open:        true,
+		Mode:        evr.ModeSocialPublic,
+		PlayerLimit: 12,
+		Players: []PlayerInfo{
+			{UserID: leaderUID.String(), SessionID: leaderSID.String()},
+			{
+				UserID:        followerUID.String(),
+				SessionID:     followerSID.String(),
+				IsReservation: true, // Created by leader's lobbyEntrantConnected
+			},
+		},
+		GroupID: &groupID,
+	}
+	env.matchRegistry.SetMatch(socialMatchID, socialLabel)
+
+	// --- Party state ---
+	ph := &PartyHandler{members: NewPartyPresenceList(8)}
+	ph.leader = &PartyLeader{
+		UserPresence: &rtapi.UserPresence{
+			UserId:    leaderUID.String(),
+			SessionId: leaderSID.String(),
+			Username:  "player_B",
+		},
+		PresenceID: &PresenceID{SessionID: leaderSID, Node: "testnode"},
+	}
+	lobbyGroup := &LobbyGroup{ph: ph}
+
+	// --- Test: findReservation should find the reservation in the social lobby ---
+	reservationMatchID, found := env.pipeline.findReservation(
+		context.Background(), loggerForTest(t), followerSession, lobbyGroup)
+
+	require.True(t, found,
+		"findReservation should find the reservation in leader's social lobby")
+	assert.Equal(t, socialMatchID.UUID, reservationMatchID.UUID,
+		"Reservation should point to the social lobby, not the arena match")
+	assert.Equal(t, socialMatchID.Node, reservationMatchID.Node)
+
+	// --- Verify: isFollowerInActiveMatch would detect the stale arena match ---
+	// In the old code (before reservations), this check would fire and return nil
+	// from lobbyFind, leaving the player stuck. With reservations, findReservation
+	// runs BEFORE this check in lobbyFind (line 117 vs line 136), so the follower
+	// is directed to the social lobby before the active-match guard can block them.
+	inActiveMatch := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), loggerForTest(t), followerSession)
+	assert.True(t, inActiveMatch,
+		"isFollowerInActiveMatch should detect the stale arena match — this is the "+
+			"bug trigger that findReservation bypasses")
+}
+
+// TestPipelineReplay_BigDuckII_OldCode_WouldStuck verifies that WITHOUT the
+// reservation (simulating old code), the follower would get stuck. Set up the
+// same scenario as the BigDuckII test but with NO reservation in the social
+// lobby. The isFollowerInActiveMatch check should fire and return true,
+// documenting the old behavior that caused infinite matchmaking.
+func TestPipelineReplay_BigDuckII_OldCode_WouldStuck(t *testing.T) {
+	env := newReplayTestEnv(t)
+
+	leaderUID := uuid.Must(uuid.NewV4())
+	leaderSID := uuid.Must(uuid.NewV4())
+	followerUID := uuid.Must(uuid.NewV4())
+	followerSID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	_ = env.newTestSession("player_B", leaderUID, leaderSID)
+	followerSession := env.newTestSession("player_A", followerUID, followerSID)
+
+	// Leader's service stream → social lobby.
+	env.tracker.Track(context.Background(), leaderSID,
+		PresenceStream{Mode: StreamModeService, Subject: leaderSID, Label: StreamLabelMatchService},
+		leaderUID,
+		PresenceMeta{Status: socialMatchID.String()},
+	)
+
+	// Follower's service stream → arena match (stale).
+	env.tracker.Track(context.Background(), followerSID,
+		PresenceStream{Mode: StreamModeService, Subject: followerSID, Label: StreamLabelMatchService},
+		followerUID,
+		PresenceMeta{Status: arenaMatchID.String()},
+	)
+
+	// Arena match in registry.
+	env.matchRegistry.SetMatch(arenaMatchID, &MatchLabel{
+		ID:          arenaMatchID,
+		Open:        false,
+		Mode:        evr.ModeArenaPublic,
+		PlayerLimit: 8,
+		Players: []PlayerInfo{
+			{UserID: leaderUID.String(), SessionID: leaderSID.String()},
+			{UserID: followerUID.String(), SessionID: followerSID.String()},
+		},
+		GroupID: &groupID,
+	})
+
+	// Social lobby — NO reservation for follower (simulating old code).
+	env.matchRegistry.SetMatch(socialMatchID, &MatchLabel{
+		ID:          socialMatchID,
+		Open:        true,
+		Mode:        evr.ModeSocialPublic,
+		PlayerLimit: 12,
+		Players: []PlayerInfo{
+			{UserID: leaderUID.String(), SessionID: leaderSID.String()},
+			// No reservation for follower — old code behavior.
+		},
+		GroupID: &groupID,
+	})
+
+	// Party state.
+	ph := &PartyHandler{members: NewPartyPresenceList(8)}
+	ph.leader = &PartyLeader{
+		UserPresence: &rtapi.UserPresence{
+			UserId:    leaderUID.String(),
+			SessionId: leaderSID.String(),
+			Username:  "player_B",
+		},
+		PresenceID: &PresenceID{SessionID: leaderSID, Node: "testnode"},
+	}
+	lobbyGroup := &LobbyGroup{ph: ph}
+
+	// Without reservations, findReservation returns false.
+	_, found := env.pipeline.findReservation(
+		context.Background(), loggerForTest(t), followerSession, lobbyGroup)
+	assert.False(t, found,
+		"Without reservation, findReservation should return false (old code behavior)")
+
+	// The follower is stuck: isFollowerInActiveMatch sees the stale arena match
+	// and would return true, causing lobbyFind to return nil with no
+	// LobbySessionSuccess — the infinite matchmaking loop.
+	inActiveMatch := env.pipeline.isFollowerInActiveMatch(
+		context.Background(), loggerForTest(t), followerSession)
+	assert.True(t, inActiveMatch,
+		"OLD CODE BUG: isFollowerInActiveMatch returns true for stale arena match. "+
+			"Without findReservation running first, lobbyFind returns nil and the "+
+			"follower gets stuck in infinite matchmaking.")
+}
+
+// ---------------------------------------------------------------------------
+// Harness validation tests
+// ---------------------------------------------------------------------------
+
+// TestPipelineReplay_FindReservation_LeaderIsCallerSkips verifies that
+// findReservation correctly returns false when the caller IS the leader
+// (guards against self-follow).
+func TestPipelineReplay_FindReservation_LeaderIsCallerSkips(t *testing.T) {
+	env := newReplayTestEnv(t)
+
+	leaderUID := uuid.Must(uuid.NewV4())
+	leaderSID := uuid.Must(uuid.NewV4())
+
+	leaderSession := env.newTestSession("leader", leaderUID, leaderSID)
+
+	// Set up lobby group where the leader is the caller.
+	ph := &PartyHandler{
+		members: NewPartyPresenceList(8),
+	}
+	ph.leader = &PartyLeader{
+		UserPresence: &rtapi.UserPresence{
+			UserId:    leaderUID.String(),
+			SessionId: leaderSID.String(),
+			Username:  "leader",
+		},
+		PresenceID: &PresenceID{SessionID: leaderSID, Node: "testnode"},
+	}
+	lobbyGroup := &LobbyGroup{ph: ph}
+
+	matchID, found := env.pipeline.findReservation(context.Background(), zap.NewNop(), leaderSession, lobbyGroup)
+
+	assert.False(t, found, "Leader calling findReservation for self should return false")
+	assert.True(t, matchID.IsNil())
+}
+
+// TestPipelineReplay_MockRegistryJoinAttempt verifies that the mock match
+// registry's JoinAttempt implementation correctly records calls and returns
+// success, proving the harness is ready for end-to-end LobbyJoinEntrants
+// testing in future phases.
+func TestPipelineReplay_MockRegistryJoinAttempt(t *testing.T) {
+	registry := newMockReplayMatchRegistry()
+
+	matchUUID := uuid.Must(uuid.NewV4())
+	userID := uuid.Must(uuid.NewV4())
+	sessionID := uuid.Must(uuid.NewV4())
+
+	found, allowed, isNew, reason, labelStr, presences := registry.JoinAttempt(
+		context.Background(), matchUUID, "testnode",
+		userID, sessionID, "testuser",
+		0, nil, "", "", "", nil,
+	)
+
+	assert.True(t, found)
+	assert.True(t, allowed)
+	assert.True(t, isNew)
+	assert.Empty(t, reason)
+	assert.Equal(t, "{}", labelStr)
+	assert.Nil(t, presences)
+
+	attempts := registry.getJoinAttempts()
+	require.Len(t, attempts, 1)
+	assert.Equal(t, matchUUID, attempts[0].MatchID)
+	assert.Equal(t, userID, attempts[0].UserID)
+	assert.Equal(t, sessionID, attempts[0].SessionID)
+	assert.Equal(t, "testuser", attempts[0].Username)
+}

--- a/server/evr_logreplay_test.go
+++ b/server/evr_logreplay_test.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// replayFixture is the on-disk format for a lifecycle replay test case.
+type replayFixture struct {
+	Name        string              `json:"name"`
+	Description string              `json:"description"`
+	SourceLog   string              `json:"source_log"`
+	TimeWindow  string              `json:"time_window"`
+	Transitions []fixtureTransition `json:"transitions"`
+}
+
+// fixtureTransition is one state change inside a replay fixture.
+type fixtureTransition struct {
+	Ts     string `json:"ts"`
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Reason string `json:"reason"`
+	Legal  bool   `json:"legal"`
+}
+
+// statesByName maps human-readable state names to MatchLifecycleState values.
+// Built once; used by parseMatchLifecycleState.
+var statesByName = func() map[string]MatchLifecycleState {
+	m := make(map[string]MatchLifecycleState, int(matchLifecycleStateCount))
+	for i := MatchLifecycleState(0); i < matchLifecycleStateCount; i++ {
+		m[stateNames[i]] = i
+	}
+	return m
+}()
+
+// parseMatchLifecycleState converts a state name string to its typed value.
+func parseMatchLifecycleState(s string) (MatchLifecycleState, error) {
+	st, ok := statesByName[s]
+	if !ok {
+		return 0, fmt.Errorf("unknown MatchLifecycleState %q", s)
+	}
+	return st, nil
+}
+
+// loadReplayFixture reads and unmarshals a replay fixture from testdata.
+func loadReplayFixture(t *testing.T, path string) replayFixture {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "reading fixture %s", path)
+	var fix replayFixture
+	require.NoError(t, json.Unmarshal(data, &fix), "unmarshaling fixture %s", path)
+	require.NotEmpty(t, fix.Transitions, "fixture %s has no transitions", path)
+	return fix
+}
+
+func TestReplay_ReconnectSocialLobbyJoin(t *testing.T) {
+	fix := loadReplayFixture(t, "testdata/replay/reconnect-social-lobby-join.json")
+	logger := loggerForTest(t)
+	lc := NewPlayerMatchLifecycle(logger)
+
+	// Replay every transition from the fixture.
+	for i, tr := range fix.Transitions {
+		toState, err := parseMatchLifecycleState(tr.To)
+		require.NoError(t, err, "transition %d: bad To state", i)
+		require.NoError(t, lc.TransitionTo(toState, tr.Reason), "transition %d failed", i)
+	}
+
+	// Compare recorded history against fixture.
+	history := lc.History()
+	require.Len(t, history, len(fix.Transitions), "history length mismatch")
+
+	for i, want := range fix.Transitions {
+		got := history[i]
+
+		wantFrom, err := parseMatchLifecycleState(want.From)
+		require.NoError(t, err, "transition %d: bad From state in fixture", i)
+		wantTo, err := parseMatchLifecycleState(want.To)
+		require.NoError(t, err, "transition %d: bad To state in fixture", i)
+
+		require.Equal(t, wantFrom, got.From,
+			"transition %d: From: want %s, got %s", i, wantFrom, got.From)
+		require.Equal(t, wantTo, got.To,
+			"transition %d: To: want %s, got %s", i, wantTo, got.To)
+		require.Equal(t, want.Reason, got.Reason,
+			"transition %d: Reason mismatch", i)
+		require.Equal(t, want.Legal, got.Legal,
+			"transition %d: Legal: want %v, got %v (from %s to %s)",
+			i, want.Legal, got.Legal, want.From, want.To)
+	}
+}
+
+// replayFixtureTest is a shared helper that loads a fixture, replays all
+// transitions through a fresh PlayerMatchLifecycle, and asserts that the
+// recorded history matches the fixture exactly (From, To, Reason, Legal).
+func replayFixtureTest(t *testing.T, path string) {
+	t.Helper()
+	fix := loadReplayFixture(t, path)
+	logger := loggerForTest(t)
+	lc := NewPlayerMatchLifecycle(logger)
+
+	for i, tr := range fix.Transitions {
+		toState, err := parseMatchLifecycleState(tr.To)
+		require.NoError(t, err, "transition %d: bad To state", i)
+		require.NoError(t, lc.TransitionTo(toState, tr.Reason), "transition %d failed", i)
+	}
+
+	history := lc.History()
+	require.Len(t, history, len(fix.Transitions), "history length mismatch")
+
+	for i, want := range fix.Transitions {
+		got := history[i]
+
+		wantFrom, err := parseMatchLifecycleState(want.From)
+		require.NoError(t, err, "transition %d: bad From state in fixture", i)
+		wantTo, err := parseMatchLifecycleState(want.To)
+		require.NoError(t, err, "transition %d: bad To state in fixture", i)
+
+		require.Equal(t, wantFrom, got.From,
+			"transition %d: From: want %s, got %s", i, wantFrom, got.From)
+		require.Equal(t, wantTo, got.To,
+			"transition %d: To: want %s, got %s", i, wantTo, got.To)
+		require.Equal(t, want.Reason, got.Reason,
+			"transition %d: Reason mismatch", i)
+		require.Equal(t, want.Legal, got.Legal,
+			"transition %d: Legal: want %v, got %v (from %s to %s)",
+			i, want.Legal, got.Legal, want.From, want.To)
+	}
+}
+
+func TestReplay_StaleStreamInfiniteMatchmaking(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/stale-stream-infinite-matchmaking.json")
+}
+
+func TestReplay_CrashRecoveryRejoin(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/crash-recovery-rejoin.json")
+}
+
+func TestReplay_FullArenaLifecycle(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/full-arena-lifecycle.json")
+}
+
+func TestReplay_PartyChurnRepeatedCycles(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/party-churn-repeated-cycles.json")
+}
+
+func TestReplay_StaleSkipMatchmakingLoop(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/stale-skip-matchmaking-loop.json")
+}
+
+func TestReplay_HealthyPartyFollow(t *testing.T) {
+	replayFixtureTest(t, "testdata/replay/healthy-party-follow.json")
+}
+
+func TestLifecycleTransition_LegalityCheck(t *testing.T) {
+	fix := loadReplayFixture(t, "testdata/replay/reconnect-social-lobby-join.json")
+
+	for i, tr := range fix.Transitions {
+		from, err := parseMatchLifecycleState(tr.From)
+		require.NoError(t, err, "transition %d: bad From state", i)
+		to, err := parseMatchLifecycleState(tr.To)
+		require.NoError(t, err, "transition %d: bad To state", i)
+
+		t.Run(fmt.Sprintf("%s_to_%s", tr.From, tr.To), func(t *testing.T) {
+			t.Parallel()
+			got := isLegalTransition(from, to)
+			require.Equal(t, tr.Legal, got,
+				"isLegalTransition(%s, %s): want %v, got %v", tr.From, tr.To, tr.Legal, got)
+		})
+	}
+}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -828,10 +828,13 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			}
 
 			// Observer: log lifecycle transition for player leaving match.
+			// Only apply match-leave transitions if the player is still InMatch.
+			// Stale leave events (player already advanced to Matchmaking,
+			// SocialReady, etc.) should be ignored — the player has moved on.
 			if _nkLocal, ok := nk.(*RuntimeGoNakamaModule); ok {
 				if s := _nkLocal.sessionRegistry.Get(uuid.FromStringOrNil(p.GetSessionId())); s != nil {
 					if ws, ok := s.(*sessionWS); ok {
-						if lc := getMatchLifecycle(ws); lc != nil {
+						if lc := getMatchLifecycle(ws); lc != nil && lc.State() == StateInMatch {
 							if hasReconnectReservation {
 								lc.Transition(StateCrashed, "disconnected")
 							} else if p.GetReason() == runtime.PresenceReasonLeave || state.GameState.IsMatchOver() {
@@ -841,6 +844,54 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 							}
 						}
 					}
+				}
+			}
+
+			// Clear party reservations based on whether the leaving player is the leader.
+			// Leader leaves -> clear ALL party reservations (followers should not join
+			// a match the leader has left).
+			// Non-leader leaves -> clear only THEIR OWN reservation (other followers'
+			// reservations remain valid because the leader is still present).
+			if mp.PartyID != uuid.Nil {
+				isLeader := false
+				if _nk, ok := nk.(*RuntimeGoNakamaModule); ok {
+					if ph, ok := _nk.partyRegistry.Get(mp.PartyID); ok {
+						ph.RLock()
+						if ph.leader != nil {
+							isLeader = ph.leader.UserPresence.SessionId == mp.GetSessionId()
+						}
+						ph.RUnlock()
+					}
+					// If partyRegistry.Get fails (party already disbanded), fall through
+					// to the non-leader path: clear only this player's own reservation.
+					// This is the safe default -- clearing all reservations without
+					// confirming leadership could delete valid reservations for other
+					// members who are still expected.
+				}
+
+				cleared := 0
+				if isLeader {
+					// Leader is leaving: clear ALL reservations for this party.
+					for sid, r := range state.reservationMap {
+						if r.Presence.PartyID == mp.PartyID {
+							delete(state.reservationMap, sid)
+							cleared++
+						}
+					}
+				} else {
+					// Non-leader is leaving: clear only THEIR OWN reservation.
+					if _, exists := state.reservationMap[mp.GetSessionId()]; exists {
+						delete(state.reservationMap, mp.GetSessionId())
+						cleared = 1
+					}
+				}
+				if cleared > 0 {
+					state.rebuildCache()
+					logger.WithFields(map[string]any{
+						"party_id":  mp.PartyID.String(),
+						"is_leader": isLeader,
+						"cleared":   cleared,
+					}).Debug("Cleared party reservations for departing player")
 				}
 			}
 
@@ -1840,6 +1891,58 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 				}
 			}
 		}
+
+	// NOTE: These cases intentionally do NOT return early.
+	// They fall through to updateLabel and return
+	// SignalResponse{Success: true}, following the same pattern as
+	// SignalPrepareSession, SignalLockSession, and SignalPlayerUpdate.
+	case SignalCreatePartyReservations:
+		var payload SignalCreatePartyReservationsPayload
+		if err := json.Unmarshal(signal.Payload, &payload); err != nil {
+			return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal create party reservations: %v", err)}.String()
+		}
+		created := 0
+		for _, member := range payload.Members {
+			sid := member.GetSessionId()
+			if _, exists := state.presenceMap[sid]; exists {
+				continue // already in match
+			}
+			if _, exists := state.reservationMap[sid]; exists {
+				continue // already reserved
+			}
+			state.reservationMap[sid] = &slotReservation{
+				Presence: member,
+				Expiry:   time.Now().Add(5 * time.Minute),
+			}
+			created++
+		}
+		if created > 0 {
+			state.rebuildCache()
+		}
+		logger.WithFields(map[string]any{
+			"requested": len(payload.Members),
+			"created":   created,
+		}).Info("Created party reservations via signal")
+
+	case SignalClearPartyReservations:
+		var payload SignalClearPartyReservationsPayload
+		if err := json.Unmarshal(signal.Payload, &payload); err != nil {
+			return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal clear party reservations: %v", err)}.String()
+		}
+		cleared := 0
+		for sid, r := range state.reservationMap {
+			if r.Presence.PartyID == payload.PartyID {
+				delete(state.reservationMap, sid)
+				cleared++
+			}
+		}
+		if cleared > 0 {
+			state.rebuildCache()
+		}
+		logger.WithFields(map[string]any{
+			"party_id": payload.PartyID.String(),
+			"cleared":  cleared,
+		}).Debug("Cleared party reservations via signal")
 
 	default:
 		logger.WithField("op_code", signal.OpCode).Warn("Unknown signal")

--- a/server/evr_match_lifecycle.go
+++ b/server/evr_match_lifecycle.go
@@ -85,38 +85,78 @@ func (s MatchLifecycleState) IsTerminal() bool {
 // illegal transitions are logged as warnings but still applied.
 var legalTransitions = map[MatchLifecycleState]map[MatchLifecycleState]bool{
 	StateIdle: {
-		StateSocialConverging: true,
+		StateSocialConverging: true, // Party follower heading to leader's social lobby.
+		StateSocialReady:      true, // Solo player joined social lobby directly.
+		StateHolding:          true, // Solo/follower sent LobbyFindSessionRequest.
+		StateMatchmaking:      true, // Solo/leader submitted ticket from menu.
+		StateJoining:          true, // Direct match join (echo taxi / reconnect).
+		StateIdle:             true, // Reconnect failed (idempotent).
 	},
 	StateSocialConverging: {
-		StateSocialReady: true,
+		StateSocialReady: true, // Arrived at leader's social lobby.
 	},
 	StateSocialReady: {
 		StateHolding:     true, // Non-leader sent LobbyFindSessionRequest.
 		StateMatchmaking: true, // Leader submits ticket.
+		StateJoining:     true, // Match found, joining (direct placement).
+		StateInMatch:     true, // Followed leader to match / reconnect.
 		StateIdle:        true, // Left party.
+		StateSocialReady: true, // Lobby switch or join-failed regroup.
+		StateCrashed:     true, // Disconnect from social (rare).
 	},
 	StateHolding: {
 		StateMatchmaking: true, // Leader's ticket includes this member.
-		StateSocialReady: true, // Matchmaking cancelled.
+		StateSocialReady: true, // Matchmaking cancelled / leader in arena.
+		StateJoining:     true, // Match found while in holding (skipped Matchmaking).
+		StateInMatch:     true, // Followed leader directly (rare).
+		StateHolding:     true, // Ticket cancelled for late arrival, rebuilding.
+		StateReturning:   true, // Stale match-end during holding.
 	},
 	StateMatchmaking: {
 		StateJoining:     true, // Match found, join started.
-		StateSocialReady: true, // Ticket cancelled (late arrival rebuild).
+		StateSocialReady: true, // Ticket cancelled / join failed.
+		StateMatchmaking: true, // Ticket rebuild (late arrival, party change).
+		StateHolding:     true, // Re-entered holding (ticket structure change).
+		StateReturning:   true, // Stale match-end (see §5B — add guard).
+		StateCrashed:     true, // Disconnect while on ticket.
 	},
 	StateJoining: {
 		StateInMatch:     true, // Connected to game server.
 		StateSocialReady: true, // Join failed, return to social.
+		StateReturning:   true, // Match ended during join window.
+		StateCrashed:     true, // Disconnect during join.
+		StateMatchmaking: true, // Ticket placed during join window.
+		StateJoining:     true, // Duplicate match-found (idempotent).
 	},
 	StateInMatch: {
 		StateReturning: true, // Match ended naturally.
 		StateCrashed:   true, // Client disconnected.
+		// Below are stale-state transitions — should be eliminated by code
+		// guards but listed for observer-mode tolerance during transition:
+		StateSocialReady: true, // Joined social while stale InMatch.
+		StateMatchmaking: true, // Ticket submitted while stale InMatch.
+		StateHolding:     true, // Holding entered while stale InMatch.
+		StateJoining:     true, // Match found while stale InMatch.
+		StateIdle:        true, // Reconnect failed (rare).
 	},
 	StateReturning: {
 		StateSocialReady: true, // Back in social lobby.
+		StateMatchmaking: true, // Fast requeue — leader submitted ticket.
+		StateHolding:     true, // Fast requeue — follower waiting for ticket.
+		StateJoining:     true, // Match found during return window.
+		StateReturning:   true, // Duplicate match-end (idempotent).
+		StateCrashed:     true, // Disconnect during return.
+		StateIdle:        true, // Reconnect failed.
 	},
 	StateCrashed: {
-		StateInMatch: true, // Reconnected within 27s.
-		StateIdle:    true, // Reconnect failed, reservation expired.
+		StateInMatch:     true, // Reconnected within 27s.
+		StateIdle:        true, // Reconnect failed, reservation expired.
+		StateJoining:     true, // Match found while reservation active.
+		StateReturning:   true, // Match ends while reservation active.
+		StateMatchmaking: true, // Picked up by new ticket.
+		StateSocialReady: true, // Joined social (gave up on reconnect).
+		StateHolding:     true, // Re-entered party flow.
+		StateCrashed:     true, // Duplicate crash event.
 	},
 }
 

--- a/server/evr_match_signals.go
+++ b/server/evr_match_signals.go
@@ -26,6 +26,8 @@ const (
 	SignalShutdown
 	SignalPlayerUpdate
 	SignalKickEntrants
+	SignalCreatePartyReservations
+	SignalClearPartyReservations
 )
 
 type SignalEnvelope struct {
@@ -102,6 +104,18 @@ type SignalReserveSlotsPayload struct {
 	SessionIDs    []string
 	RoleAlignment int
 	ExpiryTime    time.Time
+}
+
+// SignalCreatePartyReservationsPayload carries the list of party members
+// who need slot reservations in the match.
+type SignalCreatePartyReservationsPayload struct {
+	Members []*EvrMatchPresence `json:"members"`
+}
+
+// SignalClearPartyReservationsPayload carries the party ID whose
+// reservations should be removed from the match.
+type SignalClearPartyReservationsPayload struct {
+	PartyID uuid.UUID `json:"party_id"`
 }
 
 // SignalMatch is a helper function to send a signal to a match.

--- a/server/evr_pipeline_lobby.go
+++ b/server/evr_pipeline_lobby.go
@@ -30,6 +30,14 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 	}
 
 	matchID, _ := NewMatchID(lobbyUUID, p.node)
+	matchIDStr := matchID.String()
+
+	// Fetch the match label once before the entrant loop — matchID is the
+	// same for all entrants so there's no reason to call MatchLabelByID per-entrant.
+	matchLabel, matchLabelErr := MatchLabelByID(session.Context(), p.nk, matchID)
+	if matchLabelErr != nil {
+		baseLogger.Warn("Failed to get match label for guild group stream", zap.Error(matchLabelErr))
+	}
 
 	for _, entrantID := range message.EntrantIds {
 		logger := baseLogger.With(zap.String("entrant_id", entrantID))
@@ -50,9 +58,22 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		}
 
 		ctx := s.Context()
-		// Update tracker with the entrant's presence.
-		for _, subject := range [...]uuid.UUID{presence.SessionID, presence.UserID, presence.EvrID.UUID()} {
-			session.tracker.Update(ctx, s.ID(), PresenceStream{Mode: StreamModeService, Subject: subject, Label: StreamLabelMatchService}, s.UserID(), PresenceMeta{Format: s.Format(), Hidden: false, Status: matchID.String()})
+
+		// Update service streams — this is the authoritative "player is in this match" state.
+		// All 4 subjects: SessionID, LoginSessionID, UserID, EvrID.
+		for _, subject := range [...]uuid.UUID{presence.SessionID, presence.LoginSessionID, presence.UserID, presence.EvrID.UUID()} {
+			if !session.tracker.Update(ctx, s.ID(), PresenceStream{Mode: StreamModeService, Subject: subject, Label: StreamLabelMatchService}, s.UserID(), PresenceMeta{Format: s.Format(), Hidden: false, Status: matchIDStr}) {
+				logger.Warn("Failed to update service stream for entrant",
+					zap.String("subject", subject.String()),
+					zap.String("entrant_uid", presence.GetUserId()))
+			}
+		}
+
+		// Update guild group stream and leave matchmaking streams.
+		if matchLabel != nil {
+			guildGroupStream := PresenceStream{Mode: StreamModeGuildGroup, Subject: matchLabel.GetGroupID(), Label: matchLabel.Mode.String()}
+			session.tracker.Update(ctx, s.ID(), guildGroupStream, s.UserID(), PresenceMeta{Format: s.Format(), Username: s.Username(), Hidden: false, Status: matchIDStr})
+			session.tracker.UntrackLocalByModes(s.ID(), map[uint8]struct{}{StreamModeMatchmaking: {}, StreamModeGuildGroup: {}}, guildGroupStream)
 		}
 
 		// Trigger the MatchJoin event.
@@ -72,11 +93,29 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		// Social lobbies already transition to StateSocialReady in LobbyJoinEntrants.
 		if ws, ok := s.(*sessionWS); ok {
 			if lc := getMatchLifecycle(ws); lc != nil && lc.State() == StateJoining {
-				lc.TransitionTo(StateInMatch, "joined match", WithMatchID(matchID.String()))
+				lc.TransitionTo(StateInMatch, "joined match", WithMatchID(matchIDStr))
 			}
 		}
 
 		acceptedIDs = append(acceptedIDs, entrantID)
+
+		// Create party reservations for followers when the leader connects.
+		// NOTE: `s` is the player's session (line 45), NOT `session` (the game server).
+		if params, ok := LoadParams(s.Context()); ok && params.currentPartyID != uuid.Nil {
+			// Check if this player is the party leader via the party registry.
+			if ph, ok := p.nk.partyRegistry.Get(params.currentPartyID); ok {
+				ph.RLock()
+				leader := ph.leader
+				ph.RUnlock()
+				if leader != nil && leader.UserPresence.SessionId == presence.GetSessionId() {
+					// This entrant is the party leader. Dispatch reservation
+					// creation asynchronously. Use context.WithoutCancel so
+					// reservation creation completes even if the player
+					// disconnects mid-creation.
+					go p.createPartyReservations(context.WithoutCancel(s.Context()), logger, matchID, uuid.FromStringOrNil(presence.GetSessionId()), params.currentPartyID)
+				}
+			}
+		}
 	}
 
 	messages := make([]evr.Message, 0, 4)
@@ -128,6 +167,91 @@ func (p *EvrPipeline) lobbyEntrantConnected(logger *zap.Logger, session *session
 		messages = append(messages, evr.NewGameServerEntrantRejected(evr.PlayerRejectionReasonBadRequest, uuids...))
 	}
 	return session.SendEvr(messages...)
+}
+
+// createPartyReservations creates slot reservations in the given match for
+// all party members who are not already in the match. Called from
+// lobbyEntrantConnected when the connected entrant is the party leader.
+//
+// IMPORTANT: This function is dispatched as a goroutine. The caller MUST
+// pass context.WithoutCancel(s.Context()) so that reservation creation
+// completes even if the triggering player session disconnects. Using the
+// raw session context would cancel the goroutine mid-creation if the
+// player disconnects, leaving some members with reservations and others
+// without.
+func (p *EvrPipeline) createPartyReservations(ctx context.Context, logger *zap.Logger, matchID MatchID, leaderSessionID uuid.UUID, partyID uuid.UUID) {
+	// Verify the party still exists and the leader is still a member.
+	// The partyID was captured at lobbyEntrantConnected time and may be
+	// stale if the player left the party between then and now.
+	ph, ok := p.nk.partyRegistry.Get(partyID)
+	if !ok {
+		logger.Debug("Party no longer exists, skipping reservation creation",
+			zap.String("party_id", partyID.String()))
+		return
+	}
+	leaderStillMember := false
+	for _, member := range ph.members.List() {
+		if member.PresenceID != nil && member.PresenceID.SessionID == leaderSessionID {
+			leaderStillMember = true
+			break
+		}
+	}
+	if !leaderStillMember {
+		logger.Debug("Leader no longer in party, skipping reservation creation",
+			zap.String("party_id", partyID.String()),
+			zap.String("leader_sid", leaderSessionID.String()))
+		return
+	}
+
+	// List party members via the party stream.
+	stream := PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: p.node}
+	presences := p.nk.tracker.ListByStream(stream, true, true)
+
+	members := make([]*EvrMatchPresence, 0, len(presences))
+	for _, pp := range presences {
+		if pp.ID.SessionID == leaderSessionID {
+			continue // skip the leader
+		}
+		memberSession := p.nk.sessionRegistry.Get(pp.ID.SessionID)
+		if memberSession == nil {
+			continue // skip dead sessions (BAC-013)
+		}
+
+		member := &EvrMatchPresence{
+			SessionID:     pp.ID.SessionID,
+			UserID:        pp.UserID,
+			Username:      memberSession.Username(),
+			PartyID:       partyID,
+			RoleAlignment: evr.TeamSocial,
+			Node:          p.node,
+		}
+
+		// Load additional fields from session params if available.
+		if memberParams, ok := LoadParams(memberSession.Context()); ok {
+			member.EvrID = memberParams.xpID
+			member.DisplayName = memberParams.profile.DisplayName()
+		}
+
+		members = append(members, member)
+	}
+
+	if len(members) == 0 {
+		return
+	}
+
+	payload := SignalCreatePartyReservationsPayload{Members: members}
+	if _, err := SignalMatch(ctx, p.nk, matchID, SignalCreatePartyReservations, payload); err != nil {
+		logger.Warn("Failed to signal match for party reservations",
+			zap.Error(err),
+			zap.String("match_id", matchID.String()),
+			zap.String("party_id", partyID.String()))
+		return
+	}
+
+	logger.Info("Created party reservations",
+		zap.Int("members", len(members)),
+		zap.String("match_id", matchID.String()),
+		zap.String("party_id", partyID.String()))
 }
 
 func (p *EvrPipeline) lobbyEntrantsRemove(logger *zap.Logger, session *sessionWS, in *rtapi.Envelope) error {

--- a/server/evr_pipeline_matchmaker.go
+++ b/server/evr_pipeline_matchmaker.go
@@ -229,13 +229,60 @@ func LeavePartyStream(s *sessionWS) {
 }
 
 // LobbyPendingSessionCancel is a message from the server to the client, indicating that the user wishes to cancel matchmaking.
+// When a party member cancels, ALL party members' matchmaking is cancelled and any active ticket is removed.
+// Cancel does NOT remove members from the party (BAC-022).
 func (p *EvrPipeline) lobbyPendingSessionCancel(ctx context.Context, logger *zap.Logger, session *sessionWS, in evr.Message) error {
-	// Look up the matching session.
-
-	err := LeaveMatchmakingStream(logger, session)
-	if err != nil {
-		logger.Warn("Failed to leave lobby group stream", zap.Error(err))
+	// Always leave the caller's matchmaking stream first.
+	if err := LeaveMatchmakingStream(logger, session); err != nil {
+		logger.Warn("Failed to leave matchmaking stream", zap.Error(err))
 	}
+
+	// If the player is in a party, cancel matchmaking for ALL members.
+	// Per spec: "Any member cancels matchmaking -> cancel ALL members'
+	// matchmaking. Remove the ticket. No partial tickets."
+	params, ok := LoadParams(session.Context())
+	if !ok || params.currentPartyID == uuid.Nil {
+		return nil // Solo player -- already cancelled above.
+	}
+
+	// Remove any active matchmaking tickets for the party.
+	partyID := params.currentPartyID
+	if ph, ok := p.nk.partyRegistry.Get(partyID); ok {
+		lobbyGroup := &LobbyGroup{ph: ph}
+		if err := lobbyGroup.MatchmakerRemoveAll(); err != nil {
+			logger.Warn("Failed to remove party matchmaking tickets on cancel",
+				zap.String("party_id", partyID.String()),
+				zap.Error(err))
+		}
+	}
+
+	// Close all party members' matchmaking streams so their
+	// monitorMatchmakingStream goroutines cancel their lobbyFind contexts.
+	partyStream := PresenceStream{Mode: StreamModeParty, Subject: partyID, Label: p.node}
+	partyPresences := p.nk.tracker.ListByStream(partyStream, true, true)
+	for _, pp := range partyPresences {
+		if pp.ID.SessionID == session.id {
+			continue // Already cancelled above.
+		}
+		memberSession := p.nk.sessionRegistry.Get(pp.ID.SessionID)
+		if memberSession == nil {
+			continue
+		}
+		ws, ok := memberSession.(*sessionWS)
+		if !ok {
+			continue
+		}
+		if err := LeaveMatchmakingStream(logger, ws); err != nil {
+			logger.Warn("Failed to cancel party member's matchmaking stream",
+				zap.String("member_sid", pp.ID.SessionID.String()),
+				zap.Error(err))
+		}
+	}
+
+	logger.Debug("Cancelled matchmaking for entire party",
+		zap.String("party_id", partyID.String()),
+		zap.Int("members_cancelled", len(partyPresences)))
+
 	return nil
 }
 

--- a/server/evr_pipeline_party.go
+++ b/server/evr_pipeline_party.go
@@ -312,6 +312,9 @@ func (p *EvrPipeline) snsPartyJoinRequest(ctx context.Context, logger *zap.Logge
 		MemberID: params.xpID.AccountId,
 	})
 
+	// Create reservation for the new member if leader is in a social match.
+	go p.createReservationForNewPartyMember(context.WithoutCancel(ctx), logger, session, partyUUID)
+
 	return SendEVRMessages(session, false, &evr.SNSPartyJoinSuccess{
 		PartyID: msg.PartyID,
 		OwnerID: ownerAccountID,
@@ -333,6 +336,10 @@ func (p *EvrPipeline) snsPartyLeaveRequest(ctx context.Context, logger *zap.Logg
 		PartyID:  snsID,
 		MemberID: params.xpID.AccountId,
 	})
+
+	// Clear any reservation for the departing member.
+	// Must run BEFORE snsPartyLeaveCleanup, which clears params.currentPartyID.
+	p.clearMemberReservation(ctx, logger, session, partyUUID)
 
 	// Untrack triggers partyLeaveListener -> PartyHandler.Leave().
 	p.snsPartyLeaveCleanup(ctx, logger, session, params)
@@ -464,6 +471,13 @@ func (p *EvrPipeline) snsPartyKickRequest(ctx context.Context, logger *zap.Logge
 		KickID:  targetAccountID,
 	})
 
+	// Clear any reservation for the kicked member.
+	if kickedSession := p.nk.sessionRegistry.Get(uuid.FromStringOrNil(targetPresence.SessionId)); kickedSession != nil {
+		if ws, ok := kickedSession.(*sessionWS); ok {
+			p.clearMemberReservation(ctx, logger, ws, params.currentPartyID)
+		}
+	}
+
 	return SendEVRMessages(session, false, &evr.SNSPartyKickSuccess{})
 }
 
@@ -502,6 +516,41 @@ func (p *EvrPipeline) snsPartyPassOwnershipRequest(ctx context.Context, logger *
 		PartyID:    snsID,
 		NewOwnerID: targetAccountID,
 	})
+
+	// Clear old leader's reservations and cancel tickets.
+	// The old leader's match may still have reservations for party members.
+	oldLeaderStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: session.id,
+		Label:   StreamLabelMatchService,
+	}
+	if oldLeaderPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(session.id, oldLeaderStream, session.userID); oldLeaderPresence != nil {
+		oldMatchID := MatchIDFromStringOrNil(oldLeaderPresence.GetStatus())
+		if !oldMatchID.IsNil() {
+			payload := SignalClearPartyReservationsPayload{PartyID: params.currentPartyID}
+			if _, err := SignalMatch(ctx, p.nk, oldMatchID, SignalClearPartyReservations, payload); err != nil {
+				logger.Warn("Failed to clear old leader's reservations", zap.Error(err))
+			}
+		}
+	}
+	// New leader may need to create reservations in their current match.
+	if newLeaderSession := p.nk.sessionRegistry.Get(uuid.FromStringOrNil(targetPresence.SessionId)); newLeaderSession != nil {
+		if ws, ok := newLeaderSession.(*sessionWS); ok {
+			newLeaderStream := PresenceStream{
+				Mode:    StreamModeService,
+				Subject: ws.id,
+				Label:   StreamLabelMatchService,
+			}
+			if newPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(ws.id, newLeaderStream, ws.userID); newPresence != nil {
+				newMatchID := MatchIDFromStringOrNil(newPresence.GetStatus())
+				if !newMatchID.IsNil() {
+					if label, err := MatchLabelByID(ctx, p.nk, newMatchID); err == nil && label != nil && label.IsSocial() {
+						go p.createPartyReservations(context.WithoutCancel(ctx), logger, newMatchID, ws.id, params.currentPartyID)
+					}
+				}
+			}
+		}
+	}
 
 	return SendEVRMessages(session, false, &evr.SNSPartyPassSuccess{})
 }
@@ -611,6 +660,9 @@ func (p *EvrPipeline) snsPartyRespondToInviteRequest(ctx context.Context, logger
 		MemberID: params.xpID.AccountId,
 	})
 
+	// Create reservation for the new member if leader is in a social match.
+	go p.createReservationForNewPartyMember(context.WithoutCancel(ctx), logger, session, partyUUID)
+
 	return SendEVRMessages(session, false, &evr.SNSPartyJoinSuccess{
 		PartyID: snsPartyID,
 		OwnerID: ownerAccountID,
@@ -683,4 +735,137 @@ func (p *EvrPipeline) findPartyMemberPresence(partyUUID uuid.UUID, targetUserID 
 		}
 	}
 	return nil
+}
+
+// createReservationForNewPartyMember checks if the party leader is currently
+// in a social match and, if so, creates a reservation for the new member.
+// Called after a successful party join or invite acceptance.
+func (p *EvrPipeline) createReservationForNewPartyMember(ctx context.Context, logger *zap.Logger, memberSession *sessionWS, partyID uuid.UUID) {
+	// Find the party leader.
+	ph, ok := p.nk.partyRegistry.Get(partyID)
+	if !ok {
+		return
+	}
+	ph.RLock()
+	leader := ph.leader
+	ph.RUnlock()
+	if leader == nil {
+		return
+	}
+	leaderSessionID := uuid.FromStringOrNil(leader.UserPresence.SessionId)
+	leaderUserID := uuid.FromStringOrNil(leader.UserPresence.UserId)
+	if leaderSessionID == memberSession.id {
+		return // new member IS the leader
+	}
+
+	// Look up leader's current match.
+	leaderStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: leaderSessionID,
+		Label:   StreamLabelMatchService,
+	}
+	leaderPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+	if leaderPresence == nil {
+		return // leader not in a match
+	}
+	leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus())
+	if leaderMatchID.IsNil() {
+		return
+	}
+
+	// Check if leader is in a social match (skip arena/combat -- BAC-010).
+	label, err := MatchLabelByID(ctx, p.nk, leaderMatchID)
+	if err != nil || label == nil || !label.IsSocial() {
+		return
+	}
+
+	// Build reservation presence for the new member.
+	memberParams, ok := LoadParams(memberSession.Context())
+	if !ok {
+		logger.Warn("Failed to load params for new party member reservation")
+		return
+	}
+
+	member := &EvrMatchPresence{
+		SessionID:     memberSession.id,
+		UserID:        memberSession.userID,
+		Username:      memberSession.Username(),
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		Node:          p.node,
+		EvrID:         memberParams.xpID,
+		DisplayName:   memberParams.profile.DisplayName(),
+	}
+
+	// Signal match to create reservation.
+	payload := SignalCreatePartyReservationsPayload{Members: []*EvrMatchPresence{member}}
+	if _, err := SignalMatch(ctx, p.nk, leaderMatchID, SignalCreatePartyReservations, payload); err != nil {
+		logger.Warn("Failed to signal match for new party member reservation", zap.Error(err))
+		return
+	}
+
+	logger.Info("Created reservation for new party member",
+		zap.String("member_sid", memberSession.id.String()),
+		zap.String("leader_match_id", leaderMatchID.String()))
+}
+
+// clearMemberReservation looks up the party leader's current match and
+// signals it to delete the departing member's reservation slot. Called
+// when a member leaves or is kicked from the party.
+//
+// The partyID parameter must be captured BEFORE snsPartyLeaveCleanup
+// (which clears params.currentPartyID to uuid.Nil).
+func (p *EvrPipeline) clearMemberReservation(ctx context.Context, logger *zap.Logger, session *sessionWS, partyID uuid.UUID) {
+	// Find the party leader's current match.
+	ph, ok := p.nk.partyRegistry.Get(partyID)
+	if !ok {
+		return // party already disbanded
+	}
+	ph.RLock()
+	leader := ph.leader
+	ph.RUnlock()
+	if leader == nil {
+		return
+	}
+	leaderSessionID := uuid.FromStringOrNil(leader.UserPresence.SessionId)
+	leaderUserID := uuid.FromStringOrNil(leader.UserPresence.UserId)
+
+	leaderStream := PresenceStream{
+		Mode:    StreamModeService,
+		Subject: leaderSessionID,
+		Label:   StreamLabelMatchService,
+	}
+	leaderPresence := p.nk.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, leaderStream, leaderUserID)
+	if leaderPresence == nil {
+		return // leader not in a match
+	}
+	leaderMatchID := MatchIDFromStringOrNil(leaderPresence.GetStatus())
+	if leaderMatchID.IsNil() {
+		return
+	}
+
+	// Signal the match to delete reservations for this party.
+	//
+	// Phase 1 limitation: SignalClearPartyReservations clears ALL reservations
+	// for the party ID, not just the departing member's slot. This is broader
+	// than needed but safe — remaining members will get fresh reservations
+	// from the next lobbyEntrantConnected (createPartyReservations) or from
+	// appendPartyReservationPlaceholders on the next match tick.
+	//
+	// Phase 2 (TODO): Add SignalClearMemberReservation (by session ID) for
+	// surgical single-member removal.
+	payload := SignalClearPartyReservationsPayload{PartyID: partyID}
+	if _, err := SignalMatch(ctx, p.nk, leaderMatchID, SignalClearPartyReservations, payload); err != nil {
+		logger.Warn("Failed to clear departing member's reservation",
+			zap.Error(err),
+			zap.String("sid", session.id.String()),
+			zap.String("match_id", leaderMatchID.String()),
+			zap.String("party_id", partyID.String()))
+		return
+	}
+
+	logger.Debug("Cleared reservation for departing member",
+		zap.String("sid", session.id.String()),
+		zap.String("match_id", leaderMatchID.String()),
+		zap.String("party_id", partyID.String()))
 }

--- a/server/pipeline_match.go
+++ b/server/pipeline_match.go
@@ -15,7 +15,9 @@
 package server
 
 import (
+	"context"
 	"crypto"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -327,7 +329,52 @@ func (p *Pipeline) matchLeave(logger *zap.Logger, session Session, envelope *rta
 	// Check and drop the presence if possible, will always succeed.
 	stream := PresenceStream{Mode: mode, Subject: matchID, Label: matchIDComponents[1]}
 
-	p.tracker.Untrack(session.ID(), stream, session.UserID())
+	if mode == StreamModeMatchAuthoritative {
+		// EchoVR-specific signal path in a generic handler:
+		//
+		// EchoVR authoritative matches have a game server that is the authority
+		// for who is in the match. We signal the match handler to kick the
+		// player through the game server rather than directly untracking.
+		// The match handler sends an EntrantReject to the game server, which
+		// removes the player and sends LobbyEntrantRemoved back, triggering
+		// the real presence cleanup via lobbyEntrantsRemove.
+		//
+		// Non-EchoVR authoritative matches (or any match that doesn't handle
+		// SignalKickEntrants) will fail the signal or return Success=false.
+		// In either case we fall back to direct Untrack, which preserves
+		// standard Nakama behavior for non-EchoVR matches.
+		matchIDStr := fmt.Sprintf("%s.%s", matchID.String(), matchIDComponents[1])
+
+		routed := false
+		if payload, err := json.Marshal(SignalKickEntrantsPayload{
+			UserIDs: []uuid.UUID{session.UserID()},
+		}); err == nil {
+			signal := SignalEnvelope{
+				UserID:  session.UserID().String(),
+				OpCode:  SignalKickEntrants,
+				Payload: payload,
+			}
+			if signalData, err := json.Marshal(signal); err == nil {
+				signalCtx, signalCancel := context.WithTimeout(context.Background(), 5*time.Second)
+				result, signalErr := p.matchRegistry.Signal(signalCtx, matchIDStr, string(signalData))
+				signalCancel()
+				if signalErr == nil {
+					resp := SignalResponseFromString(result)
+					if resp.Success {
+						routed = true
+						logger.Debug("Match leave routed through game server signal",
+							zap.String("match_id", matchIDStr),
+							zap.String("uid", session.UserID().String()))
+					}
+				}
+			}
+		}
+		if !routed {
+			p.tracker.Untrack(session.ID(), stream, session.UserID())
+		}
+	} else {
+		p.tracker.Untrack(session.ID(), stream, session.UserID())
+	}
 
 	out := &rtapi.Envelope{Cid: envelope.Cid}
 	_ = session.Send(out, true)

--- a/server/session_ws.go
+++ b/server/session_ws.go
@@ -108,6 +108,8 @@ type (
 
 		storageIndex StorageIndex
 		evrPipeline  *EvrPipeline
+
+		sendEvrHook func(messages []evr.Message) // nil in production; set by tests to capture SendEvr calls
 	}
 
 	// Keys used for storing/retrieving user information in the context of a request after authentication.
@@ -682,6 +684,10 @@ func (s *sessionWS) SendEvrUnrequire(messages ...evr.Message) error {
 // SendEvr sends messages to the client in the EchoVR format.
 // Multiple messages are marshaled into a single payload to reduce WebSocket writes.
 func (s *sessionWS) SendEvr(messages ...evr.Message) error {
+	if s.sendEvrHook != nil {
+		s.sendEvrHook(messages)
+	}
+
 	isDebug := s.logger.Core().Enabled(zap.DebugLevel)
 
 	// Filter nil messages and log in debug mode.

--- a/server/testdata/replay/crash-recovery-rejoin.json
+++ b/server/testdata/replay/crash-recovery-rejoin.json
@@ -1,0 +1,176 @@
+{
+  "name": "crash-recovery-rejoin",
+  "description": "Player crashes mid-return from a match, reconnects 27 seconds later through Crashed state, regroups in social lobby, then successfully follows leader to a second match. Demonstrates the full crash recovery path.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T19:59:45Z/2026-06-18T20:02:59Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T19:59:45.091Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:45.212Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:45.216Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:46.218Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:03.286Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:03.303Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:25.061Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:43.169Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:55.574Z",
+      "from": "Matchmaking",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:55.688Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:20.058Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:21.781Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:21.932Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:39.561Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:43.236Z",
+      "from": "Returning",
+      "to": "Crashed",
+      "reason": "disconnected",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:10.357Z",
+      "from": "Crashed",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:10.569Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:11.252Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:12.259Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:33.007Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:34.115Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:34.266Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:41.718Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:59.477Z",
+      "from": "Returning",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/full-arena-lifecycle.json
+++ b/server/testdata/replay/full-arena-lifecycle.json
@@ -1,0 +1,106 @@
+{
+  "name": "full-arena-lifecycle",
+  "description": "Complete party lifecycle from idle through social lobby, matchmaking, arena match, and back to returning. Shows the standard follower path: join party, regroup in social, enter matchmaking, find match, play, match ends.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T19:59:45Z/2026-06-18T20:01:39Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T19:59:45.091Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:45.212Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:45.216Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:59:46.218Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:03.286Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:03.303Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:25.061Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:43.169Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:55.574Z",
+      "from": "Matchmaking",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:55.688Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:20.058Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:21.781Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:21.932Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:39.561Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/healthy-party-follow.json
+++ b/server/testdata/replay/healthy-party-follow.json
@@ -1,0 +1,57 @@
+{
+  "name": "healthy-party-follow",
+  "description": "Clean party lifecycle: join party, arrive in social lobby, follow leader to arena, get pulled back to holding when match ends, enter matchmaking on leader ticket, find match, play match. All transitions legal — no bugs, no churn, no crashes.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T23:59:43Z/2026-06-19T00:02:17Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T23:59:43.917Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T23:59:45.016Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T23:59:45.167Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-19T00:01:46.125Z",
+      "from": "InMatch",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-19T00:01:46.712Z",
+      "from": "Holding",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-19T00:02:09.900Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-19T00:02:17.484Z",
+      "from": "Joining",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/party-churn-repeated-cycles.json
+++ b/server/testdata/replay/party-churn-repeated-cycles.json
@@ -1,0 +1,211 @@
+{
+  "name": "party-churn-repeated-cycles",
+  "description": "Extended party session showing repeated matchmaking/holding cycles: initial party follow, first match, stale match-end bounce, ticket cancellation, second arena visit, crash during join, recovery, and another stale bounce. Demonstrates party churn under real conditions.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T20:06:14Z/2026-06-18T20:17:30Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T20:06:14.473Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:16.110Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:16.261Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:36.239Z",
+      "from": "InMatch",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:42.425Z",
+      "from": "Holding",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:07:09.854Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:07:17.481Z",
+      "from": "Joining",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.114Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.427Z",
+      "from": "Matchmaking",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.445Z",
+      "from": "Returning",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:20.987Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:37.293Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:37.829Z",
+      "from": "Matchmaking",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:37.829Z",
+      "from": "Holding",
+      "to": "Holding",
+      "reason": "ticket cancelled for late arrival, rebuilding",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:44.849Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:45.000Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to social lobby via poll",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:52.513Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:15:09.917Z",
+      "from": "Returning",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:15:47.693Z",
+      "from": "Joining",
+      "to": "Crashed",
+      "reason": "disconnected",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:16.695Z",
+      "from": "Crashed",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:21.365Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:42.185Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:49.838Z",
+      "from": "Joining",
+      "to": "InMatch",
+      "reason": "joined match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:49.856Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:10.900Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:10.939Z",
+      "from": "Matchmaking",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:15.605Z",
+      "from": "Returning",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:30.418Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:30.516Z",
+      "from": "Matchmaking",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/reconnect-social-lobby-join.json
+++ b/server/testdata/replay/reconnect-social-lobby-join.json
@@ -1,0 +1,64 @@
+{
+  "name": "reconnect-social-lobby-join",
+  "description": "Player reconnects after disconnect and successfully joins a social lobby, then follows leader to arena match",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T20:22:15Z/2026-06-18T20:23:18Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T20:22:32.241Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:22:33.733Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:22:33.884Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:22:54.676Z",
+      "from": "InMatch",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:22:54.825Z",
+      "from": "Holding",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:23:09.881Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:23:17.618Z",
+      "from": "Joining",
+      "to": "InMatch",
+      "reason": "joined match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:23:17.678Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/stale-skip-matchmaking-loop.json
+++ b/server/testdata/replay/stale-skip-matchmaking-loop.json
@@ -1,0 +1,169 @@
+{
+  "name": "stale-skip-matchmaking-loop",
+  "description": "Player experiences the stale fast-path skip bug: after a crash during join, recovers into matchmaking but gets stuck in Matchmaking loop for 3+ minutes. Shows the ticket inclusion storm from stale stream data.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T20:05:31Z/2026-06-18T20:20:50Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T20:05:31.311Z",
+      "from": "Idle",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:05:33.340Z",
+      "from": "Matchmaking",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:05:54.528Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:14.452Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:36.220Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:06:42.425Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:07:09.853Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:07:17.447Z",
+      "from": "Joining",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.114Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.196Z",
+      "from": "Matchmaking",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:19.383Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:23.209Z",
+      "from": "Matchmaking",
+      "to": "SocialReady",
+      "reason": "join failed, regrouping",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:24.211Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:37.293Z",
+      "from": "SocialReady",
+      "to": "Matchmaking",
+      "reason": "leader submitted ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:37.809Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:15:09.920Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:15:47.655Z",
+      "from": "Joining",
+      "to": "Crashed",
+      "reason": "disconnected",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:10.900Z",
+      "from": "Crashed",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:17:30.418Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:19:06.138Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:20:10.684Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:20:35.768Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:20:50.500Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    }
+  ]
+}

--- a/server/testdata/replay/stale-stream-infinite-matchmaking.json
+++ b/server/testdata/replay/stale-stream-infinite-matchmaking.json
@@ -1,0 +1,309 @@
+{
+  "name": "stale-stream-infinite-matchmaking",
+  "description": "Player gets stuck in Matchmaking loop for 7 minutes due to isFollowerInActiveMatch stale stream bug. Shows repeated ticket inclusion with no match assignment, preceded by normal party cycling.",
+  "source_log": "nakama-2026-06-19T17-48-09.533.log",
+  "time_window": "2026-06-18T19:57:10Z/2026-06-18T20:21:45Z",
+  "transitions": [
+    {
+      "ts": "2026-06-18T19:57:10.719Z",
+      "from": "Idle",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:57:10.719Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "leader in arena/combat — waiting in social for next round",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T19:57:12.524Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:26.029Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:26.029Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "leader in arena/combat — waiting in social for next round",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:27.035Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:34.925Z",
+      "from": "SocialReady",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": false
+    },
+    {
+      "ts": "2026-06-18T20:00:45.000Z",
+      "from": "Returning",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:45.001Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "leader in arena/combat — waiting in social for next round",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:00:46.007Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:04.332Z",
+      "from": "SocialReady",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:04.332Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "leader in arena/combat — waiting in social for next round",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:05.346Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:13.111Z",
+      "from": "SocialReady",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": false
+    },
+    {
+      "ts": "2026-06-18T20:01:28.215Z",
+      "from": "Returning",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:28.216Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "leader in arena/combat — waiting in social for next round",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:29.221Z",
+      "from": "SocialReady",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:01:36.921Z",
+      "from": "SocialReady",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": false
+    },
+    {
+      "ts": "2026-06-18T20:02:01.192Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:17.782Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:20.163Z",
+      "from": "Matchmaking",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:20.163Z",
+      "from": "Holding",
+      "to": "Holding",
+      "reason": "ticket cancelled for late arrival, rebuilding",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:27.825Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:27.976Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to social lobby via poll",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:35.699Z",
+      "from": "InMatch",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:41.264Z",
+      "from": "Returning",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:42.373Z",
+      "from": "Holding",
+      "to": "SocialReady",
+      "reason": "joined social lobby",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:42.524Z",
+      "from": "SocialReady",
+      "to": "InMatch",
+      "reason": "followed leader to match",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:59.034Z",
+      "from": "InMatch",
+      "to": "Holding",
+      "reason": "waiting for leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:02:59.177Z",
+      "from": "Holding",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:03:09.967Z",
+      "from": "Matchmaking",
+      "to": "Joining",
+      "reason": "match found, joining",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:03:17.700Z",
+      "from": "Joining",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:45.182Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:14:45.320Z",
+      "from": "Matchmaking",
+      "to": "Returning",
+      "reason": "match ended",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:15:57.447Z",
+      "from": "Returning",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:16:38.202Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:18:19.993Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:18:52.590Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:19:41.157Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:20:33.119Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:20:51.397Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:21:16.750Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    },
+    {
+      "ts": "2026-06-18T20:21:44.370Z",
+      "from": "Matchmaking",
+      "to": "Matchmaking",
+      "reason": "included on leader's ticket",
+      "legal": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Defers service/guild/matchmaking stream updates from `LobbyJoinEntrants` (speculative) to `lobbyEntrantConnected` (game server confirmed)
- Routes authoritative match leave through game server signal instead of direct tracker untrack
- Spec and behavior matrix for reservation-based party system to replace tracker-read follow/poll

## Commits

1. **fix: defer service/guild/matchmaking streams to lobbyEntrantConnected** — "player is in match" state only set when game server confirms. Removes 1-second sleep, speculative writes, and premature matchmaking untrack from `LobbyJoinEntrants`.

2. **fix: route authoritative match leave through game server signal** — `pipeline_match.go` matchLeave for authoritative matches sends `SignalKickEntrants` to the match handler instead of directly untracking. Falls back to direct untrack for non-EchoVR matches.

3. **docs: reservation-based party system spec and behavior matrix** — Full spec for replacing tracker-read party follow with event-driven reservations. 71-row behavior matrix comparing current vs proposed. 8 gaps flagged. Three-phase timeout model (formation 15s, convergence 10s, matchmaking existing).

## Motivation

BigDuckII infinite matchmaking (2026-06-18): stale `StreamLabelMatchService` tracker entry caused `isFollowerInActiveMatch` to block party follow after the player had already left the match. Root cause: the service stream was written speculatively at join attempt time, never cleared on leave.

A naive fix (passing `currentMatchID` to skip the guard) was deployed and broke all parties — the same `currentMatchID` value appears in both "leaving this match" and "already in this match" cases. Documented in `evr_lobby_find_follower_test.go:57` (skipped test).

## Test plan

- [ ] Review spec and behavior matrix for completeness
- [ ] Address 8 flagged gaps in the spec
- [ ] Integration test: party of 2, arena match, both leave, both land in same social lobby
- [ ] Integration test: party of 2, leader queues arena, follower joins within 15s, both placed
- [ ] Integration test: party of 2, leader queues arena, follower doesn't matchmake within 15s, gets removed
- [ ] Integration test: late join — leader in social lobby, new member joins party, finds reservation
- [ ] Verify no regression on solo (non-party) matchmaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)