### PR TITLE
fix: social lobby snap-back when party follower queues for arena

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -69,7 +69,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 		// prevents repeated "Joined party group" / "Already in
 		// leader's match" churn when the client re-sends
 		// LobbyFindSessionRequest on its normal message cycle.
-		if !isLeader && p.isFollowerAlreadyInLeaderMatch(logger, session, lobbyGroup, lobbyParams.CurrentMatchID) {
+		if !isLeader && p.isFollowerAlreadyInLeaderMatch(ctx, logger, session, lobbyGroup, lobbyParams.CurrentMatchID) {
 			logger.Debug("Follower already in leader's match, skipping follow path",
 				zap.String("current_match_id", lobbyParams.CurrentMatchID.String()),
 				zap.String("leader_sid", lobbyGroup.GetLeader().GetSessionId()))
@@ -1207,7 +1207,7 @@ func (p *EvrPipeline) intendedSocialTargetMatchID(session *sessionWS, lobbyParam
 //
 // Returns false when the leader cannot be found, either player is not in a
 // match, or their match IDs differ.
-func (p *EvrPipeline) isFollowerAlreadyInLeaderMatch(logger *zap.Logger, session *sessionWS, lobbyGroup *LobbyGroup, currentMatchID MatchID) bool {
+func (p *EvrPipeline) isFollowerAlreadyInLeaderMatch(ctx context.Context, logger *zap.Logger, session *sessionWS, lobbyGroup *LobbyGroup, currentMatchID MatchID) bool {
 	leader := lobbyGroup.GetLeader()
 	if leader == nil || leader.SessionId == session.id.String() {
 		return false
@@ -1246,6 +1246,16 @@ func (p *EvrPipeline) isFollowerAlreadyInLeaderMatch(logger *zap.Logger, session
 	}
 
 	if !currentMatchID.IsNil() && followerMatchID == currentMatchID {
+		// Both players are in the same match that the client reports as
+		// "current." Distinguish social (staying) from arena (leaving).
+		if p.nk != nil {
+			label, err := MatchLabelByID(ctx, p.nk, followerMatchID)
+			if err == nil && label != nil && label.IsSocial() {
+				logger.Debug("Follower and leader share a social lobby, already converged",
+					zap.String("shared_match_id", followerMatchID.String()))
+				return true
+			}
+		}
 		logger.Debug("Follower and leader share the match being left, not skipping",
 			zap.String("shared_match_id", followerMatchID.String()),
 			zap.String("current_match_id", currentMatchID.String()),
@@ -1587,7 +1597,18 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 		}
 
 		if !params.CurrentMatchID.IsNil() && leaderMatchID == params.CurrentMatchID {
-			return false
+			// Both players share the match the client reports as "current."
+			// Social lobbies persist (staying); arena lobbies are dying (leaving).
+			isSocial := false
+			if p.nk != nil {
+				label, err := MatchLabelByID(ctx, p.nk, leaderMatchID)
+				if err == nil && label != nil && label.IsSocial() {
+					isSocial = true
+				}
+			}
+			if !isSocial {
+				return false
+			}
 		}
 
 		memberStream := PresenceStream{

--- a/server/evr_lobby_follow_test.go
+++ b/server/evr_lobby_follow_test.go
@@ -2136,7 +2136,7 @@ func TestIsFollowerAlreadyInLeaderMatch_SameMatch(t *testing.T) {
 	env.setLeaderMatch(matchID)
 	env.setFollowerMatch(matchID)
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if !result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return true when both are in the same match")
 	}
@@ -2155,7 +2155,7 @@ func TestIsFollowerAlreadyInLeaderMatch_DifferentMatches(t *testing.T) {
 	env.setLeaderMatch(matchA)
 	env.setFollowerMatch(matchB)
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return false when in different matches")
 	}
@@ -2173,7 +2173,7 @@ func TestIsFollowerAlreadyInLeaderMatch_LeaderNotInMatch(t *testing.T) {
 	// Only follower is in a match; leader is not.
 	env.setFollowerMatch(matchID)
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return false when leader has no match")
 	}
@@ -2191,7 +2191,7 @@ func TestIsFollowerAlreadyInLeaderMatch_FollowerNotInMatch(t *testing.T) {
 	// Only leader is in a match; follower is not.
 	env.setLeaderMatch(matchID)
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return false when follower has no match")
 	}
@@ -2207,7 +2207,7 @@ func TestIsFollowerAlreadyInLeaderMatch_NoLeader(t *testing.T) {
 
 	env.clearLeader()
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return false when there is no leader")
 	}
@@ -2226,7 +2226,7 @@ func TestIsFollowerAlreadyInLeaderMatch_FollowerIsLeader(t *testing.T) {
 	env.setLeader(env.followerSID, env.followerUID, "follower")
 	env.setFollowerMatch(matchID)
 
-	result := env.pipeline.isFollowerAlreadyInLeaderMatch(logger, env.session, env.lobbyGroup, MatchID{})
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(context.Background(), logger, env.session, env.lobbyGroup, MatchID{})
 	if result {
 		t.Error("isFollowerAlreadyInLeaderMatch should return false when follower is the leader")
 	}
@@ -2523,5 +2523,143 @@ func TestCurrentSocialLobby_FollowToLeaderSameLobby_IsNoop(t *testing.T) {
 
 	if result != sharedLobby {
 		t.Errorf("rejoin of the leader's (same) social lobby must remain a no-op; expected %s, got %s", sharedLobby, result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Social lobby snap-back bug -- isFollowerAlreadyInLeaderMatch
+// ---------------------------------------------------------------------------
+
+// TestFollowerInSocialLobby_QueueArena_NoSnapBack verifies that when both
+// the follower and leader are in the same social lobby and the follower
+// queues for an arena, isFollowerAlreadyInLeaderMatch returns true
+// (already converged).
+func TestFollowerInSocialLobby_QueueArena_NoSnapBack(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	socialLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	env.setLeaderMatch(socialLobby)
+	env.setFollowerMatch(socialLobby)
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(socialLobby, &MatchLabel{
+		ID:   socialLobby,
+		Mode: evr.ModeSocialPublic,
+		Open: true,
+	})
+	env.withMockNK(registry)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(
+		context.Background(), logger, env.session, env.lobbyGroup, socialLobby)
+
+	if !result {
+		t.Fatal("isFollowerAlreadyInLeaderMatch returned false when both players " +
+			"are in the same social lobby -- snap-back bug")
+	}
+}
+
+// TestFollowerInArenaLobby_BothLeaving_NotConverged verifies that when both
+// players are in a dying arena lobby, the function returns false.
+func TestFollowerInArenaLobby_BothLeaving_NotConverged(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	arenaLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	logger := loggerForTest(t)
+
+	env.setLeaderMatch(arenaLobby)
+	env.setFollowerMatch(arenaLobby)
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(arenaLobby, &MatchLabel{
+		ID:   arenaLobby,
+		Mode: evr.ModeArenaPublic,
+		Open: true,
+	})
+	env.withMockNK(registry)
+
+	result := env.pipeline.isFollowerAlreadyInLeaderMatch(
+		context.Background(), logger, env.session, env.lobbyGroup, arenaLobby)
+
+	if result {
+		t.Fatal("isFollowerAlreadyInLeaderMatch returned true when both players " +
+			"are in a dying arena lobby -- should return false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Social lobby snap-back bug -- isFollowerInLeaderMatch closure
+// ---------------------------------------------------------------------------
+
+// TestPollFollowerInSocialLobby_NoRejoin verifies the closure returns true
+// when both players are in the same social lobby.
+func TestPollFollowerInSocialLobby_NoRejoin(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	socialLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	env.setLeaderMatch(socialLobby)
+	env.setFollowerMatch(socialLobby)
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(socialLobby, &MatchLabel{
+		ID:          socialLobby,
+		Mode:        evr.ModeSocialPublic,
+		Open:        true,
+		PlayerLimit: 12,
+		Players: []PlayerInfo{
+			{UserID: env.followerUID.String(), Team: 0},
+			{UserID: env.leaderUID.String(), Team: 0},
+		},
+	})
+	env.withMockNK(registry)
+
+	env.params.CurrentMatchID = socialLobby
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, timedOut := env.runPollWithTimeout(ctx, t, 5*time.Second)
+	if timedOut {
+		t.Fatal("pollFollowPartyLeader timed out -- closure failed to detect social lobby convergence")
+	}
+	if !result {
+		t.Fatal("pollFollowPartyLeader returned false when both players are " +
+			"in the same social lobby -- should return true")
+	}
+}
+
+// TestPollFollowerInArenaLobby_BothLeaving_FallsThrough verifies the closure
+// returns false when both players are in a dying arena lobby.
+func TestPollFollowerInArenaLobby_BothLeaving_FallsThrough(t *testing.T) {
+	t.Parallel()
+
+	env := newFollowTestEnv(t)
+	arenaLobby := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+
+	env.setLeaderMatch(arenaLobby)
+	env.setFollowerMatch(arenaLobby)
+
+	registry := newMockFollowMatchRegistry()
+	registry.SetMatch(arenaLobby, &MatchLabel{
+		ID:   arenaLobby,
+		Mode: evr.ModeArenaPublic,
+		Open: true,
+	})
+	env.withMockNK(registry)
+
+	env.params.CurrentMatchID = arenaLobby
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	result, _ := env.runPollWithTimeout(ctx, t, 10*time.Second)
+	if result {
+		t.Fatal("pollFollowPartyLeader returned true when both players are " +
+			"in a dying arena lobby -- should not treat as convergence")
 	}
 }


### PR DESCRIPTION
## Summary

- When a party follower sitting in a social lobby queued for arena, the `currentMatchID` exclusion in both `isFollowerAlreadyInLeaderMatch` and the `isFollowerInLeaderMatch` closure treated the shared social lobby as "both leaving" and returned false
- This caused `pollFollowPartyLeader` to fall through to `lobbyJoin`, which tried to re-join the follower to the social lobby she was already in, producing a duplicate-join BAD REQUEST that cycled 2-3 times before matchmaking worked
- The fix consults the match label via `MatchLabelByID` when both players share the match reported as `currentMatchID` -- social lobbies persist (return true = already converged), arena lobbies are dying (return false = not converged, original behavior preserved)

## Changes

- `isFollowerAlreadyInLeaderMatch`: added `ctx context.Context` parameter; when `followerMatchID == currentMatchID`, look up the label and return true for social lobbies
- `isFollowerInLeaderMatch` closure in `pollFollowPartyLeader`: same label-based disambiguation -- skip the exclusion for social lobbies
- 4 new tests covering both functions for both social (bug case) and arena (regression case)
- 6 existing `isFollowerAlreadyInLeaderMatch` test calls updated for the new `ctx` parameter

## Test plan

- [x] `TestFollowerInSocialLobby_QueueArena_NoSnapBack` -- social lobby, `isFollowerAlreadyInLeaderMatch` returns true (was false = bug)
- [x] `TestFollowerInArenaLobby_BothLeaving_NotConverged` -- arena lobby, returns false (regression guard)
- [x] `TestPollFollowerInSocialLobby_NoRejoin` -- social lobby poll convergence returns true (was timeout = bug)
- [x] `TestPollFollowerInArenaLobby_BothLeaving_FallsThrough` -- arena lobby poll returns false (regression guard)
- [x] All 7 existing `isFollowerAlreadyInLeaderMatch` tests pass
- [x] `go vet ./server/...` clean
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)