### PR TITLE
fix(cosmetics): validate ownership on in-game equip (COSMETIC-1)

### DIFF
--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -22,6 +22,19 @@ type GameServerLoadoutInstance struct {
 	Items        map[string]string `json:"items"` // slot_hash -> equipped_hash (both as hex strings)
 }
 
+// sanitizeGameServerLoadout strips any cosmetic the player does not own from a loadout
+// parsed from a GameServerSaveLoadoutRequest, mirroring EquipAndSanitize's protection
+// for the RemoteLogSet equip path (COSMETIC-1). It is a separate entry point because
+// this handler builds a full loadout from a set of slot->item pairs rather than a single
+// category/name equip.
+func sanitizeGameServerLoadout(loadout evr.CosmeticLoadout, evrProfile *EVRProfile) (evr.CosmeticLoadout, error) {
+	owned, err := profileOwnedCosmetics(evrProfile)
+	if err != nil {
+		return loadout, err
+	}
+	return sanitizeLoadout(loadout, owned), nil
+}
+
 // gameServerSaveLoadoutRequest handles loadout save requests from the game server.
 // This is triggered when a player updates their loadout at the character customization screen.
 // The game server receives an internal broadcaster message (SR15NetSaveLoadoutRequest) and
@@ -143,8 +156,19 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		}
 	}
 
-	// Update profile with new loadout
-	profile.LoadoutCosmetics.Loadout = loadout
+	// Update profile with new loadout, rejecting any cosmetic the player does not own
+	// (COSMETIC-1). This handler is the *sole* persistence path for game servers with
+	// NativeSupport: evr_runtime_event_remotelogset.go's equip handler explicitly skips
+	// itself for NativeSupport matches ("NEVR (non-legacy) servers already persist
+	// loadout equips themselves"), so the ownership fix applied there does not run for
+	// those servers at all. Without this check, a NativeSupport-hosted character
+	// customization equip would persist an unowned cosmetic (e.g. a VRML finalist tag)
+	// exactly like the original remotelogset bug.
+	sanitized, err := sanitizeGameServerLoadout(loadout, profile)
+	if err != nil {
+		return fmt.Errorf("failed to compute owned cosmetics: %w", err)
+	}
+	profile.LoadoutCosmetics.Loadout = sanitized
 
 	// Update jersey number if present
 	if payload.Number >= 0 {

--- a/server/evr_pipeline_gameserver_loadout_test.go
+++ b/server/evr_pipeline_gameserver_loadout_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// COSMETIC-1: evr_runtime_event_remotelogset.go's equip handler explicitly skips its own
+// persistence for NativeSupport game servers ("NEVR (non-legacy) servers already persist
+// loadout equips themselves"), which makes gameServerSaveLoadoutRequest (via
+// sanitizeGameServerLoadout) the *only* place that validates ownership for those matches.
+// These tests guard that path independently of the RemoteLogSet fix.
+
+func TestSanitizeGameServerLoadout_RejectsUnownedVRMLTag(t *testing.T) {
+	profile := &EVRProfile{account: &api.Account{Wallet: "{}"}} // empty wallet
+
+	loadout := evr.DefaultCosmeticLoadout()
+	loadout.Tag = "rwd_tag_s1_vrml_s1_finalist"
+
+	result, err := sanitizeGameServerLoadout(loadout, profile)
+	if err != nil {
+		t.Fatalf("sanitizeGameServerLoadout returned error: %v", err)
+	}
+
+	def := evr.DefaultCosmeticLoadout().Tag
+	if result.Tag == "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("unowned VRML finalist tag persisted; got %q, want default %q", result.Tag, def)
+	}
+	if result.Tag != def {
+		t.Errorf("tag slot not reset to default; got %q, want %q", result.Tag, def)
+	}
+}
+
+func TestSanitizeGameServerLoadout_AllowsOwnedVRMLTag(t *testing.T) {
+	profile := &EVRProfile{
+		account: &api.Account{Wallet: `{"cosmetic:arena:rwd_tag_s1_vrml_s1_finalist":1}`},
+	}
+
+	loadout := evr.DefaultCosmeticLoadout()
+	loadout.Tag = "rwd_tag_s1_vrml_s1_finalist"
+
+	result, err := sanitizeGameServerLoadout(loadout, profile)
+	if err != nil {
+		t.Fatalf("sanitizeGameServerLoadout returned error: %v", err)
+	}
+	if result.Tag != "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("owned VRML tag was stripped; got %q, want %q", result.Tag, "rwd_tag_s1_vrml_s1_finalist")
+	}
+}
+
+func TestSanitizeGameServerLoadout_AllowsDefaultItem(t *testing.T) {
+	profile := &EVRProfile{account: &api.Account{Wallet: "{}"}}
+
+	loadout := evr.DefaultCosmeticLoadout()
+	loadout.Tag = "rwd_tag_s1_a_secondary"
+
+	result, err := sanitizeGameServerLoadout(loadout, profile)
+	if err != nil {
+		t.Fatalf("sanitizeGameServerLoadout returned error: %v", err)
+	}
+	if result.Tag != "rwd_tag_s1_a_secondary" {
+		t.Errorf("default tag was altered; got %q, want %q", result.Tag, "rwd_tag_s1_a_secondary")
+	}
+}

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -100,24 +100,43 @@ func EquipAndSanitize(loadout evr.CosmeticLoadout, category, name string, owned 
 	return sanitizeLoadout(equipped, owned), nil
 }
 
+// equippedCosmeticsForProfile computes the sanitized cosmetic loadout that is safe to
+// serve — to other players (via ServerProfileStore -> otherUserProfileRequest) and to
+// the broadcast game server — even when evrProfile.LoadoutCosmetics.Loadout already
+// holds an unowned item (e.g. an account "poisoned" before the COSMETIC-1 equip-time
+// fixes existed, such as db484900-...). This is the read-path counterpart to
+// EquipAndSanitize / sanitizeGameServerLoadout: those guard what gets *written*: this
+// guards what gets *served*, and it runs unconditionally every time NewUserServerProfile
+// is called (login, lobby join, equip event) regardless of which path wrote the stored
+// value. No backfill of already-poisoned accounts is required for the "other players
+// see it" concern because of this: every regeneration re-derives ownership from the
+// current wallet and strips anything not currently owned.
+func equippedCosmeticsForProfile(evrProfile *EVRProfile) (evr.CosmeticLoadout, map[string]map[string]bool, error) {
+	cosmetics, err := profileOwnedCosmetics(evrProfile)
+	if err != nil {
+		return evr.CosmeticLoadout{}, nil, err
+	}
+
+	cosmeticLoadout := sanitizeLoadout(evrProfile.LoadoutCosmetics.Loadout, cosmetics)
+
+	// If the player has "kissy lips" emote equipped, set their emote to default.
+	if cosmeticLoadout.Emote == "emote_kissy_lips_a" {
+		cosmeticLoadout.Emote = "emote_blink_smiley_a"
+		cosmeticLoadout.SecondEmote = "emote_blink_smiley_a"
+	}
+
+	return cosmeticLoadout, cosmetics, nil
+}
+
 func UserServerProfileFromParameters(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, params *SessionParameters, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol) (*evr.ServerProfile, error) {
 	return NewUserServerProfile(ctx, logger, db, nk, params.profile, params.xpID, groupID, modes, dailyWeeklyMode, params.profile.GetGroupIGN(groupID))
 }
 
 func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, evrProfile *EVRProfile, xpID evr.EvrId, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol, displayName string) (*evr.ServerProfile, error) {
 
-	cosmetics, err := profileOwnedCosmetics(evrProfile)
+	cosmeticLoadout, cosmetics, err := equippedCosmeticsForProfile(evrProfile)
 	if err != nil {
 		return nil, err
-	}
-
-	cosmeticLoadout := evrProfile.LoadoutCosmetics.Loadout
-	cosmeticLoadout = sanitizeLoadout(cosmeticLoadout, cosmetics)
-
-	// If the player has "kissy lips" emote equipped, set their emote to default.
-	if cosmeticLoadout.Emote == "emote_kissy_lips_a" {
-		cosmeticLoadout.Emote = "emote_blink_smiley_a"
-		cosmeticLoadout.SecondEmote = "emote_blink_smiley_a"
 	}
 
 	var developerFeatures *evr.DeveloperFeatures
@@ -471,11 +490,32 @@ var allCosmetics = func() map[string]map[string]bool {
 	return all
 }()
 
+// cosmeticDefaults returns a fresh deep copy of the process-lifetime defaultCosmetics
+// (or allCosmetics) singleton. This MUST copy rather than return the shared map
+// directly: every known caller feeds the result straight into walletToCosmetics, which
+// mutates its "unlocks" argument in place (unlocks[mode][item] = true). Before this
+// function copied, that meant a single call — e.g. UserUnlockedCosmetics
+// (evr_discord_loadout.go), invoked on every /loadout autocomplete keystroke and on
+// /loadout set — would permanently merge one player's wallet-granted cosmetic (VRML
+// tag, medal, etc.) into the shared defaultCosmetics/allCosmetics map for the lifetime
+// of the running process, silently granting that restricted item to every other player
+// from then on. This is a distinct, likely-live contributor to COSMETIC-1 reports beyond
+// the unvalidated-equip write paths, and a test-isolation hazard (a test calling
+// cosmeticDefaults(false) followed by walletToCosmetics would poison every later test in
+// the same process, exactly as observed by
+// TestEquippedCosmeticsForProfile_PoisonedAccountNeverServesUnownedItem failing only when
+// run after TestEquipAndSanitize_AllowsOwnedVRMLTag in the same binary).
 func cosmeticDefaults(enableAll bool) map[string]map[string]bool {
+	src := defaultCosmetics
 	if enableAll {
-		return allCosmetics
+		src = allCosmetics
 	}
-	return defaultCosmetics
+	out := make(map[string]map[string]bool, len(src))
+	for m, c := range src {
+		out[m] = make(map[string]bool, len(c))
+		maps.Copy(out[m], c)
+	}
+	return out
 }
 
 type StoredCosmeticLoadout struct {

--- a/server/evr_profile_cache.go
+++ b/server/evr_profile_cache.go
@@ -67,12 +67,11 @@ func walletToCosmetics(wallet map[string]int64, unlocks map[string]map[string]bo
 	return unlocks
 }
 
-func UserServerProfileFromParameters(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, params *SessionParameters, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol) (*evr.ServerProfile, error) {
-	return NewUserServerProfile(ctx, logger, db, nk, params.profile, params.xpID, groupID, modes, dailyWeeklyMode, params.profile.GetGroupIGN(groupID))
-}
-
-func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, evrProfile *EVRProfile, xpID evr.EvrId, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol, displayName string) (*evr.ServerProfile, error) {
-
+// profileOwnedCosmetics returns the mode→item→owned set the player is entitled to:
+// the default (or all, when EnableAllCosmetics) cosmetics merged with wallet-granted
+// unlocks. This is the single source of truth for "does this player own this cosmetic",
+// used both when building the broadcast server profile and when validating an equip.
+func profileOwnedCosmetics(evrProfile *EVRProfile) (map[string]map[string]bool, error) {
 	var wallet map[string]int64
 	if err := json.Unmarshal([]byte(evrProfile.Wallet()), &wallet); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal wallet: %w", err)
@@ -83,7 +82,34 @@ func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, n
 		cosmetics[m] = make(map[string]bool, len(c))
 		maps.Copy(cosmetics[m], c)
 	}
-	cosmetics = walletToCosmetics(wallet, cosmetics)
+	return walletToCosmetics(wallet, cosmetics), nil
+}
+
+// EquipAndSanitize applies a client-requested equip and then strips any resulting
+// cosmetic the player does not own, returning a loadout safe to persist. This closes
+// COSMETIC-1: the in-game equip path previously stored whatever the client claimed to
+// equip (e.g. VRML finalist tags) with no ownership check. Sanitizing here mirrors the
+// broadcast path (NewUserServerProfile), so the stored loadout can never hold an item
+// the player is not entitled to, while default items and legitimately-owned cosmetics
+// pass through unchanged.
+func EquipAndSanitize(loadout evr.CosmeticLoadout, category, name string, owned map[string]map[string]bool) (evr.CosmeticLoadout, error) {
+	equipped, err := LoadoutEquipItem(loadout, category, name)
+	if err != nil {
+		return loadout, err
+	}
+	return sanitizeLoadout(equipped, owned), nil
+}
+
+func UserServerProfileFromParameters(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, params *SessionParameters, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol) (*evr.ServerProfile, error) {
+	return NewUserServerProfile(ctx, logger, db, nk, params.profile, params.xpID, groupID, modes, dailyWeeklyMode, params.profile.GetGroupIGN(groupID))
+}
+
+func NewUserServerProfile(ctx context.Context, logger *zap.Logger, db *sql.DB, nk runtime.NakamaModule, evrProfile *EVRProfile, xpID evr.EvrId, groupID string, modes []evr.Symbol, dailyWeeklyMode evr.Symbol, displayName string) (*evr.ServerProfile, error) {
+
+	cosmetics, err := profileOwnedCosmetics(evrProfile)
+	if err != nil {
+		return nil, err
+	}
 
 	cosmeticLoadout := evrProfile.LoadoutCosmetics.Loadout
 	cosmeticLoadout = sanitizeLoadout(cosmeticLoadout, cosmetics)

--- a/server/evr_profile_cache_test.go
+++ b/server/evr_profile_cache_test.go
@@ -82,6 +82,60 @@ func wantGotDiff(t *testing.T, want, got interface{}) {
 	}
 }
 
+func TestEquipAndSanitize_RejectsUnownedVRMLTag(t *testing.T) {
+	// COSMETIC-1: the in-game equip path must not persist a cosmetic the player
+	// does not own. An empty-wallet player equipping a restricted VRML finalist
+	// tag must have that slot reset to the default tag, not the finalist tag.
+	owned := cosmeticDefaults(false) // empty wallet: defaults only, all VRML restricted
+
+	loadout := evr.DefaultCosmeticLoadout()
+	result, err := EquipAndSanitize(loadout, "tag", "rwd_tag_s1_vrml_s1_finalist", owned)
+	if err != nil {
+		t.Fatalf("EquipAndSanitize returned error: %v", err)
+	}
+
+	def := evr.DefaultCosmeticLoadout().Tag
+	if result.Tag == "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("unowned VRML finalist tag persisted; got %q, want default %q", result.Tag, def)
+	}
+	if result.Tag != def {
+		t.Errorf("tag slot not reset to default; got %q, want %q", result.Tag, def)
+	}
+}
+
+func TestEquipAndSanitize_AllowsOwnedVRMLTag(t *testing.T) {
+	// Regression guard: a legitimately entitled player (wallet grants the tag)
+	// must still be able to equip it.
+	owned := cosmeticDefaults(false)
+	owned = walletToCosmetics(map[string]int64{
+		"cosmetic:arena:rwd_tag_s1_vrml_s1_finalist": 1,
+	}, owned)
+
+	loadout := evr.DefaultCosmeticLoadout()
+	result, err := EquipAndSanitize(loadout, "tag", "rwd_tag_s1_vrml_s1_finalist", owned)
+	if err != nil {
+		t.Fatalf("EquipAndSanitize returned error: %v", err)
+	}
+	if result.Tag != "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("owned VRML tag was stripped; got %q, want %q", result.Tag, "rwd_tag_s1_vrml_s1_finalist")
+	}
+}
+
+func TestEquipAndSanitize_AllowsDefaultItem(t *testing.T) {
+	// Regression guard: default items (not present in the unlock structs) must
+	// still equip — the gate must not reject the standard defaults everyone uses.
+	owned := cosmeticDefaults(false)
+
+	loadout := evr.DefaultCosmeticLoadout()
+	result, err := EquipAndSanitize(loadout, "tag", "rwd_tag_s1_a_secondary", owned)
+	if err != nil {
+		t.Fatalf("EquipAndSanitize returned error: %v", err)
+	}
+	if result.Tag != "rwd_tag_s1_a_secondary" {
+		t.Errorf("default tag was altered; got %q, want %q", result.Tag, "rwd_tag_s1_a_secondary")
+	}
+}
+
 func TestSanitizeLoadout_CombatChassis(t *testing.T) {
 	// Bug: sanitizeLoadout only checks cosmetics["arena"], so combat-only
 	// items (e.g. rwd_chassis_body_s10_a) get reverted to the default chassis

--- a/server/evr_profile_cache_test.go
+++ b/server/evr_profile_cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
 
@@ -82,6 +83,43 @@ func wantGotDiff(t *testing.T, want, got interface{}) {
 	}
 }
 
+// TestCosmeticDefaults_DoesNotLeakAcrossCalls guards against a real production hazard,
+// not just test hygiene: cosmeticDefaults(false)/cosmeticDefaults(true) return the
+// process-lifetime defaultCosmetics/allCosmetics singletons. walletToCosmetics mutates
+// its "unlocks" argument in place. Every known production caller
+// (UserUnlockedCosmetics in evr_discord_loadout.go:212, hit on every /loadout
+// autocomplete keystroke and on /loadout set) does exactly
+// `unlocks := cosmeticDefaults(...); unlocks = walletToCosmetics(wallet, unlocks)`.
+// If cosmeticDefaults ever again returns the shared map by reference instead of a copy,
+// the first player whose wallet grants a restricted cosmetic (a VRML tag, a medal) would
+// permanently mark that item "owned by default" for every other player for the life of
+// the process — a much wider-blast-radius sibling of COSMETIC-1. This test proves two
+// independent calls never observe each other's wallet-derived mutations.
+func TestCosmeticDefaults_DoesNotLeakAcrossCalls(t *testing.T) {
+	const restrictedTag = "rwd_tag_s1_vrml_s1_finalist"
+
+	// Sanity: the item must actually be restricted (i.e. absent/false) by default,
+	// otherwise this test would pass vacuously.
+	before := cosmeticDefaults(false)
+	if before["arena"][restrictedTag] {
+		t.Fatalf("test setup invalid: %q is already marked default-owned", restrictedTag)
+	}
+
+	// Simulate UserUnlockedCosmetics for a player whose wallet grants the tag.
+	granted := cosmeticDefaults(false)
+	granted = walletToCosmetics(map[string]int64{"cosmetic:arena:" + restrictedTag: 1}, granted)
+	if !granted["arena"][restrictedTag] {
+		t.Fatalf("test setup invalid: wallet grant did not mark %q owned in the local result", restrictedTag)
+	}
+
+	// A second, unrelated call (e.g. a different player with an empty wallet, or the
+	// same map re-fetched) must NOT see the first call's wallet-derived grant.
+	after := cosmeticDefaults(false)
+	if after["arena"][restrictedTag] {
+		t.Errorf("cosmeticDefaults leaked a wallet-derived grant across calls: %q is now marked default-owned for every caller", restrictedTag)
+	}
+}
+
 func TestEquipAndSanitize_RejectsUnownedVRMLTag(t *testing.T) {
 	// COSMETIC-1: the in-game equip path must not persist a cosmetic the player
 	// does not own. An empty-wallet player equipping a restricted VRML finalist
@@ -133,6 +171,78 @@ func TestEquipAndSanitize_AllowsDefaultItem(t *testing.T) {
 	}
 	if result.Tag != "rwd_tag_s1_a_secondary" {
 		t.Errorf("default tag was altered; got %q, want %q", result.Tag, "rwd_tag_s1_a_secondary")
+	}
+}
+
+// TestEquippedCosmeticsForProfile_PoisonedAccountNeverServesUnownedItem is the read-path
+// counterpart to the equip-time fixes (EquipAndSanitize, sanitizeGameServerLoadout). It
+// simulates an account that was already "poisoned" before those fixes existed — i.e. an
+// unowned VRML finalist tag is already sitting directly in
+// EVRProfile.LoadoutCosmetics.Loadout, exactly like the reported sample account
+// db484900-7f6c-4c3a-b7fd-aed3518cffc3 (empty wallet, VRML tag present in stored
+// loadout). equippedCosmeticsForProfile is what NewUserServerProfile calls to build
+// evr.ServerProfile.EquippedCosmetics — the value that ServerProfileStore persists and
+// that otherUserProfileRequest/the broadcast game server serve to OTHER players. This
+// test proves that boundary strips the poisoned value on every regeneration, with no
+// backfill required: ownership is re-derived from the current wallet every time.
+func TestEquippedCosmeticsForProfile_PoisonedAccountNeverServesUnownedItem(t *testing.T) {
+	profile := &EVRProfile{
+		account: &api.Account{Wallet: "{}"}, // empty wallet, like db484900-...
+	}
+	// Simulate pre-fix stored state: unowned items already written directly into the
+	// stored loadout (as if by the unpatched equip or game-server save-loadout path).
+	profile.LoadoutCosmetics.Loadout = evr.DefaultCosmeticLoadout()
+	profile.LoadoutCosmetics.Loadout.Tag = "rwd_tag_s1_vrml_s1_finalist"
+	profile.LoadoutCosmetics.Loadout.Medal = "rwd_medal_0006"
+
+	loadout, owned, err := equippedCosmeticsForProfile(profile)
+	if err != nil {
+		t.Fatalf("equippedCosmeticsForProfile returned error: %v", err)
+	}
+
+	def := evr.DefaultCosmeticLoadout()
+	if loadout.Tag == "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("poisoned VRML finalist tag was served; got %q, want default %q", loadout.Tag, def.Tag)
+	}
+	if loadout.Tag != def.Tag {
+		t.Errorf("tag slot not reset to default; got %q, want %q", loadout.Tag, def.Tag)
+	}
+	if loadout.Medal == "rwd_medal_0006" {
+		t.Errorf("poisoned medal was served; got %q, want default %q", loadout.Medal, def.Medal)
+	}
+	if loadout.Medal != def.Medal {
+		t.Errorf("medal slot not reset to default; got %q, want %q", loadout.Medal, def.Medal)
+	}
+
+	// Belt-and-suspenders: the returned owned-cosmetics set (also used to populate
+	// ServerProfile.UnlockedCosmetics, which the client uses to render what's owned)
+	// must not claim the poisoned items are owned either.
+	for _, modeUnlocks := range owned {
+		if modeUnlocks["rwd_tag_s1_vrml_s1_finalist"] {
+			t.Errorf("owned-cosmetics set falsely marks the poisoned VRML tag as owned")
+		}
+		if modeUnlocks["rwd_medal_0006"] {
+			t.Errorf("owned-cosmetics set falsely marks the poisoned medal as owned")
+		}
+	}
+}
+
+// TestEquippedCosmeticsForProfile_WalletGrantedItemStillServed is the regression guard:
+// a legitimately entitled player (wallet grants the item) must still see it served, not
+// just stripped indiscriminately.
+func TestEquippedCosmeticsForProfile_WalletGrantedItemStillServed(t *testing.T) {
+	profile := &EVRProfile{
+		account: &api.Account{Wallet: `{"cosmetic:arena:rwd_tag_s1_vrml_s1_finalist":1}`},
+	}
+	profile.LoadoutCosmetics.Loadout = evr.DefaultCosmeticLoadout()
+	profile.LoadoutCosmetics.Loadout.Tag = "rwd_tag_s1_vrml_s1_finalist"
+
+	loadout, _, err := equippedCosmeticsForProfile(profile)
+	if err != nil {
+		t.Fatalf("equippedCosmeticsForProfile returned error: %v", err)
+	}
+	if loadout.Tag != "rwd_tag_s1_vrml_s1_finalist" {
+		t.Errorf("wallet-owned VRML tag was stripped; got %q, want %q", loadout.Tag, "rwd_tag_s1_vrml_s1_finalist")
 	}
 }
 

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -325,8 +325,16 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				continue
 			}
 
-			// Update the equipped item in the profile.
-			if profile.LoadoutCosmetics.Loadout, err = LoadoutEquipItem(profile.LoadoutCosmetics.Loadout, category, name); err != nil {
+			// Update the equipped item in the profile, rejecting any cosmetic the
+			// player does not own (COSMETIC-1). EquipAndSanitize mirrors the
+			// broadcast-path sanitize, so an unowned item (e.g. a VRML finalist tag
+			// on an empty wallet) is reset to the slot default instead of persisted.
+			owned, err := profileOwnedCosmetics(profile)
+			if err != nil {
+				logger.WithField("error", err).Warn("Failed to compute owned cosmetics")
+				continue
+			}
+			if profile.LoadoutCosmetics.Loadout, err = EquipAndSanitize(profile.LoadoutCosmetics.Loadout, category, name, owned); err != nil {
 				return fmt.Errorf("failed to update equipped item: %w", err)
 			}
 
@@ -415,12 +423,27 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				ClientIsPCVR     bool       `json:"client_is_pcvr"`
 				RemoteLogMessage string     `json:"remote_log_message"`
 			}{
-				MatchID:          matchID,
-				MatchMode:        label.Mode,
-				MatchStartedAt:   label.StartTime,
-				ServerID:         func() string { if label.GameServer != nil { return label.GameServer.SessionID.String() }; return "" }(),
-				MatchOperator:    func() string { if label.GameServer != nil { return label.GameServer.OperatorID.String() }; return "" }(),
-				MatchEndpoint:    func() string { if label.GameServer != nil { return label.GameServer.Endpoint.String() }; return "" }(),
+				MatchID:        matchID,
+				MatchMode:      label.Mode,
+				MatchStartedAt: label.StartTime,
+				ServerID: func() string {
+					if label.GameServer != nil {
+						return label.GameServer.SessionID.String()
+					}
+					return ""
+				}(),
+				MatchOperator: func() string {
+					if label.GameServer != nil {
+						return label.GameServer.OperatorID.String()
+					}
+					return ""
+				}(),
+				MatchEndpoint: func() string {
+					if label.GameServer != nil {
+						return label.GameServer.Endpoint.String()
+					}
+					return ""
+				}(),
 				ClientIsPCVR:     params.IsPCVR(),
 				ClientUserID:     session.UserID().String(),
 				ClientUsername:   session.Username(),


### PR DESCRIPTION
## COSMETIC-1 — in-game equip path did not validate cosmetic ownership

Reported in #global-operators (Goopsie, he_is_the_cat): players wearing VRML finalist/champion tags with an **empty wallet** and no VRML group membership. Sample account `db484900-7f6c-4c3a-b7fd-aed3518cffc3` — console WALLET tab shows `{}` yet a VRML tag is present in the stored loadout.

This PR now covers three fixes for the same underlying class of bug, found while verifying downstream severity of the original report. All three are needed together — merging only the first would leave two other live ways to persist/leak an unowned cosmetic.

### 1. Root cause — RemoteLogSet equip handler (original fix)
The `RemoteLogSet` "equipped customization" handler (`evr_runtime_event_remotelogset.go:329`) called `LoadoutEquipItem(...)` and persisted the result with **no ownership check**. `LoadoutEquipItem` blindly assigns the requested item to its slot, so a client could self-equip any restricted cosmetic (VRML finalist tags, medals, decals) regardless of wallet entitlement, and it was stored in account metadata.

**What was already correct (ruled out):**
- Defaults are clean — all 22 VRML fields in `ArenaUnlocks`/`CombatUnlocks` are `validate:"restricted"` (incl. opaque S5/S6/S7 IDs), so `defaultCosmetics` does not grant them.
- Entitlements are granted only by writing wallet keys (`AssignEntitlements`).
- The **broadcast** server profile (`NewUserServerProfile` → `sanitizeLoadout`) already strips unowned items before `ServerProfileStore`.

**Fix:** apply the equip, then run the existing `sanitizeLoadout` against the player's owned set before persisting. The owned-cosmetics computation (defaults + wallet) is extracted into `profileOwnedCosmetics` as a single source of truth, reused by `NewUserServerProfile` and the new `EquipAndSanitize` helper.

### 2. NativeSupport game servers bypass the RemoteLogSet fix entirely (new)
`evr_runtime_event_remotelogset.go`'s equip handler explicitly skips its own persistence for game servers with `NativeSupport` set:
```go
// NEVR (non-legacy) servers already persist loadout equips themselves.
if ... label.GameServer.NativeSupport { continue }
```
For those matches, the **only** persistence path is `gameServerSaveLoadoutRequest` (`evr_pipeline_gameserver_loadout.go`), which the game server calls via its `SR15NetSaveLoadoutRequest` relay — triggered, per that file's own comment, "when a player updates their loadout at the character customization screen." It had the identical bug: every slot→item pair from the payload was written straight into `profile.LoadoutCosmetics.Loadout` with no ownership check, completely bypassing fix #1.

**Fix:** extracted `sanitizeGameServerLoadout`, which reuses `profileOwnedCosmetics` + `sanitizeLoadout` to strip any unowned item before it's stored — same ownership source of truth as fix #1.

### 3. Read-path guarantee + a second, wider-blast-radius bug found while proving it (new)
Before merging, we wanted to *prove* — not just reason — that the read/serve boundary can never leak a pre-existing "poisoned" account (one that already has an unowned item stored from before these fixes existed, e.g. `db484900-...`), without needing a backfill migration. `NewUserServerProfile` can't be unit-tested directly (it needs a live `*sql.DB` for `PlayerStatisticsGetID`, no mock available in this repo), so its owned-cosmetics + sanitize step was extracted into a pure function, `equippedCosmeticsForProfile`. A new test constructs an `EVRProfile` with an unowned VRML tag and medal already written directly into `LoadoutCosmetics.Loadout` and proves the value that would be persisted via `ServerProfileStore` (and served to other players via `otherUserProfileRequest`) never contains them — confirming **no backfill is required**: ownership is re-derived from the current wallet on every regeneration (login, lobby join, any equip event), regardless of which path wrote the bad value.

Writing that test surfaced a separate, more severe bug: `cosmeticDefaults(enableAll)` returned the shared, **process-lifetime** `defaultCosmetics`/`allCosmetics` package singleton **by reference**. Every known caller pipes the result straight into `walletToCosmetics`, which mutates its argument in place. In production, `UserUnlockedCosmetics` (`evr_discord_loadout.go:212`) does exactly `unlocks := cosmeticDefaults(...); unlocks = walletToCosmetics(wallet, unlocks)` on **every `/loadout` autocomplete keystroke and on `/loadout set`** — so the first player whose wallet legitimately grants a restricted cosmetic (a VRML tag, a medal) would permanently mark that item "owned by default" for **every other player**, for the life of the running nakama process. This is a distinct, likely-live contributor to COSMETIC-1 reports with a much wider blast radius than the two write-path bugs above — it doesn't require an exploit at all, just one legitimate VRML-tag holder using the Discord loadout command.

It also explained a locally confusing symptom: the new poisoned-account test passed in isolation but failed whenever run after the existing `TestEquipAndSanitize_AllowsOwnedVRMLTag` (from fix #1) in the same test binary — that test does the same unguarded `cosmeticDefaults` + `walletToCosmetics` call, quietly poisoning `defaultCosmetics` for every test after it.

**Fix:** `cosmeticDefaults` now returns a deep copy on every call instead of the shared map.

### Downstream visibility to other players — now verified, not just reasoned
Traced every read of `LoadoutCosmetics`/`cosmetic_loadout`: the only place another player's client can request someone's cosmetics is `otherUserProfileRequest` → `ServerProfileLoadByXPID`, which only ever returns what `ServerProfileStore` cached — and all three producers of that cache (`evr_lobby_joinentrant.go`, `evr_pipeline_login.go`'s `loggedInUserProfileRequest`, and the remotelogset equip handler) go through `NewUserServerProfile`/`sanitizeLoadout` first. Combined with fixes #1–#3, there is no remaining path (found in this codebase) that serves a raw, unsanitized loadout to another player.

**Known remaining gaps, out of scope for this PR (lower severity, tracked separately):** `/loadout set` (Discord) only blocks VRML-named items by string match, not other restricted categories (medals/decals); `/loadout get` and `/outfits manage load` re-apply a stored wardrobe outfit with no sanitization. None of these affect what other players see (per the tracing above), only what gets persisted/redisplayed to the account's own owner — recommend follow-up tickets.

### Tests (TDD, green with `-race`, including full un-filtered `go test ./server/...`)
- `TestEquipAndSanitize_*` (fix #1): unowned VRML tag on empty wallet → reset to default; wallet-granted tag → still equips; default item → unchanged.
- `TestSanitizeGameServerLoadout_*` (fix #2): same three cases for the NativeSupport game-server save-loadout path.
- `TestEquippedCosmeticsForProfile_PoisonedAccountNeverServesUnownedItem` / `_WalletGrantedItemStillServed` (fix #3, read path): a poisoned `EVRProfile` (unowned item already stored) never has it served; a legitimately wallet-granted item still is.
- `TestCosmeticDefaults_DoesNotLeakAcrossCalls` (fix #3, cache poisoning): two independent calls never observe each other's wallet-derived mutations.

### Notes
- Incidentally gofmt-normalizes a pre-existing inline-func struct literal in `evr_runtime_event_remotelogset.go` (required for the changed file to pass the gofmt gate).
- Remaining `go test ./server/...` failures are pre-existing and unrelated: no local CockroachDB for integration tests (`TestRuntime*`, `TestLocalStorageIndex*`), and one hardcoded-date test (`TestStatisticsGroup_MarshalText`) tied to the system clock.

Co-Authored-By: Andrew Bates <a@sprock.io>
