### PR TITLE
fix: remove internal IP ping fallback during broadcaster registration

### DIFF
--- a/server/evr_pipeline_gameserver.go
+++ b/server/evr_pipeline_gameserver.go
@@ -198,6 +198,17 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 		internalIP = normalized
 	}
 
+	// Null out the internal IP when it duplicates the external IP. The internal
+	// slot is only useful when Nakama and the game server share a LAN; when both
+	// addresses are the same the field adds no information and the ping retry
+	// would just repeat the same probe.
+	if internalIP != nil && internalIP.Equal(externalIP) {
+		logger.Debug("Game server internal_ip equals external_ip; clearing internal_ip",
+			zap.String("ip", internalIP.String()),
+			zap.Uint64("server_id", serverID))
+		internalIP = nil
+	}
+
 	isNative := false
 	if uuid.FromStringOrNil(request.LoginSessionId) != uuid.Nil {
 		isNative = true
@@ -337,13 +348,8 @@ func (p *EvrPipeline) gameserverRegistrationRequest(logger *zap.Logger, session 
 		for range retries {
 			rtt, err = BroadcasterHealthcheck(p.internalIP, config.Endpoint.ExternalIP, int(config.Endpoint.Port), 500*time.Millisecond)
 			if err != nil {
-				// Try the internal IP
-				rtt, err = BroadcasterHealthcheck(p.internalIP, config.Endpoint.InternalIP, int(config.Endpoint.Port), 500*time.Millisecond)
-				if err != nil {
-					time.Sleep(500 * time.Millisecond)
-					continue
-				}
-
+				time.Sleep(500 * time.Millisecond)
+				continue
 			}
 			if rtt >= 0 {
 				isAlive = true


### PR DESCRIPTION
## Summary

- **Remove the internal IP ping fallback** from the broadcaster healthcheck retry loop. In production, Nakama and game servers are never on the same LAN, so pinging the internal IP always fails. The fallback error was overwriting the external IP error, making logs show an internal IP timeout instead of the real failure.
- **Null out internal IP when it equals external IP.** If the game server reports an internal address identical to the external address (from `session.ClientIP()`), the duplicate is cleared to nil. This complements the existing `normalizeInternalIP` guard that already handles public IPs sent as internal.

## Test plan

- [ ] Register a broadcaster with a distinct internal IP — verify only external IP is pinged during healthcheck
- [ ] Register a broadcaster where internal IP == external IP — verify internal IP is cleared to nil in logs (debug level)
- [ ] Register a broadcaster with an unreachable external IP — verify error message shows the external IP timeout, not an internal IP timeout
- [ ] `GOWORK=off go vet ./server/...` passes clean
- [ ] `GOWORK=off go build ./...` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)