### PR TITLE
fix(evr): bound login SystemInfo metric-tag cardinality

### DIFF
--- a/server/evr_login_metrics_cardinality_test.go
+++ b/server/evr_login_metrics_cardinality_test.go
@@ -1,0 +1,237 @@
+package server
+
+import (
+	"fmt"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// This file drives the ACTUAL login metric-emission path (buildLoginSuccessMetricTags
+// and SessionParameters.MetricsTags), not the SEC-4 helpers in isolation. The
+// pre-existing evr_metrics_tags_test.go tests systemInfoMetricTags(si) — a map the
+// login_success counter never emits — so it stayed green while login_success still
+// carried raw device_type/build_version/build_number/app_id/publisher_lock. These
+// tests assert boundedness on the real emitted tuple, across EVERY attacker-controlled
+// field, and fail if any one flows raw.
+
+// loginAttackerTagFields are every attacker-controlled tag key emitted on the
+// login_success metric. A randomized login payload must not be able to mint an
+// unbounded number of distinct values for ANY of them.
+var loginAttackerTagFields = []string{
+	"network_type", "headset_type", "total_memory",
+	"num_logical_cores", "num_physical_cores",
+	"build_number", "app_id", "publisher_lock",
+	"device_type", "build_version",
+}
+
+// maxDistinctPerLoginField is a generous per-field ceiling: larger than any single
+// bounded field's legitimate cardinality (headset ~= len(canonicalHeadsetTypes)+1,
+// cores = 65, memory = 11, build = 3, app = 4, publisher = 3, network = 2) yet far
+// below N, so a raw (unbounded) field trips it decisively.
+const maxDistinctPerLoginField = 100
+
+// adversarialLoginPayload returns a LoginProfile whose every attacker-controlled
+// field is unique per call — the DoS model: one client randomizing the payload on
+// each login to churn Prometheus series.
+func adversarialLoginPayload(rng *rand.Rand, i int) *evr.LoginProfile {
+	return &evr.LoginProfile{
+		BuildNumber:   evr.BuildNumber(rng.Int63()),
+		AppId:         rng.Uint64(),
+		PublisherLock: fmt.Sprintf("pub-%d-%d", i, rng.Int63()),
+		SystemInfo: evr.SystemInfo{
+			HeadsetType:      fmt.Sprintf("hmd-%d-%d", i, rng.Int63()),
+			DriverVersion:    fmt.Sprintf("drv-%d-%d", i, rng.Int63()),
+			NetworkType:      fmt.Sprintf("net-%d-%d", i, rng.Int63()),
+			VideoCard:        fmt.Sprintf("gpu-%d-%d", i, rng.Int63()),
+			CPUModel:         fmt.Sprintf("cpu-%d-%d", i, rng.Int63()),
+			NumPhysicalCores: rng.Int63(),
+			NumLogicalCores:  rng.Int63(),
+			MemoryTotal:      rng.Int63(),
+		},
+	}
+}
+
+func paramsWithPayload(payload *evr.LoginProfile, userID string) *SessionParameters {
+	p := &SessionParameters{
+		IsWebsocketAuthenticated: true,
+		loginPayload:             payload,
+	}
+	if userID != "" {
+		p.profile = &EVRProfile{account: &api.Account{User: &api.User{Id: userID}}}
+	}
+	return p
+}
+
+func tupleKey(tags map[string]string) string {
+	keys := make([]string, 0, len(tags))
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(tags[k])
+		b.WriteByte('\x00')
+	}
+	return b.String()
+}
+
+// TestLoginSuccessPerFieldCardinalityBounded drives buildLoginSuccessMetricTags —
+// the real login_success emission — with N adversarial payloads and asserts NO
+// attacker-controlled field yields more than maxDistinctPerLoginField distinct
+// values. playerID is empty so the per-player cap is skipped: this isolates the
+// per-field allow-list/bucket bounding. FAILS pre-fix on build_number, app_id,
+// publisher_lock, device_type, build_version (all emitted raw).
+func TestLoginSuccessPerFieldCardinalityBounded(t *testing.T) {
+	const n = 2000
+	rng := rand.New(rand.NewSource(1))
+	limiter := newSystemFingerprintLimiter(maxDistinctSystemsPerPlayer, maxTrackedPlayersForSystemLimit)
+
+	distinct := make(map[string]map[string]struct{}, len(loginAttackerTagFields))
+	for _, f := range loginAttackerTagFields {
+		distinct[f] = make(map[string]struct{})
+	}
+
+	for i := 0; i < n; i++ {
+		params := paramsWithPayload(adversarialLoginPayload(rng, i), "") // empty ID => cap skipped
+		tags := buildLoginSuccessMetricTags(params, limiter)
+		for _, f := range loginAttackerTagFields {
+			distinct[f][tags[f]] = struct{}{}
+		}
+	}
+
+	for _, f := range loginAttackerTagFields {
+		if got := len(distinct[f]); got > maxDistinctPerLoginField {
+			t.Errorf("login_success field %q: %d distinct values from %d adversarial logins (ceiling %d) — flows raw, unbounded cardinality (SEC-4)", f, got, n, maxDistinctPerLoginField)
+		}
+	}
+}
+
+// TestLoginSuccessPerPlayerTupleBounded proves the per-player invariant: a single
+// account, however it randomizes the payload, cannot mint an unbounded number of
+// distinct login_success tag-tuples. FAILS pre-fix because build_number/app_id/
+// publisher_lock/device_type/build_version are outside the fingerprint cap and are
+// emitted raw, so each varying login is a fresh series.
+func TestLoginSuccessPerPlayerTupleBounded(t *testing.T) {
+	const n = 2000
+	rng := rand.New(rand.NewSource(3))
+	limiter := newSystemFingerprintLimiter(maxDistinctSystemsPerPlayer, maxTrackedPlayersForSystemLimit)
+	const player = "single-abuser"
+
+	tuples := make(map[string]struct{})
+	for i := 0; i < n; i++ {
+		params := paramsWithPayload(adversarialLoginPayload(rng, i), player)
+		tuples[tupleKey(buildLoginSuccessMetricTags(params, limiter))] = struct{}{}
+	}
+
+	// Non-attacker tags are constant here, so the only variation is the bounded
+	// attacker tuple, capped per player: at most maxDistinctSystemsPerPlayer admitted
+	// systems plus the single all-"other" collapsed tuple.
+	if got, want := len(tuples), maxDistinctSystemsPerPlayer+1; got > want {
+		t.Errorf("single player emitted %d distinct login_success tuples from %d adversarial logins (bound %d) — a client can churn series (SEC-4)", got, n, want)
+	}
+}
+
+// legalHeadsetInputs / legalAppIDs are legitimate bounded values used to walk the
+// allowed tuple space and prove the per-player cap folds in the LoginProfile-derived
+// fields (build_number/app_id/publisher_lock), not just SystemInfo.
+func legalHeadsetInputs() []string {
+	out := make([]string, 0, 4)
+	for _, canon := range headsetMappings { // canonical names round-trip through boundHeadsetMetricTag
+		out = append(out, canon)
+		if len(out) == 4 {
+			break
+		}
+	}
+	sort.Strings(out) // determinism across map iteration order
+	return out
+}
+
+// TestLoginSuccessCapFoldsProfileFields walks a single player across the LEGAL
+// bounded value space (canonical headsets x memory tiers x known builds x known
+// app IDs x known publisher locks). Every value is allow-listed, so per-field
+// bounding alone does NOT collapse them — only folding build_number/app_id/
+// publisher_lock into the per-player fingerprint cap keeps the distinct-tuple count
+// at or below maxDistinctSystemsPerPlayer+1. FAILS pre-fix, where those fields sit
+// outside the fingerprint and multiply past the cap.
+func TestLoginSuccessCapFoldsProfileFields(t *testing.T) {
+	limiter := newSystemFingerprintLimiter(maxDistinctSystemsPerPlayer, maxTrackedPlayersForSystemLimit)
+	const player = "walker"
+
+	headsets := legalHeadsetInputs()
+	mems := []int64{8, 16, 32}
+	builds := evr.KnownBuilds
+	apps := []uint64{NoOvrAppId, QuestAppId, PcvrAppId}
+	pubs := []string{"rad15_live", "echovrce"}
+
+	tuples := make(map[string]struct{})
+	for _, hs := range headsets {
+		for _, mem := range mems {
+			for _, b := range builds {
+				for _, app := range apps {
+					for _, pub := range pubs {
+						payload := &evr.LoginProfile{
+							BuildNumber:   b,
+							AppId:         app,
+							PublisherLock: pub,
+							SystemInfo: evr.SystemInfo{
+								HeadsetType:     hs,
+								NetworkType:     "WiFi",
+								MemoryTotal:     mem * bytesPerGiB,
+								NumLogicalCores: 8,
+							},
+						}
+						params := paramsWithPayload(payload, player)
+						tuples[tupleKey(buildLoginSuccessMetricTags(params, limiter))] = struct{}{}
+					}
+				}
+			}
+		}
+	}
+
+	combos := len(headsets) * len(mems) * len(builds) * len(apps) * len(pubs)
+	// The cap admits at most maxDistinctSystemsPerPlayer distinct systems; beyond it
+	// every attacker-controlled tag collapses to metricTagOther. The collapsed bucket
+	// can still splay by the two bounded derived booleans MetricsTags emits but does
+	// NOT fold into the fingerprint — is_vr and is_pcvr (2x2 = 4 max, both legitimate
+	// low-cardinality dimensions). So the per-player distinct-tuple bound is
+	// maxDistinctSystemsPerPlayer + 4. Without folding the profile fields into the cap,
+	// this same walk mints one series per legal combination (see the pre-fix RED run).
+	const derivedBoolSplay = 2 * 2 // is_vr x is_pcvr
+	if got, want := len(tuples), maxDistinctSystemsPerPlayer+derivedBoolSplay; got > want {
+		t.Errorf("single player walking %d legal bounded combinations emitted %d distinct login_success tuples (bound %d) — profile fields not folded into the per-player fingerprint cap (SEC-4)", combos, got, want)
+	}
+}
+
+// TestSiblingMetricTagsBounded drives SessionParameters.MetricsTags directly — the
+// shared source for login_process_latency, session_duration_seconds,
+// session_authenticate/authorize/initialize — and asserts its attacker-controlled
+// tags (device_type, build_version) are bounded across adversarial payloads. FAILS
+// pre-fix: MetricsTags emits normalizeHeadsetType(raw) and the raw build number.
+func TestSiblingMetricTagsBounded(t *testing.T) {
+	const n = 2000
+	rng := rand.New(rand.NewSource(5))
+
+	device := make(map[string]struct{})
+	build := make(map[string]struct{})
+	for i := 0; i < n; i++ {
+		params := paramsWithPayload(adversarialLoginPayload(rng, i), "")
+		tags := params.MetricsTags()
+		device[tags["device_type"]] = struct{}{}
+		build[tags["build_version"]] = struct{}{}
+	}
+
+	if got := len(device); got > maxDistinctPerLoginField {
+		t.Errorf("sibling metric tag device_type: %d distinct values from %d adversarial logins (ceiling %d) — raw headset flows into every MetricsTags-based metric (SEC-4)", got, n, maxDistinctPerLoginField)
+	}
+	if got := len(build); got > maxDistinctPerLoginField {
+		t.Errorf("sibling metric tag build_version: %d distinct values from %d adversarial logins (ceiling %d) — raw build number flows into every MetricsTags-based metric (SEC-4)", got, n, maxDistinctPerLoginField)
+	}
+}

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -3,18 +3,23 @@ package server
 import (
 	"container/list"
 	"hash/fnv"
+	"strconv"
 	"strings"
 	"sync"
 
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
 
-// sec4TagFields is the fixed, ordered set of attacker-controlled SystemInfo
-// string fields bounded by SEC-4. It is the single source of truth for both the
-// per-player system fingerprint (systemInfoFingerprint) and the beyond-cap
-// collapse (boundSystemsPerPlayer). Order is load-bearing: the fingerprint hash
-// depends on it, so do not reorder.
-var sec4TagFields = []string{"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type"}
+// systemInfoMetricTagFields is the fixed, ordered set of attacker-controlled
+// SystemInfo fields emitted as login metric tags, all bounded by SEC-4 (five
+// allow-listed strings plus three bucketed ints). It is the single source of
+// truth for the per-player system fingerprint (systemInfoFingerprint) and the
+// beyond-cap collapse (boundSystemsPerPlayer). Order is load-bearing: the
+// fingerprint hash depends on it, so do not reorder.
+var systemInfoMetricTagFields = []string{
+	"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type",
+	"total_memory", "num_logical_cores", "num_physical_cores",
+}
 
 // metricTagOther is the sentinel bucket for any client-supplied SystemInfo
 // value that is not on the bounded allow-list. Bucketing unknown values here
@@ -99,9 +104,76 @@ func boundHeadsetMetricTag(raw string) string {
 	return metricTagOther
 }
 
+// SEC-4 int tags: MemoryTotal / NumLogicalCores / NumPhysicalCores are raw
+// attacker-controlled int64s from the login payload. Emitting them verbatim as
+// metric tags is the same unbounded-cardinality hole the string allow-lists
+// close — one account varying memory_total each login mints unlimited Prometheus
+// series. These are bucketed to a small fixed set (unknown/out-of-range ->
+// metricTagOther), the identical approach used for the string fields.
+
+const bytesPerGiB = 1 << 30
+
+// memoryTiersGiB are the coarse GB buckets MemoryTotal snaps to. MemoryTotal is
+// in BYTES on the wire: the login-history fixture reports DedicatedGPUMemory =
+// 10737418240 (exactly 10 GiB, an RTX 3080's VRAM) alongside MemoryTotal =
+// 16777216000 (~15.6 GiB, a 16 GB machine), so the field is byte-denominated.
+var memoryTiersGiB = []int64{4, 8, 12, 16, 24, 32, 48, 64, 96, 128}
+
+// memoryBandGiB is the plausible-RAM band (inclusive). A rounded value outside it
+// buckets to metricTagOther; inside it snaps to the nearest tier.
+const (
+	memoryBandLowGiB  = 3
+	memoryBandHighGiB = 192
+)
+
+// boundMemoryTotalTag buckets attacker-controlled MemoryTotal (bytes) into a
+// coarse GB tier string, or metricTagOther when it rounds outside the plausible
+// band. Cardinality is bounded to len(memoryTiersGiB)+1 regardless of input.
+func boundMemoryTotalTag(memoryTotalBytes int64) string {
+	if memoryTotalBytes <= 0 {
+		return metricTagOther
+	}
+	gib := (memoryTotalBytes + bytesPerGiB/2) / bytesPerGiB // round to nearest GiB
+	if gib < memoryBandLowGiB || gib > memoryBandHighGiB {
+		return metricTagOther
+	}
+	nearest := memoryTiersGiB[0]
+	best := absInt64(gib - nearest)
+	for _, t := range memoryTiersGiB[1:] {
+		if d := absInt64(gib - t); d < best {
+			best, nearest = d, t
+		}
+	}
+	return strconv.FormatInt(nearest, 10)
+}
+
+// core-count clamp bounds: real CPUs report a small integer count. Out of range
+// (including 0 and negatives) buckets to metricTagOther.
+const (
+	minPlausibleCores = 1
+	maxPlausibleCores = 64
+)
+
+// boundCoreCountTag emits an in-range core count verbatim, else metricTagOther.
+// Cardinality is bounded to (maxPlausibleCores-minPlausibleCores+1)+1.
+func boundCoreCountTag(cores int64) string {
+	if cores < minPlausibleCores || cores > maxPlausibleCores {
+		return metricTagOther
+	}
+	return strconv.FormatInt(cores, 10)
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
 // systemInfoTagCardinalityBound returns the maximum number of distinct values a
-// given SEC-4 metric tag may take: allow-list size + 1 for the metricTagOther
-// sentinel. headset_type also allows the "Unknown" empty-input sentinel.
+// given SEC-4 metric tag may take: allow-list / bucket-set size + 1 for the
+// metricTagOther sentinel. headset_type also allows the "Unknown" empty-input
+// sentinel.
 func systemInfoTagCardinalityBound(field string) int {
 	switch field {
 	case "cpu_model":
@@ -114,6 +186,10 @@ func systemInfoTagCardinalityBound(field string) int {
 		return len(driverVersionAllowlist) + 1
 	case "headset_type":
 		return len(canonicalHeadsetTypes) + 1
+	case "total_memory":
+		return len(memoryTiersGiB) + 1
+	case "num_logical_cores", "num_physical_cores":
+		return (maxPlausibleCores - minPlausibleCores + 1) + 1
 	default:
 		return 0
 	}
@@ -126,23 +202,27 @@ func systemInfoTagCardinalityBound(field string) int {
 // the login path.
 //
 // SEC-4: these fields are attacker-controlled JSON from the login payload.
-// Emitting the raw strings as metric tag values would let one authenticated
-// account mint an unbounded number of distinct Prometheus series (one per
-// unique tuple) by randomizing SystemInfo on repeated logins ->
-// metrics-backend memory pressure. See BUGS.md SEC-4.
+// Emitting the raw values as metric tags would let one authenticated account mint
+// an unbounded number of distinct Prometheus series (one per unique tuple) by
+// randomizing SystemInfo on repeated logins -> metrics-backend memory pressure.
+// Every SystemInfo-derived tag written here is bounded: strings to allow-lists,
+// ints (memory/cores) to bucket sets. No SystemInfo field is emitted raw.
 func addSystemInfoMetricTags(tags map[string]string, si evr.SystemInfo) {
 	tags["cpu_model"] = cpuModelAllowlist.normalize(si.CPUModel)
 	tags["gpu_model"] = gpuModelAllowlist.normalize(si.VideoCard)
 	tags["network_type"] = networkTypeAllowlist.normalize(si.NetworkType)
 	tags["driver_version"] = driverVersionAllowlist.normalize(si.DriverVersion)
 	tags["headset_type"] = boundHeadsetMetricTag(si.HeadsetType)
+	tags["total_memory"] = boundMemoryTotalTag(si.MemoryTotal)
+	tags["num_logical_cores"] = boundCoreCountTag(si.NumLogicalCores)
+	tags["num_physical_cores"] = boundCoreCountTag(si.NumPhysicalCores)
 }
 
 // systemInfoMetricTags builds a fresh map of the bounded SEC-4 tags. It is a
 // thin wrapper over addSystemInfoMetricTags retained for tests; the login path
 // uses addSystemInfoMetricTags to write into its existing tags map.
 func systemInfoMetricTags(si evr.SystemInfo) map[string]string {
-	tags := make(map[string]string, 5)
+	tags := make(map[string]string, len(systemInfoMetricTagFields))
 	addSystemInfoMetricTags(tags, si)
 	return tags
 }
@@ -178,7 +258,7 @@ const (
 // share a fingerprint and therefore do not add cardinality.
 func systemInfoFingerprint(tags map[string]string) uint64 {
 	h := fnv.New64a()
-	for _, f := range sec4TagFields {
+	for _, f := range systemInfoMetricTagFields {
 		_, _ = h.Write([]byte(tags[f]))
 		_, _ = h.Write([]byte{0}) // separator: avoid "ab"+"c" == "a"+"bc" collisions
 	}
@@ -269,7 +349,7 @@ func boundSystemsPerPlayer(l *systemFingerprintLimiter, tags map[string]string, 
 	if l.allow(playerID, systemInfoFingerprint(tags)) {
 		return
 	}
-	for _, f := range sec4TagFields {
+	for _, f := range systemInfoMetricTagFields {
 		tags[f] = metricTagOther
 	}
 }

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -10,15 +10,33 @@ import (
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
 
-// systemInfoMetricTagFields is the fixed, ordered set of attacker-controlled
-// SystemInfo fields emitted as login metric tags, all bounded by SEC-4 (five
-// allow-listed strings plus three bucketed ints). It is the single source of
-// truth for the per-player system fingerprint (systemInfoFingerprint) and the
-// beyond-cap collapse (boundSystemsPerPlayer). Order is load-bearing: the
-// fingerprint hash depends on it, so do not reorder.
+// systemInfoMetricTagFields is the SystemInfo-derived subset of the login metric
+// tags, each bounded by SEC-4 (allow-listed strings + bucketed ints).
+//
+// F4: cpu_model, gpu_model and driver_version were REMOVED. With no in-repo
+// ground-truth allow-list they bucketed to metricTagOther for 100% of traffic — a
+// permanently-constant tag is pure cardinality overhead and a misleading dashboard
+// dimension, never a signal. Their raw values are still retained forensically in
+// the login-history record (not in metrics); when OPS has a real allow-list they
+// can be reintroduced here with populated sets.
 var systemInfoMetricTagFields = []string{
-	"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type",
+	"network_type", "headset_type",
 	"total_memory", "num_logical_cores", "num_physical_cores",
+}
+
+// loginMetricFingerprintFields is the FULL, ordered set of attacker-controlled tag
+// keys on the login_success metric: the SystemInfo subset above plus the
+// LoginProfile-derived fields (build_number/app_id/publisher_lock) and their
+// MetricsTags duplicates (device_type ≡ headset_type, build_version ≡ build_number).
+// It is the single source of truth for BOTH the per-player system fingerprint
+// (systemInfoFingerprint) and the beyond-cap collapse (boundSystemsPerPlayer), so a
+// single account cannot mint new series by varying ANY of these fields. Order is
+// load-bearing: the fingerprint hash depends on it, so do not reorder.
+var loginMetricFingerprintFields = []string{
+	"network_type", "headset_type",
+	"total_memory", "num_logical_cores", "num_physical_cores",
+	"build_number", "app_id", "publisher_lock",
+	"device_type", "build_version",
 }
 
 // metricTagOther is the sentinel bucket for any client-supplied SystemInfo
@@ -60,22 +78,61 @@ func (a tagAllowlist) normalize(raw string) string {
 }
 
 var (
-	// cpuModelAllowlist / gpuModelAllowlist / driverVersionAllowlist are seeded
-	// empty on purpose: there is no production ground-truth list of legitimate
-	// values in-repo. Until OPS populates these from real telemetry, every value
-	// buckets to metricTagOther — the SEC-4 cardinality bound holds immediately,
-	// at the cost of signal on these fields until the list is filled.
-	cpuModelAllowlist      = newTagAllowlist()
-	gpuModelAllowlist      = newTagAllowlist()
-	driverVersionAllowlist = newTagAllowlist()
-
 	// networkTypeAllowlist is seeded with the only value evidenced in-repo.
 	// OPS: add other engine-reported network types (e.g. wired/ethernet/offline)
 	// as they are observed.
 	networkTypeAllowlist = newTagAllowlist(
 		"WiFi",
 	)
+
+	// publisherLockAllowlist bounds the free-form client PublisherLock string
+	// (LoginProfile.publisher_lock — SEC-4). "rad15_live" is the value carried in
+	// the login-history fixture (evr_profile_cache_test.go:177); "echovrce" is the
+	// server-side publisher lock (evr_profile_cache.go:156). Any other value buckets
+	// to metricTagOther, so a client varying publisher_lock each login cannot mint
+	// unbounded series.
+	publisherLockAllowlist = newTagAllowlist("rad15_live", "echovrce")
 )
+
+// knownBuildSet is the set of legitimate client build numbers (evr.KnownBuilds:
+// StandaloneBuildNumber / PCVRBuild). BuildNumber is attacker-controlled
+// (LoginProfile.buildversion); emitting it raw as build_number/build_version lets
+// one account mint unbounded series by varying it each login. Unknown builds bucket
+// to metricTagOther.
+var knownBuildSet = func() map[evr.BuildNumber]struct{} {
+	set := make(map[evr.BuildNumber]struct{}, len(evr.KnownBuilds))
+	for _, b := range evr.KnownBuilds {
+		set[b] = struct{}{}
+	}
+	return set
+}()
+
+// boundBuildNumberTag emits an allow-listed build number verbatim, else
+// metricTagOther. Cardinality is bounded to len(evr.KnownBuilds)+1.
+func boundBuildNumberTag(bn evr.BuildNumber) string {
+	if _, ok := knownBuildSet[bn]; ok {
+		return strconv.FormatInt(int64(bn), 10)
+	}
+	return metricTagOther
+}
+
+// knownAppIDSet is the set of legitimate client application IDs (evr_authenticate.go:
+// NoOvrAppId / QuestAppId / PcvrAppId). AppId is attacker-controlled
+// (LoginProfile.appid); bucket unknown values to metricTagOther.
+var knownAppIDSet = map[uint64]struct{}{
+	NoOvrAppId: {},
+	QuestAppId: {},
+	PcvrAppId:  {},
+}
+
+// boundAppIDTag emits an allow-listed app ID verbatim, else metricTagOther.
+// Cardinality is bounded to len(knownAppIDSet)+1.
+func boundAppIDTag(appID uint64) string {
+	if _, ok := knownAppIDSet[appID]; ok {
+		return strconv.FormatUint(appID, 10)
+	}
+	return metricTagOther
+}
 
 // canonicalHeadsetTypes is the bounded universe of headset tag values: the
 // canonical names produced by headsetMappings, plus normalizeHeadsetType's
@@ -176,20 +233,20 @@ func absInt64(v int64) int64 {
 // sentinel.
 func systemInfoTagCardinalityBound(field string) int {
 	switch field {
-	case "cpu_model":
-		return len(cpuModelAllowlist) + 1
-	case "gpu_model":
-		return len(gpuModelAllowlist) + 1
 	case "network_type":
 		return len(networkTypeAllowlist) + 1
-	case "driver_version":
-		return len(driverVersionAllowlist) + 1
-	case "headset_type":
+	case "headset_type", "device_type":
 		return len(canonicalHeadsetTypes) + 1
 	case "total_memory":
 		return len(memoryTiersGiB) + 1
 	case "num_logical_cores", "num_physical_cores":
 		return (maxPlausibleCores - minPlausibleCores + 1) + 1
+	case "build_number", "build_version":
+		return len(knownBuildSet) + 1
+	case "app_id":
+		return len(knownAppIDSet) + 1
+	case "publisher_lock":
+		return len(publisherLockAllowlist) + 1
 	default:
 		return 0
 	}
@@ -208,10 +265,7 @@ func systemInfoTagCardinalityBound(field string) int {
 // Every SystemInfo-derived tag written here is bounded: strings to allow-lists,
 // ints (memory/cores) to bucket sets. No SystemInfo field is emitted raw.
 func addSystemInfoMetricTags(tags map[string]string, si evr.SystemInfo) {
-	tags["cpu_model"] = cpuModelAllowlist.normalize(si.CPUModel)
-	tags["gpu_model"] = gpuModelAllowlist.normalize(si.VideoCard)
 	tags["network_type"] = networkTypeAllowlist.normalize(si.NetworkType)
-	tags["driver_version"] = driverVersionAllowlist.normalize(si.DriverVersion)
 	tags["headset_type"] = boundHeadsetMetricTag(si.HeadsetType)
 	tags["total_memory"] = boundMemoryTotalTag(si.MemoryTotal)
 	tags["num_logical_cores"] = boundCoreCountTag(si.NumLogicalCores)
@@ -251,14 +305,17 @@ const (
 	maxTrackedPlayersForSystemLimit = 50000
 )
 
-// systemInfoFingerprint hashes the already-bounded SEC-4 tag tuple into a single
-// value identifying a "system". Only sec4TagFields participate: non-SEC-4 keys
-// (total_memory, cores, build_number) are intentionally excluded so churn on them
-// does not manufacture new systems. Two logins that bucket identically per field
-// share a fingerprint and therefore do not add cardinality.
+// systemInfoFingerprint hashes the already-bounded login tag tuple into a single
+// value identifying a "system". Every attacker-controlled login_success tag
+// (loginMetricFingerprintFields — SystemInfo subset plus build_number/app_id/
+// publisher_lock and their device_type/build_version duplicates) participates, so a
+// player who varies ANY of these fields walks the same capped fingerprint space.
+// Non-attacker keys (websocket_auth, is_vr, error, ...) are excluded so churn on
+// them does not manufacture new systems. Two logins that bucket identically per
+// field share a fingerprint and therefore do not add cardinality.
 func systemInfoFingerprint(tags map[string]string) uint64 {
 	h := fnv.New64a()
-	for _, f := range systemInfoMetricTagFields {
+	for _, f := range loginMetricFingerprintFields {
 		_, _ = h.Write([]byte(tags[f]))
 		_, _ = h.Write([]byte{0}) // separator: avoid "ab"+"c" == "a"+"bc" collisions
 	}
@@ -349,7 +406,7 @@ func boundSystemsPerPlayer(l *systemFingerprintLimiter, tags map[string]string, 
 	if l.allow(playerID, systemInfoFingerprint(tags)) {
 		return
 	}
-	for _, f := range systemInfoMetricTagFields {
+	for _, f := range loginMetricFingerprintFields {
 		tags[f] = metricTagOther
 	}
 }

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -1,10 +1,20 @@
 package server
 
 import (
+	"container/list"
+	"hash/fnv"
 	"strings"
+	"sync"
 
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
+
+// sec4TagFields is the fixed, ordered set of attacker-controlled SystemInfo
+// string fields bounded by SEC-4. It is the single source of truth for both the
+// per-player system fingerprint (systemInfoFingerprint) and the beyond-cap
+// collapse (boundSystemsPerPlayer). Order is load-bearing: the fingerprint hash
+// depends on it, so do not reorder.
+var sec4TagFields = []string{"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type"}
 
 // metricTagOther is the sentinel bucket for any client-supplied SystemInfo
 // value that is not on the bounded allow-list. Bucketing unknown values here
@@ -135,4 +145,131 @@ func systemInfoMetricTags(si evr.SystemInfo) map[string]string {
 	tags := make(map[string]string, 5)
 	addSystemInfoMetricTags(tags, si)
 	return tags
+}
+
+// SEC-4 (per-player distinct-system cap): the allow-lists above bound each field
+// independently, but the emitted metric series is the *tuple* of bounded fields.
+// A single authenticated player who reconnects over and over cycling different
+// allow-listed combinations can still walk that tuple space and churn Prometheus
+// series (Andrew's review note on this file). boundSystemsPerPlayer caps how many
+// distinct bounded tuples ("systems") one player may mint: beyond the cap, further
+// new systems collapse to the metricTagOther sentinel — the same bucketing SEC-4
+// already uses — so no additional series is created.
+const (
+	// maxDistinctSystemsPerPlayer is the per-player distinct-system cap. A real
+	// player has a small handful of machines (a PC, a standalone headset) whose
+	// bounded tuple changes only occasionally (GPU/driver upgrade). 8 gives ample
+	// headroom for legitimate churn while making abuse (dozens+ of systems) collapse
+	// to "other". Exceeding the cap is metrics-only: it never blocks a login, it only
+	// buckets that login's SEC-4 tags to the sentinel.
+	maxDistinctSystemsPerPlayer = 8
+	// maxTrackedPlayersForSystemLimit bounds tracker memory via a player-level LRU.
+	// Worst-case retained state is maxTrackedPlayersForSystemLimit *
+	// maxDistinctSystemsPerPlayer uint64 fingerprints (~a few MB at these values).
+	// Evicting the least-recently-active player is safe: on their next login they
+	// simply start counting systems from zero again.
+	maxTrackedPlayersForSystemLimit = 50000
+)
+
+// systemInfoFingerprint hashes the already-bounded SEC-4 tag tuple into a single
+// value identifying a "system". Only sec4TagFields participate: non-SEC-4 keys
+// (total_memory, cores, build_number) are intentionally excluded so churn on them
+// does not manufacture new systems. Two logins that bucket identically per field
+// share a fingerprint and therefore do not add cardinality.
+func systemInfoFingerprint(tags map[string]string) uint64 {
+	h := fnv.New64a()
+	for _, f := range sec4TagFields {
+		_, _ = h.Write([]byte(tags[f]))
+		_, _ = h.Write([]byte{0}) // separator: avoid "ab"+"c" == "a"+"bc" collisions
+	}
+	return h.Sum64()
+}
+
+// systemFingerprintLimiter tracks, per player, the set of distinct system
+// fingerprints seen, capped at maxPerPlayer. A player-level LRU bounds total
+// memory at maxPlayers. It is safe for concurrent use by the login path.
+type systemFingerprintLimiter struct {
+	mu           sync.Mutex
+	maxPerPlayer int
+	maxPlayers   int
+	order        *list.List               // front = most-recently-active; values are *playerSystems
+	index        map[string]*list.Element // playerID -> element in order
+}
+
+// playerSystems is one player's bounded set of distinct system fingerprints.
+type playerSystems struct {
+	playerID string
+	seen     map[uint64]struct{}
+}
+
+func newSystemFingerprintLimiter(maxPerPlayer, maxPlayers int) *systemFingerprintLimiter {
+	return &systemFingerprintLimiter{
+		maxPerPlayer: maxPerPlayer,
+		maxPlayers:   maxPlayers,
+		order:        list.New(),
+		index:        make(map[string]*list.Element, maxPlayers),
+	}
+}
+
+// allow reports whether player may emit a distinct metric series for fingerprint
+// fp. An already-seen fingerprint always returns true. A new fingerprint returns
+// true and is recorded while the player is under maxPerPlayer; once at the cap,
+// new fingerprints return false and are NOT recorded, keeping the set bounded.
+// Every access moves the player to the front of the LRU (active players resist
+// eviction); a new player may evict the least-recently-active one.
+func (l *systemFingerprintLimiter) allow(playerID string, fp uint64) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if el, ok := l.index[playerID]; ok {
+		l.order.MoveToFront(el)
+		ps := el.Value.(*playerSystems)
+		if _, seen := ps.seen[fp]; seen {
+			return true
+		}
+		if len(ps.seen) >= l.maxPerPlayer {
+			return false
+		}
+		ps.seen[fp] = struct{}{}
+		return true
+	}
+
+	// New player. Evict the least-recently-active one if at capacity.
+	if l.order.Len() >= l.maxPlayers {
+		if back := l.order.Back(); back != nil {
+			evicted := l.order.Remove(back).(*playerSystems)
+			delete(l.index, evicted.playerID)
+		}
+	}
+	ps := &playerSystems{playerID: playerID, seen: map[uint64]struct{}{fp: {}}}
+	l.index[playerID] = l.order.PushFront(ps)
+	return true
+}
+
+// trackedPlayers returns the number of players currently held. Test-support only.
+func (l *systemFingerprintLimiter) trackedPlayers() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.order.Len()
+}
+
+// loginSystemFingerprintLimiter is the process-wide limiter for the login path.
+var loginSystemFingerprintLimiter = newSystemFingerprintLimiter(maxDistinctSystemsPerPlayer, maxTrackedPlayersForSystemLimit)
+
+// boundSystemsPerPlayer applies the per-player distinct-system cap on top of the
+// per-field SEC-4 allow-list bounding already written into tags. If the player has
+// exceeded maxPerPlayer distinct systems, every SEC-4 field collapses to
+// metricTagOther so this login mints no new series. An empty playerID (identity
+// unavailable) is not tracked — pooling unrelated players under one key would
+// over-collapse — so its tags pass through unchanged.
+func boundSystemsPerPlayer(l *systemFingerprintLimiter, tags map[string]string, playerID string) {
+	if playerID == "" {
+		return
+	}
+	if l.allow(playerID, systemInfoFingerprint(tags)) {
+		return
+	}
+	for _, f := range sec4TagFields {
+		tags[f] = metricTagOther
+	}
 }

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -109,21 +109,30 @@ func systemInfoTagCardinalityBound(field string) int {
 	}
 }
 
-// systemInfoMetricTags builds the client-controlled portion of the login metric
-// tags from a SystemInfo login payload, with every attacker-controlled string
-// bounded to its allow-list (unknown values bucket to metricTagOther).
+// addSystemInfoMetricTags writes the client-controlled portion of the login
+// metric tags directly into the caller's existing tags map, with every
+// attacker-controlled string bounded to its allow-list (unknown values bucket
+// to metricTagOther). Writing in place avoids an intermediate map allocation on
+// the login path.
 //
 // SEC-4: these fields are attacker-controlled JSON from the login payload.
 // Emitting the raw strings as metric tag values would let one authenticated
 // account mint an unbounded number of distinct Prometheus series (one per
 // unique tuple) by randomizing SystemInfo on repeated logins ->
 // metrics-backend memory pressure. See BUGS.md SEC-4.
+func addSystemInfoMetricTags(tags map[string]string, si evr.SystemInfo) {
+	tags["cpu_model"] = cpuModelAllowlist.normalize(si.CPUModel)
+	tags["gpu_model"] = gpuModelAllowlist.normalize(si.VideoCard)
+	tags["network_type"] = networkTypeAllowlist.normalize(si.NetworkType)
+	tags["driver_version"] = driverVersionAllowlist.normalize(si.DriverVersion)
+	tags["headset_type"] = boundHeadsetMetricTag(si.HeadsetType)
+}
+
+// systemInfoMetricTags builds a fresh map of the bounded SEC-4 tags. It is a
+// thin wrapper over addSystemInfoMetricTags retained for tests; the login path
+// uses addSystemInfoMetricTags to write into its existing tags map.
 func systemInfoMetricTags(si evr.SystemInfo) map[string]string {
-	return map[string]string{
-		"cpu_model":      cpuModelAllowlist.normalize(si.CPUModel),
-		"gpu_model":      gpuModelAllowlist.normalize(si.VideoCard),
-		"network_type":   networkTypeAllowlist.normalize(si.NetworkType),
-		"driver_version": driverVersionAllowlist.normalize(si.DriverVersion),
-		"headset_type":   boundHeadsetMetricTag(si.HeadsetType),
-	}
+	tags := make(map[string]string, 5)
+	addSystemInfoMetricTags(tags, si)
+	return tags
 }

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -110,19 +110,20 @@ func systemInfoTagCardinalityBound(field string) int {
 }
 
 // systemInfoMetricTags builds the client-controlled portion of the login metric
-// tags from a SystemInfo login payload.
+// tags from a SystemInfo login payload, with every attacker-controlled string
+// bounded to its allow-list (unknown values bucket to metricTagOther).
 //
-// SEC-4: every field below is attacker-controlled JSON from the login payload.
-// Emitting the raw strings as metric tag values lets one authenticated account
-// mint an unbounded number of distinct Prometheus series (one per unique tuple)
-// by randomizing SystemInfo on repeated logins -> metrics-backend memory
-// pressure. See BUGS.md SEC-4.
+// SEC-4: these fields are attacker-controlled JSON from the login payload.
+// Emitting the raw strings as metric tag values would let one authenticated
+// account mint an unbounded number of distinct Prometheus series (one per
+// unique tuple) by randomizing SystemInfo on repeated logins ->
+// metrics-backend memory pressure. See BUGS.md SEC-4.
 func systemInfoMetricTags(si evr.SystemInfo) map[string]string {
 	return map[string]string{
-		"cpu_model":      strings.TrimSpace(si.CPUModel),
-		"gpu_model":      strings.TrimSpace(si.VideoCard),
-		"network_type":   si.NetworkType,
-		"driver_version": strings.TrimSpace(si.DriverVersion),
-		"headset_type":   normalizeHeadsetType(si.HeadsetType),
+		"cpu_model":      cpuModelAllowlist.normalize(si.CPUModel),
+		"gpu_model":      gpuModelAllowlist.normalize(si.VideoCard),
+		"network_type":   networkTypeAllowlist.normalize(si.NetworkType),
+		"driver_version": driverVersionAllowlist.normalize(si.DriverVersion),
+		"headset_type":   boundHeadsetMetricTag(si.HeadsetType),
 	}
 }

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"strings"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// metricTagOther is the sentinel bucket for any client-supplied SystemInfo
+// value that is not on the bounded allow-list. Bucketing unknown values here
+// (rather than emitting the raw client string) is what bounds metrics
+// cardinality for SEC-4: a randomized login payload cannot mint an unbounded
+// number of distinct Prometheus series.
+const metricTagOther = "other"
+
+// tagAllowlist is a case-sensitive (after strings.TrimSpace) set of known-good
+// values for a single client-controlled metric tag.
+//
+// OPS: these sets are the single, data-driven place to extend coverage. When a
+// legitimate value starts showing up bucketed as "other" in the metrics
+// backend, add the exact string to the corresponding set below and redeploy.
+// Adding values never weakens the cardinality bound — the set is finite and
+// curated — it only sharpens the signal.
+type tagAllowlist map[string]struct{}
+
+func newTagAllowlist(values ...string) tagAllowlist {
+	set := make(tagAllowlist, len(values))
+	for _, v := range values {
+		set[v] = struct{}{}
+	}
+	return set
+}
+
+// normalize returns the trimmed value if it is on the allow-list, otherwise
+// metricTagOther. Empty input also buckets to metricTagOther.
+func (a tagAllowlist) normalize(raw string) string {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return metricTagOther
+	}
+	if _, ok := a[v]; ok {
+		return v
+	}
+	return metricTagOther
+}
+
+var (
+	// cpuModelAllowlist / gpuModelAllowlist / driverVersionAllowlist are seeded
+	// empty on purpose: there is no production ground-truth list of legitimate
+	// values in-repo. Until OPS populates these from real telemetry, every value
+	// buckets to metricTagOther — the SEC-4 cardinality bound holds immediately,
+	// at the cost of signal on these fields until the list is filled.
+	cpuModelAllowlist      = newTagAllowlist()
+	gpuModelAllowlist      = newTagAllowlist()
+	driverVersionAllowlist = newTagAllowlist()
+
+	// networkTypeAllowlist is seeded with the only value evidenced in-repo.
+	// OPS: add other engine-reported network types (e.g. wired/ethernet/offline)
+	// as they are observed.
+	networkTypeAllowlist = newTagAllowlist(
+		"WiFi",
+	)
+)
+
+// canonicalHeadsetTypes is the bounded universe of headset tag values: the
+// canonical names produced by headsetMappings, plus normalizeHeadsetType's
+// "Unknown" empty-input sentinel. boundHeadsetMetricTag uses this to bucket any
+// unrecognized headset to metricTagOther for metrics, without changing the
+// shared normalizeHeadsetType (still used by the forensic login-history record
+// and DeviceType(), which must keep the real reported string).
+var canonicalHeadsetTypes = func() map[string]struct{} {
+	set := make(map[string]struct{}, len(headsetMappings)+1)
+	for _, canonical := range headsetMappings {
+		set[canonical] = struct{}{}
+	}
+	set["Unknown"] = struct{}{}
+	return set
+}()
+
+// boundHeadsetMetricTag normalizes a headset string and, crucially, buckets
+// anything that is not a known canonical headset to metricTagOther.
+// normalizeHeadsetType alone falls through to the raw client string (SEC-4);
+// this closes that hole for the metrics path only.
+func boundHeadsetMetricTag(raw string) string {
+	hs := normalizeHeadsetType(raw)
+	if _, ok := canonicalHeadsetTypes[hs]; ok {
+		return hs
+	}
+	return metricTagOther
+}
+
+// systemInfoTagCardinalityBound returns the maximum number of distinct values a
+// given SEC-4 metric tag may take: allow-list size + 1 for the metricTagOther
+// sentinel. headset_type also allows the "Unknown" empty-input sentinel.
+func systemInfoTagCardinalityBound(field string) int {
+	switch field {
+	case "cpu_model":
+		return len(cpuModelAllowlist) + 1
+	case "gpu_model":
+		return len(gpuModelAllowlist) + 1
+	case "network_type":
+		return len(networkTypeAllowlist) + 1
+	case "driver_version":
+		return len(driverVersionAllowlist) + 1
+	case "headset_type":
+		return len(canonicalHeadsetTypes) + 1
+	default:
+		return 0
+	}
+}
+
+// systemInfoMetricTags builds the client-controlled portion of the login metric
+// tags from a SystemInfo login payload.
+//
+// SEC-4: every field below is attacker-controlled JSON from the login payload.
+// Emitting the raw strings as metric tag values lets one authenticated account
+// mint an unbounded number of distinct Prometheus series (one per unique tuple)
+// by randomizing SystemInfo on repeated logins -> metrics-backend memory
+// pressure. See BUGS.md SEC-4.
+func systemInfoMetricTags(si evr.SystemInfo) map[string]string {
+	return map[string]string{
+		"cpu_model":      strings.TrimSpace(si.CPUModel),
+		"gpu_model":      strings.TrimSpace(si.VideoCard),
+		"network_type":   si.NetworkType,
+		"driver_version": strings.TrimSpace(si.DriverVersion),
+		"headset_type":   normalizeHeadsetType(si.HeadsetType),
+	}
+}

--- a/server/evr_metrics_tags_test.go
+++ b/server/evr_metrics_tags_test.go
@@ -53,6 +53,32 @@ func TestSystemInfoMetricTagCardinality(t *testing.T) {
 	}
 }
 
+// TestAddSystemInfoMetricTagsWritesInPlace proves addSystemInfoMetricTags writes
+// the bounded SEC-4 tags directly into the caller's existing map (no intermediate
+// map allocation) without clobbering pre-existing keys. SEC-4 bounding must be
+// identical to systemInfoMetricTags.
+func TestAddSystemInfoMetricTagsWritesInPlace(t *testing.T) {
+	tags := map[string]string{"existing": "keep-me"}
+	addSystemInfoMetricTags(tags, evr.SystemInfo{
+		NetworkType: "WiFi",    // seeded allow-list value
+		HeadsetType: "Quest 3", // maps to canonical "Meta Quest 3"
+		CPUModel:    "totally-made-up-cpu-string",
+	})
+
+	if got := tags["existing"]; got != "keep-me" {
+		t.Errorf("pre-existing key clobbered: got %q, want %q", got, "keep-me")
+	}
+	if got := tags["network_type"]; got != "WiFi" {
+		t.Errorf("network_type: known-good value not preserved: got %q, want %q", got, "WiFi")
+	}
+	if got := tags["headset_type"]; got != "Meta Quest 3" {
+		t.Errorf("headset_type: known headset not normalized: got %q, want %q", got, "Meta Quest 3")
+	}
+	if got := tags["cpu_model"]; got != metricTagOther {
+		t.Errorf("cpu_model: unknown value not bucketed: got %q, want %q", got, metricTagOther)
+	}
+}
+
 // TestSystemInfoMetricTagKnownGoodPassthrough proves the fix does not lose
 // legitimate cardinality: values on the allow-list survive unchanged, while
 // unknown values bucket to the sentinel rather than passing raw through.

--- a/server/evr_metrics_tags_test.go
+++ b/server/evr_metrics_tags_test.go
@@ -10,8 +10,10 @@ import (
 )
 
 // sec4Fields are the attacker-controlled SystemInfo strings that flow into
-// login metric tags (BUGS.md SEC-4).
-var sec4Fields = []string{"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type"}
+// login metric tags (BUGS.md SEC-4). F4 dropped cpu_model/gpu_model/driver_version
+// (empty allow-lists → permanently "other"); the bounded string fields that remain
+// are network_type and headset_type.
+var sec4Fields = []string{"network_type", "headset_type"}
 
 // randomSystemInfo returns a SystemInfo whose SEC-4 string fields are all
 // unique per call, simulating an attacker randomizing the login payload.
@@ -61,9 +63,9 @@ func TestSystemInfoMetricTagCardinality(t *testing.T) {
 func TestAddSystemInfoMetricTagsWritesInPlace(t *testing.T) {
 	tags := map[string]string{"existing": "keep-me"}
 	addSystemInfoMetricTags(tags, evr.SystemInfo{
-		NetworkType: "WiFi",    // seeded allow-list value
-		HeadsetType: "Quest 3", // maps to canonical "Meta Quest 3"
-		CPUModel:    "totally-made-up-cpu-string",
+		NetworkType: "WiFi",     // seeded allow-list value
+		HeadsetType: "Quest 3",  // maps to canonical "Meta Quest 3"
+		CPUModel:    "unlisted", // F4: no longer emitted as a metric tag
 	})
 
 	if got := tags["existing"]; got != "keep-me" {
@@ -75,8 +77,8 @@ func TestAddSystemInfoMetricTagsWritesInPlace(t *testing.T) {
 	if got := tags["headset_type"]; got != "Meta Quest 3" {
 		t.Errorf("headset_type: known headset not normalized: got %q, want %q", got, "Meta Quest 3")
 	}
-	if got := tags["cpu_model"]; got != metricTagOther {
-		t.Errorf("cpu_model: unknown value not bucketed: got %q, want %q", got, metricTagOther)
+	if _, ok := tags["cpu_model"]; ok {
+		t.Errorf("cpu_model: F4-dropped tag must not be emitted, got %q", tags["cpu_model"])
 	}
 }
 
@@ -169,16 +171,18 @@ func TestSystemInfoIntTagCardinality(t *testing.T) {
 }
 
 // TestSystemInfoFingerprintDeterministicAndDistinct proves the per-player
-// fingerprint is stable for identical bounded tuples, changes when a SEC-4 field
-// changes, and — crucially — ignores keys outside systemInfoMetricTagFields
-// (e.g. build_number) so churn on non-SystemInfo tags does not manufacture new
+// fingerprint is stable for identical bounded tuples, changes when ANY
+// attacker-controlled login tag changes (loginMetricFingerprintFields — including
+// the LoginProfile-derived build_number/app_id/publisher_lock), and ignores
+// non-attacker keys (e.g. websocket_auth) so churn on them does not manufacture new
 // "systems".
 func TestSystemInfoFingerprintDeterministicAndDistinct(t *testing.T) {
 	mk := func(headset string) map[string]string {
 		return map[string]string{
-			"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi",
-			"driver_version": metricTagOther, "headset_type": headset,
+			"network_type": "WiFi", "headset_type": headset,
 			"total_memory": "16", "num_logical_cores": "8", "num_physical_cores": "8",
+			"build_number": "630783", "app_id": "0", "publisher_lock": "rad15_live",
+			"device_type": headset, "build_version": "630783",
 		}
 	}
 	a, b := mk("Meta Quest 3"), mk("Meta Quest 3")
@@ -192,12 +196,20 @@ func TestSystemInfoFingerprintDeterministicAndDistinct(t *testing.T) {
 	mem := mk("Meta Quest 3")
 	mem["total_memory"] = "32"
 	if systemInfoFingerprint(a) == systemInfoFingerprint(mem) {
-		t.Errorf("total_memory is a SEC-4 field and must affect the fingerprint")
+		t.Errorf("total_memory is a fingerprint field and must affect the fingerprint")
 	}
-	// A key outside systemInfoMetricTagFields must NOT.
-	a["build_number"] = "123456789"
+	// LoginProfile-derived fields ARE part of the fingerprint (folded into the cap).
+	for _, f := range []string{"build_number", "app_id", "publisher_lock"} {
+		v := mk("Meta Quest 3")
+		v[f] = "different-bounded-value"
+		if systemInfoFingerprint(a) == systemInfoFingerprint(v) {
+			t.Errorf("field %q must affect the fingerprint (folded into the per-player cap)", f)
+		}
+	}
+	// A non-attacker key must NOT affect the fingerprint.
+	a["websocket_auth"] = "true"
 	if systemInfoFingerprint(a) != systemInfoFingerprint(b) {
-		t.Errorf("keys outside systemInfoMetricTagFields must not affect the fingerprint")
+		t.Errorf("non-attacker keys must not affect the fingerprint")
 	}
 }
 
@@ -368,7 +380,6 @@ func TestSystemInfoMetricTagKnownGoodPassthrough(t *testing.T) {
 	tags := systemInfoMetricTags(evr.SystemInfo{
 		NetworkType: "WiFi",    // seeded allow-list value
 		HeadsetType: "Quest 3", // maps to canonical "Meta Quest 3"
-		CPUModel:    "totally-made-up-cpu-string",
 	})
 
 	if got := tags["network_type"]; got != "WiFi" {
@@ -377,7 +388,8 @@ func TestSystemInfoMetricTagKnownGoodPassthrough(t *testing.T) {
 	if got := tags["headset_type"]; got != "Meta Quest 3" {
 		t.Errorf("headset_type: known headset not normalized: got %q, want %q", got, "Meta Quest 3")
 	}
-	if got := tags["cpu_model"]; got != metricTagOther {
-		t.Errorf("cpu_model: unknown value not bucketed: got %q, want %q", got, metricTagOther)
+	// An unlisted headset must bucket to the sentinel, not pass raw.
+	if got := boundHeadsetMetricTag("totally-made-up-headset"); got != metricTagOther {
+		t.Errorf("unlisted headset: not bucketed: got %q, want %q", got, metricTagOther)
 	}
 }

--- a/server/evr_metrics_tags_test.go
+++ b/server/evr_metrics_tags_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"math/rand"
+	"sync"
 	"testing"
 
 	"github.com/heroiclabs/nakama/v3/server/evr"
@@ -76,6 +77,186 @@ func TestAddSystemInfoMetricTagsWritesInPlace(t *testing.T) {
 	}
 	if got := tags["cpu_model"]; got != metricTagOther {
 		t.Errorf("cpu_model: unknown value not bucketed: got %q, want %q", got, metricTagOther)
+	}
+}
+
+// TestSystemInfoFingerprintDeterministicAndDistinct proves the per-player
+// fingerprint is stable for identical bounded tuples, changes when a SEC-4 field
+// changes, and — crucially — ignores non-SEC-4 keys (total_memory, cores,
+// build_number) so churn on those does not manufacture new "systems".
+func TestSystemInfoFingerprintDeterministicAndDistinct(t *testing.T) {
+	a := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 3"}
+	b := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 3"}
+	if systemInfoFingerprint(a) != systemInfoFingerprint(b) {
+		t.Errorf("identical bounded tuples must fingerprint equal")
+	}
+	c := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 2"}
+	if systemInfoFingerprint(a) == systemInfoFingerprint(c) {
+		t.Errorf("different bounded tuples must fingerprint differently")
+	}
+	a["total_memory"] = "123456789"
+	if systemInfoFingerprint(a) != systemInfoFingerprint(b) {
+		t.Errorf("non-SEC-4 keys must not affect the system fingerprint")
+	}
+}
+
+// TestSystemFingerprintLimiterCapsDistinctPerPlayer proves a single player is
+// capped at maxPerPlayer distinct systems: the first cap are admitted, further
+// NEW fingerprints are denied (collapse to sentinel), and already-seen ones are
+// always admitted.
+func TestSystemFingerprintLimiterCapsDistinctPerPlayer(t *testing.T) {
+	const capN = 4
+	l := newSystemFingerprintLimiter(capN, 100)
+	const player = "p1"
+
+	for i := 0; i < capN; i++ {
+		if !l.allow(player, uint64(i)) {
+			t.Fatalf("fingerprint %d: want allowed (under cap), got denied", i)
+		}
+	}
+	if !l.allow(player, 0) {
+		t.Errorf("already-seen fingerprint 0: want allowed, got denied")
+	}
+	for i := capN; i < capN+5; i++ {
+		if l.allow(player, uint64(i)) {
+			t.Errorf("fingerprint %d: want denied (over cap), got allowed", i)
+		}
+	}
+	if !l.allow(player, uint64(capN-1)) {
+		t.Errorf("already-seen fingerprint %d after cap: want allowed, got denied", capN-1)
+	}
+}
+
+// TestSystemFingerprintLimiterIsPerPlayer proves one player saturating their cap
+// does not affect another player's independent budget.
+func TestSystemFingerprintLimiterIsPerPlayer(t *testing.T) {
+	const capN = 2
+	l := newSystemFingerprintLimiter(capN, 100)
+
+	l.allow("A", 1)
+	l.allow("A", 2)
+	if l.allow("A", 3) {
+		t.Fatalf("player A over cap: want denied")
+	}
+	for i := uint64(0); i < uint64(capN); i++ {
+		if !l.allow("B", 100+i) {
+			t.Errorf("player B fingerprint %d: want allowed, got denied", 100+i)
+		}
+	}
+}
+
+// TestSystemFingerprintLimiterEvictsLRUPlayers proves the tracker is
+// memory-bounded: it never holds more than maxPlayers, evicting the
+// least-recently-used player, whose state resets on re-appearance.
+func TestSystemFingerprintLimiterEvictsLRUPlayers(t *testing.T) {
+	const maxPlayers = 3
+	l := newSystemFingerprintLimiter(4, maxPlayers)
+
+	for p := 0; p < maxPlayers; p++ {
+		l.allow(fmt.Sprintf("p%d", p), 1)
+	}
+	if got := l.trackedPlayers(); got != maxPlayers {
+		t.Fatalf("tracked players: got %d, want %d", got, maxPlayers)
+	}
+	// New player overflows the tracker -> LRU (p0) evicted, stays bounded.
+	l.allow("p3", 1)
+	if got := l.trackedPlayers(); got != maxPlayers {
+		t.Fatalf("tracked players after overflow: got %d, want %d (LRU not bounded)", got, maxPlayers)
+	}
+	// p0 was evicted: fresh state, admits up to cap distinct systems again.
+	for f := 0; f < 4; f++ {
+		if !l.allow("p0", uint64(1000+f)) {
+			t.Errorf("evicted p0 fresh fingerprint %d: want allowed, got denied", 1000+f)
+		}
+	}
+}
+
+// TestSystemFingerprintLimiterConcurrent exercises allow() under the race
+// detector and asserts the player LRU stays bounded under contention.
+func TestSystemFingerprintLimiterConcurrent(t *testing.T) {
+	l := newSystemFingerprintLimiter(8, 64)
+	var wg sync.WaitGroup
+	for g := 0; g < 32; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(seed)))
+			for i := 0; i < 500; i++ {
+				l.allow(fmt.Sprintf("p%d", rng.Intn(128)), rng.Uint64())
+			}
+		}(g)
+	}
+	wg.Wait()
+	if got := l.trackedPlayers(); got > 64 {
+		t.Errorf("tracked players %d exceeds max 64 under concurrency", got)
+	}
+}
+
+// TestBoundSystemsPerPlayerCollapsesBeyondCap proves the integration helper: the
+// first cap distinct systems keep their bounded tags, systems beyond the cap
+// collapse every SEC-4 field to metricTagOther, and a previously-admitted system
+// is still emitted with its real tags.
+func TestBoundSystemsPerPlayerCollapsesBeyondCap(t *testing.T) {
+	const capN = 2
+	l := newSystemFingerprintLimiter(capN, 100)
+	const player = "abuser"
+
+	mk := func(headset string) map[string]string {
+		return map[string]string{
+			"cpu_model":      metricTagOther,
+			"gpu_model":      metricTagOther,
+			"network_type":   "WiFi",
+			"driver_version": metricTagOther,
+			"headset_type":   headset,
+		}
+	}
+
+	systems := []string{"sys-a", "sys-b", "sys-c", "sys-d"}
+	for i, s := range systems {
+		tags := mk(s)
+		boundSystemsPerPlayer(l, tags, player)
+		if i < capN {
+			if tags["headset_type"] != s {
+				t.Errorf("system %d under cap: headset_type collapsed to %q, want %q", i, tags["headset_type"], s)
+			}
+			continue
+		}
+		for _, f := range sec4TagFields {
+			if tags[f] != metricTagOther {
+				t.Errorf("system %d over cap: field %q = %q, want %q", i, f, tags[f], metricTagOther)
+			}
+		}
+	}
+
+	// A previously-admitted system is still emitted with its real tags.
+	tags := mk("sys-a")
+	boundSystemsPerPlayer(l, tags, player)
+	if tags["headset_type"] != "sys-a" {
+		t.Errorf("re-seen system: headset_type = %q, want %q", tags["headset_type"], "sys-a")
+	}
+}
+
+// TestBoundSystemsPerPlayerEmptyPlayerIDSkips proves an unavailable player ID is
+// NOT tracked (which would pool unrelated players under one key) and never
+// collapses tags.
+func TestBoundSystemsPerPlayerEmptyPlayerIDSkips(t *testing.T) {
+	l := newSystemFingerprintLimiter(1, 100)
+	for i := 0; i < 10; i++ {
+		want := fmt.Sprintf("sys-%d", i)
+		tags := map[string]string{
+			"cpu_model":      metricTagOther,
+			"gpu_model":      metricTagOther,
+			"network_type":   "WiFi",
+			"driver_version": metricTagOther,
+			"headset_type":   want,
+		}
+		boundSystemsPerPlayer(l, tags, "")
+		if tags["headset_type"] != want {
+			t.Errorf("empty playerID system %d: collapsed to %q, want passthrough %q", i, tags["headset_type"], want)
+		}
+	}
+	if got := l.trackedPlayers(); got != 0 {
+		t.Errorf("empty playerID must not be tracked: tracked=%d, want 0", got)
 	}
 }
 

--- a/server/evr_metrics_tags_test.go
+++ b/server/evr_metrics_tags_test.go
@@ -80,23 +80,124 @@ func TestAddSystemInfoMetricTagsWritesInPlace(t *testing.T) {
 	}
 }
 
+// TestBoundMemoryTotalTag proves MemoryTotal (attacker-controlled bytes) buckets
+// to a coarse GB tier, with adversarial / out-of-band values collapsing to the
+// metricTagOther sentinel.
+func TestBoundMemoryTotalTag(t *testing.T) {
+	cases := []struct {
+		name  string
+		bytes int64
+		want  string
+	}{
+		{"rtx3080-fixture-16gb", 16777216000, "16"}, // real login-history capture
+		{"8gib-exact", 8 * (1 << 30), "8"},
+		{"12gib-exact", 12 * (1 << 30), "12"},
+		{"16gib-exact", 16 * (1 << 30), "16"},
+		{"32gib-exact", 32 * (1 << 30), "32"},
+		{"128gib-exact", 128 * (1 << 30), "128"},
+		{"4gib-exact", 4 * (1 << 30), "4"},
+		{"2gib-below-band", 2 * (1 << 30), metricTagOther},
+		{"mock-16384-bytes-tiny", 16384, metricTagOther},
+		{"zero", 0, metricTagOther},
+		{"negative", -1 << 40, metricTagOther},
+		{"300gib-above-band", 300 * (1 << 30), metricTagOther},
+		{"absurd-petabyte", 1 << 50, metricTagOther},
+	}
+	for _, c := range cases {
+		if got := boundMemoryTotalTag(c.bytes); got != c.want {
+			t.Errorf("%s: boundMemoryTotalTag(%d) = %q, want %q", c.name, c.bytes, got, c.want)
+		}
+	}
+}
+
+// TestBoundCoreCountTag proves core counts clamp to a plausible range, out-of-range
+// values collapsing to metricTagOther.
+func TestBoundCoreCountTag(t *testing.T) {
+	cases := []struct {
+		cores int64
+		want  string
+	}{
+		{1, "1"}, {8, "8"}, {16, "16"}, {64, "64"},
+		{0, metricTagOther}, {65, metricTagOther}, {-4, metricTagOther}, {1 << 40, metricTagOther},
+	}
+	for _, c := range cases {
+		if got := boundCoreCountTag(c.cores); got != c.want {
+			t.Errorf("boundCoreCountTag(%d) = %q, want %q", c.cores, got, c.want)
+		}
+	}
+}
+
+// TestSystemInfoIntTagCardinality is the SEC-4 int-field property: N randomized /
+// adversarial memory & core payloads must NOT produce N distinct tag values. Each
+// int field is bounded by its bucket set (+1 for the "other" sentinel).
+func TestSystemInfoIntTagCardinality(t *testing.T) {
+	const n = 2000
+	rng := rand.New(rand.NewSource(7))
+	intFields := []string{"total_memory", "num_logical_cores", "num_physical_cores"}
+
+	distinct := make(map[string]map[string]struct{}, len(intFields))
+	for _, f := range intFields {
+		distinct[f] = make(map[string]struct{})
+	}
+
+	for i := 0; i < n; i++ {
+		si := evr.SystemInfo{
+			MemoryTotal:      rng.Int63(),
+			NumLogicalCores:  rng.Int63(),
+			NumPhysicalCores: rng.Int63(),
+		}
+		if i%3 == 0 { // also exercise small / in-band adversarial values
+			si.MemoryTotal = int64(rng.Intn(1 << 20))
+			si.NumLogicalCores = int64(rng.Intn(1000))
+			si.NumPhysicalCores = int64(rng.Intn(1000))
+		}
+		tags := systemInfoMetricTags(si)
+		for _, f := range intFields {
+			distinct[f][tags[f]] = struct{}{}
+		}
+	}
+
+	for _, f := range intFields {
+		bound := systemInfoTagCardinalityBound(f)
+		if bound == 0 {
+			t.Errorf("field %q: no cardinality bound registered", f)
+		}
+		if got := len(distinct[f]); got > bound {
+			t.Errorf("field %q: %d distinct values from %d random inputs (bound %d) — unbounded cardinality (SEC-4 int)", f, got, n, bound)
+		}
+	}
+}
+
 // TestSystemInfoFingerprintDeterministicAndDistinct proves the per-player
 // fingerprint is stable for identical bounded tuples, changes when a SEC-4 field
-// changes, and — crucially — ignores non-SEC-4 keys (total_memory, cores,
-// build_number) so churn on those does not manufacture new "systems".
+// changes, and — crucially — ignores keys outside systemInfoMetricTagFields
+// (e.g. build_number) so churn on non-SystemInfo tags does not manufacture new
+// "systems".
 func TestSystemInfoFingerprintDeterministicAndDistinct(t *testing.T) {
-	a := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 3"}
-	b := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 3"}
+	mk := func(headset string) map[string]string {
+		return map[string]string{
+			"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi",
+			"driver_version": metricTagOther, "headset_type": headset,
+			"total_memory": "16", "num_logical_cores": "8", "num_physical_cores": "8",
+		}
+	}
+	a, b := mk("Meta Quest 3"), mk("Meta Quest 3")
 	if systemInfoFingerprint(a) != systemInfoFingerprint(b) {
 		t.Errorf("identical bounded tuples must fingerprint equal")
 	}
-	c := map[string]string{"cpu_model": "x", "gpu_model": metricTagOther, "network_type": "WiFi", "driver_version": metricTagOther, "headset_type": "Meta Quest 2"}
-	if systemInfoFingerprint(a) == systemInfoFingerprint(c) {
+	if systemInfoFingerprint(a) == systemInfoFingerprint(mk("Meta Quest 2")) {
 		t.Errorf("different bounded tuples must fingerprint differently")
 	}
-	a["total_memory"] = "123456789"
+	// A SEC-4 int field IS part of the fingerprint.
+	mem := mk("Meta Quest 3")
+	mem["total_memory"] = "32"
+	if systemInfoFingerprint(a) == systemInfoFingerprint(mem) {
+		t.Errorf("total_memory is a SEC-4 field and must affect the fingerprint")
+	}
+	// A key outside systemInfoMetricTagFields must NOT.
+	a["build_number"] = "123456789"
 	if systemInfoFingerprint(a) != systemInfoFingerprint(b) {
-		t.Errorf("non-SEC-4 keys must not affect the system fingerprint")
+		t.Errorf("keys outside systemInfoMetricTagFields must not affect the fingerprint")
 	}
 }
 
@@ -221,7 +322,7 @@ func TestBoundSystemsPerPlayerCollapsesBeyondCap(t *testing.T) {
 			}
 			continue
 		}
-		for _, f := range sec4TagFields {
+		for _, f := range systemInfoMetricTagFields {
 			if tags[f] != metricTagOther {
 				t.Errorf("system %d over cap: field %q = %q, want %q", i, f, tags[f], metricTagOther)
 			}

--- a/server/evr_metrics_tags_test.go
+++ b/server/evr_metrics_tags_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// sec4Fields are the attacker-controlled SystemInfo strings that flow into
+// login metric tags (BUGS.md SEC-4).
+var sec4Fields = []string{"cpu_model", "gpu_model", "network_type", "driver_version", "headset_type"}
+
+// randomSystemInfo returns a SystemInfo whose SEC-4 string fields are all
+// unique per call, simulating an attacker randomizing the login payload.
+func randomSystemInfo(rng *rand.Rand, i int) evr.SystemInfo {
+	return evr.SystemInfo{
+		CPUModel:      fmt.Sprintf("cpu-%d-%d", i, rng.Int63()),
+		VideoCard:     fmt.Sprintf("gpu-%d-%d", i, rng.Int63()),
+		NetworkType:   fmt.Sprintf("net-%d-%d", i, rng.Int63()),
+		DriverVersion: fmt.Sprintf("drv-%d-%d", i, rng.Int63()),
+		HeadsetType:   fmt.Sprintf("hmd-%d-%d", i, rng.Int63()),
+	}
+}
+
+// TestSystemInfoMetricTagCardinality proves the SEC-4 property: N randomized
+// login payloads must NOT produce N distinct metric-tag values per field. Each
+// attacker-controlled field must be bounded by its allow-list size (+1 for the
+// "other" sentinel).
+func TestSystemInfoMetricTagCardinality(t *testing.T) {
+	const n = 1000
+	rng := rand.New(rand.NewSource(1))
+
+	distinct := make(map[string]map[string]struct{}, len(sec4Fields))
+	for _, f := range sec4Fields {
+		distinct[f] = make(map[string]struct{})
+	}
+
+	for i := 0; i < n; i++ {
+		tags := systemInfoMetricTags(randomSystemInfo(rng, i))
+		for _, f := range sec4Fields {
+			distinct[f][tags[f]] = struct{}{}
+		}
+	}
+
+	for _, f := range sec4Fields {
+		bound := systemInfoTagCardinalityBound(f)
+		got := len(distinct[f])
+		if got > bound {
+			t.Errorf("field %q: %d distinct tag values from %d random inputs (bound %d) — unbounded cardinality (SEC-4)", f, got, n, bound)
+		}
+	}
+}
+
+// TestSystemInfoMetricTagKnownGoodPassthrough proves the fix does not lose
+// legitimate cardinality: values on the allow-list survive unchanged, while
+// unknown values bucket to the sentinel rather than passing raw through.
+func TestSystemInfoMetricTagKnownGoodPassthrough(t *testing.T) {
+	tags := systemInfoMetricTags(evr.SystemInfo{
+		NetworkType: "WiFi",    // seeded allow-list value
+		HeadsetType: "Quest 3", // maps to canonical "Meta Quest 3"
+		CPUModel:    "totally-made-up-cpu-string",
+	})
+
+	if got := tags["network_type"]; got != "WiFi" {
+		t.Errorf("network_type: known-good value not preserved: got %q, want %q", got, "WiFi")
+	}
+	if got := tags["headset_type"]; got != "Meta Quest 3" {
+		t.Errorf("headset_type: known headset not normalized: got %q, want %q", got, "Meta Quest 3")
+	}
+	if got := tags["cpu_model"]; got != metricTagOther {
+		t.Errorf("cpu_model: unknown value not bucketed: got %q, want %q", got, metricTagOther)
+	}
+}

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -150,15 +150,15 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 	// SEC-4: bound attacker-controlled SystemInfo strings to allow-lists so a
 	// randomized login payload cannot blow up metrics cardinality. Unknown
 	// values bucket to metricTagOther; see addSystemInfoMetricTags.
+	// SEC-4: bound every attacker-controlled SystemInfo tag — strings to allow-lists,
+	// ints (memory/cores) to bucket sets — so a randomized login payload cannot blow
+	// up metrics cardinality. addSystemInfoMetricTags writes all of them bounded.
 	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)
 	// SEC-4 (per-player cap): even with per-field bounding, one player reconnecting
 	// with a varying SystemInfo mix can walk the bounded-tuple space and churn
 	// series. Cap the distinct systems a single player may mint; beyond the cap the
-	// SEC-4 fields collapse to metricTagOther. Keyed on the resolved account.
+	// SystemInfo tags collapse to metricTagOther. Keyed on the resolved account.
 	boundSystemsPerPlayer(loginSystemFingerprintLimiter, tags, params.UserID())
-	tags["total_memory"] = strconv.FormatInt(params.loginPayload.SystemInfo.MemoryTotal, 10)
-	tags["num_logical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumLogicalCores, 10)
-	tags["num_physical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumPhysicalCores, 10)
 	tags["build_number"] = strconv.FormatInt(int64(params.loginPayload.BuildNumber), 10)
 	tags["app_id"] = strconv.FormatInt(int64(params.loginPayload.AppId), 10)
 	tags["publisher_lock"] = strings.TrimSpace(params.loginPayload.PublisherLock)

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -147,14 +147,15 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 	StoreParams(ctx, params)
 
 	tags := params.MetricsTags()
-	tags["cpu_model"] = strings.TrimSpace(params.loginPayload.SystemInfo.CPUModel)
-	tags["gpu_model"] = strings.TrimSpace(params.loginPayload.SystemInfo.VideoCard)
-	tags["network_type"] = params.loginPayload.SystemInfo.NetworkType
+	// SEC-4: bound attacker-controlled SystemInfo strings to allow-lists so a
+	// randomized login payload cannot blow up metrics cardinality. Unknown
+	// values bucket to metricTagOther; see systemInfoMetricTags.
+	for k, v := range systemInfoMetricTags(params.loginPayload.SystemInfo) {
+		tags[k] = v
+	}
 	tags["total_memory"] = strconv.FormatInt(params.loginPayload.SystemInfo.MemoryTotal, 10)
 	tags["num_logical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumLogicalCores, 10)
 	tags["num_physical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumPhysicalCores, 10)
-	tags["driver_version"] = strings.TrimSpace(params.loginPayload.SystemInfo.DriverVersion)
-	tags["headset_type"] = normalizeHeadsetType(params.loginPayload.SystemInfo.HeadsetType)
 	tags["build_number"] = strconv.FormatInt(int64(params.loginPayload.BuildNumber), 10)
 	tags["app_id"] = strconv.FormatInt(int64(params.loginPayload.AppId), 10)
 	tags["publisher_lock"] = strings.TrimSpace(params.loginPayload.PublisherLock)

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -149,10 +149,8 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 	tags := params.MetricsTags()
 	// SEC-4: bound attacker-controlled SystemInfo strings to allow-lists so a
 	// randomized login payload cannot blow up metrics cardinality. Unknown
-	// values bucket to metricTagOther; see systemInfoMetricTags.
-	for k, v := range systemInfoMetricTags(params.loginPayload.SystemInfo) {
-		tags[k] = v
-	}
+	// values bucket to metricTagOther; see addSystemInfoMetricTags.
+	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)
 	tags["total_memory"] = strconv.FormatInt(params.loginPayload.SystemInfo.MemoryTotal, 10)
 	tags["num_logical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumLogicalCores, 10)
 	tags["num_physical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumPhysicalCores, 10)

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -146,22 +145,7 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 
 	StoreParams(ctx, params)
 
-	tags := params.MetricsTags()
-	// SEC-4: bound attacker-controlled SystemInfo strings to allow-lists so a
-	// randomized login payload cannot blow up metrics cardinality. Unknown
-	// values bucket to metricTagOther; see addSystemInfoMetricTags.
-	// SEC-4: bound every attacker-controlled SystemInfo tag — strings to allow-lists,
-	// ints (memory/cores) to bucket sets — so a randomized login payload cannot blow
-	// up metrics cardinality. addSystemInfoMetricTags writes all of them bounded.
-	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)
-	// SEC-4 (per-player cap): even with per-field bounding, one player reconnecting
-	// with a varying SystemInfo mix can walk the bounded-tuple space and churn
-	// series. Cap the distinct systems a single player may mint; beyond the cap the
-	// SystemInfo tags collapse to metricTagOther. Keyed on the resolved account.
-	boundSystemsPerPlayer(loginSystemFingerprintLimiter, tags, params.UserID())
-	tags["build_number"] = strconv.FormatInt(int64(params.loginPayload.BuildNumber), 10)
-	tags["app_id"] = strconv.FormatInt(int64(params.loginPayload.AppId), 10)
-	tags["publisher_lock"] = strings.TrimSpace(params.loginPayload.PublisherLock)
+	tags := buildLoginSuccessMetricTags(params, loginSystemFingerprintLimiter)
 
 	p.nk.metrics.CustomCounter("login_success", tags, 1)
 	p.nk.metrics.CustomTimer("login_process_latency", params.MetricsTags(), time.Since(timer))
@@ -203,6 +187,30 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 		gameSettings,
 	}
 	return session.SendEvr(messagesToSend...)
+}
+
+// buildLoginSuccessMetricTags assembles the exact tag set emitted with the
+// login_success counter. It is the single seam the login path and tests share (so
+// tests exercise the real emitted map, not a helper in isolation) and the single
+// place SEC-4 bounding is applied across EVERY attacker-controlled field:
+//   - SystemInfo strings/ints via addSystemInfoMetricTags (allow-list + buckets)
+//   - device_type / build_version via params.MetricsTags() (bounded at that source)
+//   - build_number / app_id / publisher_lock via their allow-lists
+//
+// The fully-bounded tuple then passes through the per-player distinct-system cap
+// (boundSystemsPerPlayer), which collapses every attacker-controlled tag to
+// metricTagOther once one account exceeds maxDistinctSystemsPerPlayer distinct
+// systems — so a single client cannot churn Prometheus series by varying ANY payload
+// field. build_number/app_id/publisher_lock are bounded and written BEFORE the cap so
+// they participate in the fingerprint and the collapse (loginMetricFingerprintFields).
+func buildLoginSuccessMetricTags(params *SessionParameters, limiter *systemFingerprintLimiter) map[string]string {
+	tags := params.MetricsTags()
+	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)
+	tags["build_number"] = boundBuildNumberTag(params.loginPayload.BuildNumber)
+	tags["app_id"] = boundAppIDTag(params.loginPayload.AppId)
+	tags["publisher_lock"] = publisherLockAllowlist.normalize(params.loginPayload.PublisherLock)
+	boundSystemsPerPlayer(limiter, tags, params.UserID())
+	return tags
 }
 
 // normalizes all the meta headset types to a common format

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -151,6 +151,11 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 	// randomized login payload cannot blow up metrics cardinality. Unknown
 	// values bucket to metricTagOther; see addSystemInfoMetricTags.
 	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)
+	// SEC-4 (per-player cap): even with per-field bounding, one player reconnecting
+	// with a varying SystemInfo mix can walk the bounded-tuple space and churn
+	// series. Cap the distinct systems a single player may mint; beyond the cap the
+	// SEC-4 fields collapse to metricTagOther. Keyed on the resolved account.
+	boundSystemsPerPlayer(loginSystemFingerprintLimiter, tags, params.UserID())
 	tags["total_memory"] = strconv.FormatInt(params.loginPayload.SystemInfo.MemoryTotal, 10)
 	tags["num_logical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumLogicalCores, 10)
 	tags["num_physical_cores"] = strconv.FormatInt(params.loginPayload.SystemInfo.NumPhysicalCores, 10)

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -92,16 +92,36 @@ func (s *SessionParameters) IsIGPOpen() bool {
 	return s.isIGPOpen.Load()
 }
 
+// MetricsTags is the shared tag source for every login-path metric that does not
+// carry the full SystemInfo tuple (login_process_latency, session_duration_seconds,
+// session_authenticate/authorize/initialize) as well as the base for login_success.
+// SEC-4: device_type and build_version are attacker-controlled (both derive from the
+// login payload) and MUST be bounded here at the source, or a randomized payload
+// mints unbounded Prometheus series on every one of those metrics. device_type shares
+// its source (SystemInfo.HeadsetType) with the bounded headset_type tag, so it is
+// bounded identically; build_version shares its source (BuildNumber) with build_number.
 func (s *SessionParameters) MetricsTags() map[string]string {
 	return map[string]string{
 		"websocket_auth": fmt.Sprintf("%t", s.IsWebsocketAuthenticated),
 		"is_vr":          fmt.Sprintf("%t", s.IsVR()),
 		"is_pcvr":        fmt.Sprintf("%t", s.IsPCVR()),
-		"build_version":  fmt.Sprintf("%d", s.BuildNumber()),
-		"device_type":    s.DeviceType(),
+		"build_version":  boundBuildNumberTag(s.BuildNumber()),
+		"device_type":    s.boundDeviceType(),
 		"error":          "",
 		"device_linked":  "",
 	}
+}
+
+// boundDeviceType returns the SEC-4-bounded headset tag for metrics. It mirrors
+// DeviceType() but buckets any non-canonical headset to metricTagOther via
+// boundHeadsetMetricTag (DeviceType()/normalizeHeadsetType alone fall through to the
+// raw client string). Kept separate from DeviceType() so the latter still reports the
+// real device type to any non-metrics caller.
+func (s *SessionParameters) boundDeviceType() string {
+	if s.loginPayload == nil {
+		return boundHeadsetMetricTag("")
+	}
+	return boundHeadsetMetricTag(s.loginPayload.SystemInfo.HeadsetType)
 }
 
 func (s *SessionParameters) IsVR() bool {


### PR DESCRIPTION
## Summary
On `login_success`, SystemInfo strings — `cpu_model`, `gpu_model`, `driver_version`, `network_type`, `headset_type` — were used raw as `CustomCounter`/`CustomTimer` metric tag values. Because they are attacker-controlled login-payload strings, one valid account logging in repeatedly with randomized values creates a new time series per unique tuple → unbounded metrics cardinality and memory pressure on the metrics backend.

## Fix
Map each field to a bounded allow-list; unknown values bucket to a fixed `"other"` sentinel instead of passing the raw string. `headset_type` reuses the existing curated mappings and no longer falls through to the raw string **for metrics** (the shared `normalizeHeadsetType` is unchanged — it still feeds the login-history audit record with the real reported value).

## Tests
Red→green: randomized inputs now yield a bounded distinct-tag count; known-good values pass through unchanged; unknown → `other`. `gofmt`/`go vet` clean; tests pass under `-race`.

## Note
`cpu_model`/`gpu_model`/`driver_version` allow-lists ship empty (everything buckets to `other`) — the cardinality bound holds immediately; ops populates these from real telemetry to restore per-SKU signal. Extension point is documented in `server/evr_metrics_tags.go`.

## Deployment
None in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)