### PR TITLE
fix: global operators see enforcement attribution across all guilds in /lookup

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2443,8 +2443,9 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				ShowLoginsSince:                loginsSince,
 				SendFileOnError:                access.IsGlobalOperator,
 
-				CallerUserID:    callerUserID,
-				CallerIsAuditor: access.IsAuditor,
+				CallerUserID:           callerUserID,
+				CallerIsAuditor:        access.IsAuditor,
+				CallerIsGlobalOperator: access.IsGlobalOperator,
 			}
 
 			return d.handleProfileRequest(ctx, logger, nk, s, i, target, opts)

--- a/server/evr_discord_appbot_enforcement.go
+++ b/server/evr_discord_appbot_enforcement.go
@@ -647,7 +647,7 @@ func (d *DiscordAppBot) updateEnforcementMessage(i *discordgo.InteractionCreate,
 
 	// Regenerate the suspension details field; hide notes in channel message when toggle is active
 	showNotes := !gg.RestrictEnforcerNoteVisibility
-	suspensionField := createSuspensionDetailsEmbedField(gg.Name(), []GuildEnforcementRecord{newRecord}, voids, true, showNotes, true, gg.Group.Id, "")
+	suspensionField := createSuspensionDetailsEmbedField(gg.Name(), []GuildEnforcementRecord{newRecord}, voids, true, showNotes, true, gg.Group.Id, "", false)
 	if suspensionField != nil {
 		updatedEmbed.Fields = append(updatedEmbed.Fields, suspensionField)
 	}

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -1169,7 +1169,7 @@ func (d *DiscordAppBot) kickPlayer(logger runtime.Logger, i *discordgo.Interacti
 				// Create a field for each group
 				// Show enforcer ID in enforcement notice channel; hide notes when toggle restricts visibility
 				showNotes := !gg.RestrictEnforcerNoteVisibility
-				field := createSuspensionDetailsEmbedField(gn, records, voids, true, showNotes, true, gID, "")
+				field := createSuspensionDetailsEmbedField(gn, records, voids, true, showNotes, true, gID, "", false)
 				embed.Fields = append(embed.Fields, field)
 			}
 

--- a/server/evr_discord_appbot_whoami.go
+++ b/server/evr_discord_appbot_whoami.go
@@ -42,8 +42,9 @@ type UserProfileRequestOptions struct {
 	ShowLoginsSince                time.Time
 	SendFileOnError                bool // If true, send a file with the error message instead of an ephemeral message
 
-	CallerUserID    string // Nakama user ID of the caller (for per-record note filtering)
-	CallerIsAuditor bool   // Auditors bypass per-record note restriction
+	CallerUserID           string // Nakama user ID of the caller (for per-record note filtering)
+	CallerIsAuditor        bool   // Auditors bypass per-record note restriction
+	CallerIsGlobalOperator bool   // Global operators see enforcement attribution across all guilds
 }
 
 const (
@@ -510,7 +511,7 @@ func (w *WhoAmI) createSuspensionsEmbed() *discordgo.MessageEmbed {
 				callerForFilter = w.opts.CallerUserID
 			}
 
-			if field := createSuspensionDetailsEmbedField(gName, records, voids, w.opts.IncludeInactiveSuspensions, w.opts.IncludeSuspensionAuditorNotes, w.opts.IncludeSuspensionAuditorNotes, w.GroupID, callerForFilter); field != nil {
+			if field := createSuspensionDetailsEmbedField(gName, records, voids, w.opts.IncludeInactiveSuspensions, w.opts.IncludeSuspensionAuditorNotes, w.opts.IncludeSuspensionAuditorNotes, w.GroupID, callerForFilter, w.opts.CallerIsGlobalOperator); field != nil {
 				if field.Value != "" {
 					fields = append(fields, field)
 				}

--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -503,7 +503,7 @@ func formatEnforcementReporter(r GuildEnforcementRecord) string {
 // createSuspensionDetailsEmbedField builds a Discord embed field summarizing enforcement records.
 // callerUserID restricts note visibility per-record: empty string means show all notes (auditor/operator),
 // non-empty means only show notes on records where EnforcerUserID matches the caller.
-func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcementRecord, voids map[string]GuildEnforcementRecordVoid, includeInactive, includeAuditorNotes, showEnforcerID bool, currentGuildID string, callerUserID string) *discordgo.MessageEmbedField {
+func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcementRecord, voids map[string]GuildEnforcementRecordVoid, includeInactive, includeAuditorNotes, showEnforcerID bool, currentGuildID string, callerUserID string, callerIsGlobalOperator bool) *discordgo.MessageEmbedField {
 	if len(records) == 0 {
 		return nil
 	}
@@ -523,9 +523,11 @@ func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcem
 			durationText = fmt.Sprintf("~~%s~~", durationText)
 		}
 
-		// Show enforcer Discord ID only if viewer is a moderator AND suspension is for current guild
+		// Show enforcer Discord ID only if viewer is a moderator AND suspension is for
+		// the current guild — except global operators, who oversee all guilds and see
+		// attribution everywhere.
 		enforcerInfo := ""
-		if showEnforcerID && r.GroupID == currentGuildID {
+		if showEnforcerID && (callerIsGlobalOperator || r.GroupID == currentGuildID) {
 			enforcerInfo = fmt.Sprintf(" by <@!%s>", r.EnforcerDiscordID)
 		}
 
@@ -535,9 +537,10 @@ func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcem
 		)
 
 		// Surface who filed/reported the action (issue #466), gated the same way as
-		// enforcer info: only to moderators viewing a record for the current guild.
+		// enforcer info: only to moderators viewing a record for the current guild,
+		// plus global operators who see all guilds.
 		// Records without a stored reporter (legacy or operator-initiated) omit this line.
-		if showEnforcerID && r.GroupID == currentGuildID {
+		if showEnforcerID && (callerIsGlobalOperator || r.GroupID == currentGuildID) {
 			if reporterValue := formatEnforcementReporter(r); reporterValue != "" {
 				parts = append(parts, fmt.Sprintf("- reported by %s", reporterValue))
 			}

--- a/server/evr_enforcement_journal_test.go
+++ b/server/evr_enforcement_journal_test.go
@@ -310,7 +310,8 @@ func TestCreateSuspensionDetailsEmbedField(t *testing.T) {
 				tc.includeAuditorNotes,
 				tc.showEnforcerID,
 				tc.currentGuildID,
-				"", // callerUserID: empty = no per-record restriction
+				"",    // callerUserID: empty = no per-record restriction
+				false, // callerIsGlobalOperator
 			)
 
 			if field == nil {
@@ -365,7 +366,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 	}
 
 	t.Run("Empty callerUserID shows all notes (auditor/operator path)", func(t *testing.T) {
-		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "")
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "", false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -378,7 +379,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 	})
 
 	t.Run("CallerUserID=enforcerA sees only own notes", func(t *testing.T) {
-		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerA)
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerA, false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -391,7 +392,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 	})
 
 	t.Run("CallerUserID=enforcerB sees only own notes", func(t *testing.T) {
-		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerB)
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, enforcerB, false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -404,7 +405,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 	})
 
 	t.Run("CallerUserID=unrelated sees no notes", func(t *testing.T) {
-		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "unrelated-enforcer")
+		field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, groupA, "unrelated-enforcer", false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -432,7 +433,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 			},
 		}
 		// enforcerB should not see void notes on A's record
-		field := createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerB)
+		field := createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerB, false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -441,7 +442,7 @@ func TestCreateSuspensionDetailsEmbedField_CallerFiltering(t *testing.T) {
 		}
 
 		// enforcerA should see void notes on their own record
-		field = createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerA)
+		field = createSuspensionDetailsEmbedField("Guild A", records, voids, true, true, true, groupA, enforcerA, false)
 		if field == nil {
 			t.Fatal("expected field to be non-nil")
 		}
@@ -642,4 +643,49 @@ func TestMidSessionSuspension_StaleEnforcementsMissPostLoginKick(t *testing.T) {
 	if !found || len(freshModeRecords) == 0 {
 		t.Errorf("fresh enforcement check missed the mid-session suspension: got %v", freshEnforcements)
 	}
+}
+
+// TestSuspensionAttribution_GlobalOperatorSeesCrossGuild verifies that a global
+// operator running /lookup sees enforcement attribution (who issued the
+// suspension) for records belonging to OTHER guilds, not just the guild the
+// command was run in. Regular enforcers/auditors remain scoped to the current
+// guild. Regression for: global operators were filtered like regular enforcers
+// and could not see cross-guild enforcement-journal attribution.
+func TestSuspensionAttribution_GlobalOperatorSeesCrossGuild(t *testing.T) {
+	const (
+		currentGuild = "guild-A"
+		otherGuild   = "guild-B"
+	)
+	// A suspension issued in a DIFFERENT guild than the one /lookup is run in.
+	records := []GuildEnforcementRecord{{
+		ID:                "rec-cross",
+		GroupID:           otherGuild,
+		EnforcerDiscordID: "enforcer-disc-999",
+		EnforcerUserID:    "enforcer-uid-999",
+		CreatedAt:         time.Now().Add(-time.Hour),
+		UpdatedAt:         time.Now().Add(-time.Hour),
+		UserNoticeText:    "Cross-guild notice",
+		Expiry:            time.Now().Add(time.Hour),
+	}}
+	const attribution = "by <@!enforcer-disc-999>"
+
+	t.Run("global operator sees cross-guild attribution", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild B", records, nil, false, true, true, currentGuild, "", true)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if !strings.Contains(field.Value, attribution) {
+			t.Errorf("global operator should see cross-guild attribution; got: %s", field.Value)
+		}
+	})
+
+	t.Run("non-global viewer does not see cross-guild attribution", func(t *testing.T) {
+		field := createSuspensionDetailsEmbedField("Guild B", records, nil, false, true, true, currentGuild, "", false)
+		if field == nil {
+			t.Fatal("expected field to be non-nil")
+		}
+		if strings.Contains(field.Value, attribution) {
+			t.Errorf("non-global viewer must NOT see attribution for another guild's record; got: %s", field.Value)
+		}
+	})
 }

--- a/server/evr_enforcement_reporter_test.go
+++ b/server/evr_enforcement_reporter_test.go
@@ -172,7 +172,7 @@ func TestCreateSuspensionDetailsEmbedField_Reporter(t *testing.T) {
 
 	t.Run("reporter present is rendered", func(t *testing.T) {
 		t.Parallel()
-		field := createSuspensionDetailsEmbedField("Guild A", withReporter, nil, false, true, true, groupA, "")
+		field := createSuspensionDetailsEmbedField("Guild A", withReporter, nil, false, true, true, groupA, "", false)
 		if field == nil {
 			t.Fatal("expected non-nil field")
 		}
@@ -192,7 +192,7 @@ func TestCreateSuspensionDetailsEmbedField_Reporter(t *testing.T) {
 			UserNoticeText:    "Notice text",
 			Expiry:            time.Now().Add(time.Hour),
 		}}
-		field := createSuspensionDetailsEmbedField("Guild A", legacy, nil, false, true, true, groupA, "")
+		field := createSuspensionDetailsEmbedField("Guild A", legacy, nil, false, true, true, groupA, "", false)
 		if field == nil {
 			t.Fatal("expected non-nil field")
 		}


### PR DESCRIPTION
## What

Global operators running `/lookup` now see enforcement attribution (who
issued a suspension, and who reported it) for records belonging to **other**
guilds — not just the guild the command is run in.

## Why

Attribution lines (`by <@!enforcer>` and `- reported by …`) in
`createSuspensionDetailsEmbedField` were gated on `r.GroupID == currentGuildID`,
so a global operator viewing a cross-guild suspension saw the record but with
the enforcer/reporter stripped. Global operators oversee all guilds, so they
should see attribution everywhere. Regular enforcers/auditors remain scoped to
the current guild — guild isolation of attribution for non-operators is
unchanged.

## How

- Add `callerIsGlobalOperator bool` to `createSuspensionDetailsEmbedField`; the
  attribution gate becomes `showEnforcerID && (callerIsGlobalOperator || r.GroupID == currentGuildID)`.
- Thread `CallerIsGlobalOperator` through `UserProfileRequestOptions` →
  `WhoAmI.createSuspensionsEmbed`. Set from `access.IsGlobalOperator` on the
  `/lookup` path only. `/whoami` self-view and the enforcement-notice /
  kick-notice callers pass `false` (those are single-guild contexts).
- Per-record note filtering is untouched: `IsAuditor` already subsumes
  `IsGlobalOperator`, so operator note visibility was already correct.

## Tests

New `TestSuspensionAttribution_GlobalOperatorSeesCrossGuild`:
- global operator **sees** cross-guild attribution
- non-global viewer does **not** see another guild's attribution

Existing embed-field tests updated for the new parameter.

Gate (local):
- `gofmt -l` on the 7 changed files: clean
- `go vet ./server/`: pass
- `go build ./...`: pass
- `go test -race` for enforcement_journal / reporter / caller-filtering /
  mid-session-suspension: all PASS

Full `go test ./server/...` requires a live Postgres and was not run here.

## Deployment

None in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
