### PR TITLE
Audit follow-ups: config cache, report rate-limit fail-closed, enforcer mention, SEC-4 comments

### DIFF
--- a/server/evr_enforcement_journal.go
+++ b/server/evr_enforcement_journal.go
@@ -527,7 +527,11 @@ func createSuspensionDetailsEmbedField(guildName string, records []GuildEnforcem
 		// the current guild — except global operators, who oversee all guilds and see
 		// attribution everywhere.
 		enforcerInfo := ""
-		if showEnforcerID && (callerIsGlobalOperator || r.GroupID == currentGuildID) {
+		// Only attribute when we actually have an enforcer Discord ID. Legacy /
+		// operator-initiated records carry an empty EnforcerDiscordID; formatting it
+		// unconditionally renders a broken "by <@!>" mention. Symmetric with the
+		// reporter path below, which omits its line when the reporter is blank.
+		if showEnforcerID && (callerIsGlobalOperator || r.GroupID == currentGuildID) && r.EnforcerDiscordID != "" {
 			enforcerInfo = fmt.Sprintf(" by <@!%s>", r.EnforcerDiscordID)
 		}
 

--- a/server/evr_enforcement_journal_test.go
+++ b/server/evr_enforcement_journal_test.go
@@ -689,3 +689,33 @@ func TestSuspensionAttribution_GlobalOperatorSeesCrossGuild(t *testing.T) {
 		}
 	})
 }
+
+// TestSuspensionAttribution_EmptyEnforcerIDOmitsMention verifies that a record
+// with no enforcer Discord ID (legacy / operator-initiated, now more visible to
+// global operators cross-guild) does NOT render a malformed "by <@!>" mention.
+func TestSuspensionAttribution_EmptyEnforcerIDOmitsMention(t *testing.T) {
+	const currentGuild = "guild-A"
+	records := []GuildEnforcementRecord{{
+		ID:                "rec-legacy",
+		GroupID:           currentGuild,
+		EnforcerDiscordID: "", // no enforcer Discord ID on record
+		EnforcerUserID:    "",
+		CreatedAt:         time.Now().Add(-time.Hour),
+		UpdatedAt:         time.Now().Add(-time.Hour),
+		UserNoticeText:    "Operator-initiated notice",
+		Expiry:            time.Now().Add(time.Hour),
+	}}
+
+	// showEnforcerID=true and same-guild, so the attribution branch is taken; the
+	// empty ID must still suppress the mention rather than emit "by <@!>".
+	field := createSuspensionDetailsEmbedField("Guild A", records, nil, false, true, true, currentGuild, "", false)
+	if field == nil {
+		t.Fatal("expected field to be non-nil")
+	}
+	if strings.Contains(field.Value, "<@!>") {
+		t.Errorf("empty enforcer ID must not render a malformed mention; got: %s", field.Value)
+	}
+	if strings.Contains(field.Value, " by ") {
+		t.Errorf("empty enforcer ID must omit the \"by\" attribution entirely; got: %s", field.Value)
+	}
+}

--- a/server/evr_enforcement_rpc.go
+++ b/server/evr_enforcement_rpc.go
@@ -91,7 +91,7 @@ func PlayerReportRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 	}
 
 	// Check rate limit - max 5 reports per hour per user
-	if err := checkReportRateLimit(ctx, nk, userID); err != nil {
+	if err := checkReportRateLimit(ctx, logger, nk, userID); err != nil {
 		return "", err
 	}
 
@@ -162,7 +162,7 @@ func PlayerReportRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 }
 
 // checkReportRateLimit checks if the user has exceeded the rate limit of 5 reports per hour
-func checkReportRateLimit(ctx context.Context, nk runtime.NakamaModule, userID string) error {
+func checkReportRateLimit(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, userID string) error {
 	// List all reports by this user, paging through storage with a cursor.
 	// This avoids relying on StorageList ordering, which is not guaranteed to be time-based.
 
@@ -173,8 +173,22 @@ func checkReportRateLimit(ctx context.Context, nk runtime.NakamaModule, userID s
 	for {
 		objects, newCursor, err := nk.StorageList(ctx, SystemUserID, userID, StorageCollectionPlayerReports, 100, cursor)
 		if err != nil {
-			// If there's an error reading storage, allow the report (fail open for rate limiting)
-			return nil
+			// Fail CLOSED: a storage error must not become a rate-limit bypass.
+			// player/report is reachable by any authenticated user, so returning
+			// nil here (fail open) would let anyone who can induce storage errors
+			// exceed the MaxReportsPerHour cap at will. Deny the report instead and
+			// warn — someone should look, because reports are being blocked by a
+			// storage fault, not by the cap.
+			if logger != nil {
+				logger.WithFields(map[string]interface{}{
+					"user_id": userID,
+					"error":   err.Error(),
+				}).Warn("player/report rate-limit storage read failed; denying report (fail closed)")
+			}
+			return runtime.NewError(
+				"Unable to verify report rate limit right now. Please try again later.",
+				StatusUnavailable,
+			)
 		}
 
 		for _, obj := range objects {

--- a/server/evr_enforcement_rpc_test.go
+++ b/server/evr_enforcement_rpc_test.go
@@ -16,6 +16,10 @@ import (
 type mockEnforcementNakamaModule struct {
 	runtime.NakamaModule
 	storageObjects map[string][]*api.StorageObject
+	// storageListErr, when set, forces StorageList to fail — used to prove the
+	// rate limiter fails CLOSED (denies) rather than open (allows) on a storage
+	// error.
+	storageListErr error
 }
 
 func newMockEnforcementNakamaModule() *mockEnforcementNakamaModule {
@@ -74,6 +78,9 @@ func (m *mockEnforcementNakamaModule) StorageWrite(ctx context.Context, writes [
 }
 
 func (m *mockEnforcementNakamaModule) StorageList(ctx context.Context, callerID, userID, collection string, limit int, cursor string) ([]*api.StorageObject, string, error) {
+	if m.storageListErr != nil {
+		return nil, "", m.storageListErr
+	}
 	objects := make([]*api.StorageObject, 0)
 	for _, objs := range m.storageObjects {
 		for i := range objs {
@@ -361,7 +368,7 @@ func TestCheckReportRateLimit(t *testing.T) {
 	userID := "test-user"
 
 	// No reports yet - should pass
-	err := checkReportRateLimit(ctx, nk, userID)
+	err := checkReportRateLimit(ctx, nil, nk, userID)
 	if err != nil {
 		t.Errorf("Expected no error with no reports, got: %v", err)
 	}
@@ -393,7 +400,7 @@ func TestCheckReportRateLimit(t *testing.T) {
 	}
 
 	// Still under limit (4) - should pass
-	err = checkReportRateLimit(ctx, nk, userID)
+	err = checkReportRateLimit(ctx, nil, nk, userID)
 	if err != nil {
 		t.Errorf("Expected no error with 4 reports, got: %v", err)
 	}
@@ -421,7 +428,7 @@ func TestCheckReportRateLimit(t *testing.T) {
 	_, _ = nk.StorageWrite(ctx, writes)
 
 	// Still should pass (4 recent + 1 old = 5 total, but only 4 recent)
-	err = checkReportRateLimit(ctx, nk, userID)
+	err = checkReportRateLimit(ctx, nil, nk, userID)
 	if err != nil {
 		t.Errorf("Expected no error with 4 recent + 1 old reports, got: %v", err)
 	}
@@ -449,9 +456,25 @@ func TestCheckReportRateLimit(t *testing.T) {
 	_, _ = nk.StorageWrite(ctx, writes)
 
 	// Now at limit (5 recent) - should be rate limited
-	err = checkReportRateLimit(ctx, nk, userID)
+	err = checkReportRateLimit(ctx, nil, nk, userID)
 	if err == nil {
 		t.Error("Expected rate limit error with 5 recent reports, got nil")
+	}
+}
+
+// TestCheckReportRateLimit_StorageErrorDenies proves the rate limiter fails
+// CLOSED: when the storage read errors, the report is DENIED, not allowed.
+// player/report is reachable by any authenticated user, so a fail-open path
+// (return nil on error) would let an attacker who can induce storage errors
+// bypass the MaxReportsPerHour cap entirely.
+func TestCheckReportRateLimit_StorageErrorDenies(t *testing.T) {
+	ctx := context.Background()
+	nk := newMockEnforcementNakamaModule()
+	nk.storageListErr = fmt.Errorf("simulated storage outage")
+
+	err := checkReportRateLimit(ctx, nil, nk, "test-user")
+	if err == nil {
+		t.Fatal("expected rate limiter to DENY (fail closed) on storage error, got nil (fail open — an attacker inducing storage errors bypasses the cap)")
 	}
 }
 

--- a/server/evr_metrics_tags.go
+++ b/server/evr_metrics_tags.go
@@ -298,10 +298,14 @@ const (
 	// buckets that login's SEC-4 tags to the sentinel.
 	maxDistinctSystemsPerPlayer = 8
 	// maxTrackedPlayersForSystemLimit bounds tracker memory via a player-level LRU.
-	// Worst-case retained state is maxTrackedPlayersForSystemLimit *
-	// maxDistinctSystemsPerPlayer uint64 fingerprints (~a few MB at these values).
-	// Evicting the least-recently-active player is safe: on their next login they
-	// simply start counting systems from zero again.
+	// The raw fingerprints alone are maxTrackedPlayersForSystemLimit *
+	// maxDistinctSystemsPerPlayer uint64s (~3 MB at these values), but the
+	// surrounding per-player bookkeeping dominates: an LRU list element, an index
+	// map entry keyed on the string player ID, and a per-player seen-set map each
+	// cost far more than the 8 bytes of a fingerprint. Realistic retained heap is
+	// ~20-40 MB at these values — still bounded and safe. Evicting the
+	// least-recently-active player is safe: on their next login they simply start
+	// counting systems from zero again.
 	maxTrackedPlayersForSystemLimit = 50000
 )
 
@@ -310,9 +314,11 @@ const (
 // (loginMetricFingerprintFields — SystemInfo subset plus build_number/app_id/
 // publisher_lock and their device_type/build_version duplicates) participates, so a
 // player who varies ANY of these fields walks the same capped fingerprint space.
-// Non-attacker keys (websocket_auth, is_vr, error, ...) are excluded so churn on
-// them does not manufacture new systems. Two logins that bucket identically per
-// field share a fingerprint and therefore do not add cardinality.
+// The excluded keys are either operational (websocket_auth, error, device_linked)
+// or attacker-derived but low-cardinality booleans intentionally left uncapped
+// (is_vr, is_pcvr — each bounded to 2 values); excluding them means churn on them
+// does not manufacture new systems. Two logins that bucket identically per field
+// share a fingerprint and therefore do not add cardinality.
 func systemInfoFingerprint(tags map[string]string) uint64 {
 	h := fnv.New64a()
 	for _, f := range loginMetricFingerprintFields {

--- a/server/evr_pipeline_config.go
+++ b/server/evr_pipeline_config.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"container/list"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -15,11 +14,6 @@ import (
 )
 
 const configCacheTTL = 5 * time.Minute
-
-// configCacheMaxEntries bounds the number of distinct config Types held in
-// memory. ConfigRequest is reachable with only the (public) ServerKey, so the
-// cache must never be able to grow without a hard size cap (SEC-1).
-const configCacheMaxEntries = 256
 
 // configStorageRead is the storage read used by configRequest. It is a package
 // variable so tests can substitute a counting stub without a live database;
@@ -35,30 +29,29 @@ type cachedConfigEntry struct {
 	expiry time.Time
 }
 
-// configCacheStore is a bounded, TTL'd LRU keyed on the config Type only — the
-// same key the storage read itself uses (Collection "Config:"+Type, Key Type;
-// the read ignores ID). The previous implementation keyed the cache on the
-// client-controlled Type+":"+ID, which let any remote caller holding the
-// public ServerKey (a) miss the cache on every packet and force one DB read
-// each, and (b) grow the cache without bound when a stored Config:<Type>
-// object existed. Keying on Type plus an LRU size cap removes both (SEC-1).
+// configCacheStore is a TTL'd cache keyed on the config Type only — the same key
+// the storage read itself uses (Collection "Config:"+Type, Key Type; the read
+// ignores ID). The previous implementation keyed the cache on the
+// client-controlled Type+":"+ID, which let any remote caller holding the public
+// ServerKey (a) miss the cache on every packet and force one DB read each, and
+// (b) grow the cache without bound when a stored Config:<Type> object existed.
+// Keying on Type is what removes both (SEC-1).
+//
+// The cache needs no size cap of its own: loadConfigJSON only ever calls put for
+// Types that pass the evr.IsValidConfigType whitelist (the fixed ~4 types in
+// evr.defaultConfigResources), so the map holds at most len(defaultConfigResources)
+// entries no matter how the client varies Type or ID. (A former container/list
+// LRU with a 256-entry cap sat behind that whitelist and was therefore
+// unreachable — the cache could never exceed the whitelist size — so it was
+// removed in favor of this plain map.)
 type configCacheStore struct {
 	mu      sync.Mutex
-	ll      *list.List
-	entries map[string]*list.Element
-	maxSize int
+	entries map[string]*cachedConfigEntry
 }
 
-type configCacheItem struct {
-	key   string
-	entry *cachedConfigEntry
-}
-
-func newConfigCacheStore(maxSize int) *configCacheStore {
+func newConfigCacheStore() *configCacheStore {
 	return &configCacheStore{
-		ll:      list.New(),
-		entries: make(map[string]*list.Element),
-		maxSize: maxSize,
+		entries: make(map[string]*cachedConfigEntry),
 	}
 }
 
@@ -66,56 +59,37 @@ func newConfigCacheStore(maxSize int) *configCacheStore {
 func (c *configCacheStore) get(key string) (*cachedConfigEntry, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	el, ok := c.entries[key]
+	entry, ok := c.entries[key]
 	if !ok {
 		return nil, false
 	}
-	item := el.Value.(*configCacheItem)
-	if time.Now().After(item.entry.expiry) {
-		c.ll.Remove(el)
+	if time.Now().After(entry.expiry) {
 		delete(c.entries, key)
 		return nil, false
 	}
-	c.ll.MoveToFront(el)
-	return item.entry, true
+	return entry, true
 }
 
-// put stores entry under key, evicting the least-recently-used entries once
-// the store exceeds maxSize.
+// put stores entry under key.
 func (c *configCacheStore) put(key string, entry *cachedConfigEntry) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if el, ok := c.entries[key]; ok {
-		el.Value.(*configCacheItem).entry = entry
-		c.ll.MoveToFront(el)
-		return
-	}
-	el := c.ll.PushFront(&configCacheItem{key: key, entry: entry})
-	c.entries[key] = el
-	for c.maxSize > 0 && c.ll.Len() > c.maxSize {
-		oldest := c.ll.Back()
-		if oldest == nil {
-			break
-		}
-		c.ll.Remove(oldest)
-		delete(c.entries, oldest.Value.(*configCacheItem).key)
-	}
+	c.entries[key] = entry
 }
 
 func (c *configCacheStore) len() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.ll.Len()
+	return len(c.entries)
 }
 
 func (c *configCacheStore) clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.ll.Init()
-	c.entries = make(map[string]*list.Element)
+	c.entries = make(map[string]*cachedConfigEntry)
 }
 
-var configCache = newConfigCacheStore(configCacheMaxEntries)
+var configCache = newConfigCacheStore()
 
 // Test helpers (used by evr_pipeline_config_sec_test.go).
 func clearConfigCacheForTest()   { configCache.clear() }
@@ -178,8 +152,9 @@ func (p *EvrPipeline) loadConfigJSON(ctx context.Context, logger *zap.Logger, se
 	// client-controlled message.Type; keying the cache on Type alone (the SEC-1
 	// re-key) does not help when Type itself is unvalidated — an attacker sending
 	// a unique Type per packet misses the cache every time, forcing one DB read
-	// each (negative-cached, then LRU-evicted), which reproduces the exact
-	// per-packet DB amplification SEC-1 exists to kill. Rejecting unrecognized
+	// each (and, absent this gate, one cache entry per unique Type — unbounded
+	// growth), which reproduces the exact per-packet DB amplification SEC-1 exists
+	// to kill. Rejecting unrecognized
 	// Types here — before the cache and before configStorageRead — makes an
 	// unknown-Type flood cost zero DB reads. The valid set is
 	// evr.IsValidConfigType, derived from the same table GetDefaultConfigResource

--- a/server/evr_pipeline_config_sec_test.go
+++ b/server/evr_pipeline_config_sec_test.go
@@ -150,8 +150,8 @@ func TestSEC1_ConfigCache_BoundedUnderDistinctIDs(t *testing.T) {
 // to Type, but Type is exactly as client-controlled and unvalidated as ID was.
 // An attacker sending a UNIQUE, unrecognized Type per packet ("a0","a1",...)
 // misses the cache on every packet and, without a whitelist in front of the DB,
-// forces one storage read per packet (each result negative-cached, then evicted
-// by the 256-entry LRU, so it never stops hitting the DB). The whitelist must
+// forces one storage read per packet (and one negative-cache entry per unique
+// Type — unbounded growth, on top of never-ending DB reads). The whitelist must
 // make unknown Types cost ZERO storage reads, while a legitimate Type still
 // reads the DB exactly once and then serves from cache.
 func TestSEC1_ConfigRequest_UnknownTypeFlood_ZeroDBReads(t *testing.T) {
@@ -188,24 +188,51 @@ func TestSEC1_ConfigRequest_UnknownTypeFlood_ZeroDBReads(t *testing.T) {
 	}
 }
 
-// SEC-1: the cache must be size-bounded so a flood of distinct Types cannot
-// grow it without limit.
-func TestSEC1_ConfigCache_SizeCapped(t *testing.T) {
+// SEC-1: the cache is bounded by the IsValidConfigType whitelist, not a size
+// cap. A flood of invalid Types is rejected before put and never cached; the
+// only Types that can ever be cached are the fixed whitelist, so the cache holds
+// exactly the number of distinct valid Types requested — no more, regardless of
+// how the client varies Type or ID. (The former LRU size cap sat behind this
+// whitelist and was unreachable dead code, so an assertion that the cache stayed
+// under the cap was vacuous: a flood of invalid Types never reached put, leaving
+// the cache at 0 and the <=256 assertion trivially true. This asserts the real
+// bound instead.)
+func TestSEC1_ConfigCache_BoundedByWhitelist(t *testing.T) {
 	stub := &configTestStub{storedJSON: `{"ok":true}`}
 	installConfigStub(t, stub)
 
 	p := &EvrPipeline{}
 	session, _ := newNilIdentityConfigSession(t, p)
 
-	n := configCacheMaxEntries * 3
-	for i := 0; i < n; i++ {
-		msg := &evr.ConfigRequest{Type: fmt.Sprintf("type-%d", i), ID: fmt.Sprintf("type-%d", i)}
+	// Flood of unique INVALID Types (with varying IDs): every one is rejected by
+	// the whitelist before put, so none is ever cached.
+	const invalidFlood = 1000
+	for i := 0; i < invalidFlood; i++ {
+		msg := &evr.ConfigRequest{Type: fmt.Sprintf("invalid-%d", i), ID: fmt.Sprintf("id-%d", i)}
 		_ = p.configRequest(session.ctx, session.logger, session, msg)
 	}
+	if entries := configCacheLenForTest(); entries != 0 {
+		t.Fatalf("SEC-1 whitelist bound: %d invalid Types produced %d cache entries, want 0", invalidFlood, entries)
+	}
 
-	if entries := configCacheLenForTest(); entries > configCacheMaxEntries {
-		t.Fatalf("SEC-1 cache cap: %d distinct Types produced %d cache entries, want <= %d",
-			n, entries, configCacheMaxEntries)
+	// Every VALID Type, each requested many times with distinct client-supplied
+	// IDs. The cache must hold exactly one entry per valid Type (ID never touches
+	// the cache key) and never grow beyond the whitelist size.
+	validTypes := []string{
+		"main_menu",
+		"active_battle_pass_season",
+		"active_store_entry",
+		"active_store_featured_entry",
+	}
+	for _, tp := range validTypes {
+		for j := 0; j < 20; j++ {
+			msg := &evr.ConfigRequest{Type: tp, ID: fmt.Sprintf("%s-id-%d", tp, j)}
+			_ = p.configRequest(session.ctx, session.logger, session, msg)
+		}
+	}
+	if got, want := configCacheLenForTest(), len(validTypes); got != want {
+		t.Fatalf("SEC-1 whitelist bound: cache holds %d entries after valid+invalid flood, want exactly %d (one per valid Type)",
+			got, want)
 	}
 }
 

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -197,12 +197,25 @@ func (p *EvrPipeline) loginRequest(ctx context.Context, logger *zap.Logger, sess
 //   - device_type / build_version via params.MetricsTags() (bounded at that source)
 //   - build_number / app_id / publisher_lock via their allow-lists
 //
+// Note: on login_success, headset_type (from addSystemInfoMetricTags) always equals
+// device_type (from MetricsTags), and build_number always equals build_version, since
+// each pair derives from the same payload field via the same bounding function. This
+// duplicate tag-width is intentionally kept: dropping headset_type/build_number from
+// the emitted tuple would require also removing them from loginMetricFingerprintFields
+// (else boundSystemsPerPlayer's collapse loop re-adds them as metricTagOther), i.e.
+// changing the DoS-critical fingerprint/cap logic. Correlated tags do not expand the
+// Prometheus series space (device_type/build_version carry identical values), so the
+// cost is bytes, not cardinality — not worth touching the fingerprint for.
+//
 // The fully-bounded tuple then passes through the per-player distinct-system cap
-// (boundSystemsPerPlayer), which collapses every attacker-controlled tag to
-// metricTagOther once one account exceeds maxDistinctSystemsPerPlayer distinct
-// systems — so a single client cannot churn Prometheus series by varying ANY payload
-// field. build_number/app_id/publisher_lock are bounded and written BEFORE the cap so
-// they participate in the fingerprint and the collapse (loginMetricFingerprintFields).
+// (boundSystemsPerPlayer), which collapses every FINGERPRINTED attacker-controlled tag
+// to metricTagOther once one account exceeds maxDistinctSystemsPerPlayer distinct
+// systems. The only attacker-derived tags NOT collapsed are the two low-cardinality
+// booleans is_vr/is_pcvr (from MetricsTags, intentionally uncapped at 2 values each and
+// deliberately excluded from the fingerprint), so a single client still cannot churn
+// Prometheus series by varying any payload field. build_number/app_id/publisher_lock are
+// bounded and written BEFORE the cap so they participate in the fingerprint and the
+// collapse (loginMetricFingerprintFields).
 func buildLoginSuccessMetricTags(params *SessionParameters, limiter *systemFingerprintLimiter) map[string]string {
 	tags := params.MetricsTags()
 	addSystemInfoMetricTags(tags, params.loginPayload.SystemInfo)


### PR DESCRIPTION
Four small, low-severity polish fixes surfaced by the nakama security audit. Each is a separate commit for cleaner review. No behavior change except FIX 2 (flagged below).

## FIX 1 — Collapse dead config-cache LRU + fix vacuous test (SEC-1)
`server/evr_pipeline_config.go`, `server/evr_pipeline_config_sec_test.go`

The config cache's `container/list` 256-entry LRU sat behind the `IsValidConfigType` whitelist (only ~4 static types can ever be cached), so the eviction machinery was unreachable dead code. Replaced with a plain `map[string]*cachedConfigEntry` under the existing mutex. TTL, negative caching, not-caching of transient DB errors, and concurrency safety all preserved.

`TestSEC1_ConfigCache_SizeCapped` flooded unwhitelisted Types rejected before `put`, so the cache stayed at 0 and its `<=256` assertion passed vacuously. Replaced with `TestSEC1_ConfigCache_BoundedByWhitelist`, which asserts the real bound: after an invalid-Type flood plus every valid Type requested with churning IDs, the cache holds exactly the valid-type count.

## FIX 2 — player/report rate limit now fails CLOSED on storage error
`server/evr_enforcement_rpc.go`, `server/evr_enforcement_rpc_test.go`

`checkReportRateLimit` returned `nil` (allow) on a `StorageList` error — fail open. This endpoint is reachable by any authenticated user, so an attacker who can induce storage errors could bypass the 5/hr cap. Now fails closed: warns (user id + error) and returns `StatusUnavailable` denying the report.

**⚠️ DELIBERATE BEHAVIOR CHANGE:** a storage outage now blocks new reports instead of allowing unlimited ones. Security-correct default for a rate limiter, but an availability-vs-abuse trade-off — flagged for review.

## FIX 3 — Empty EnforcerDiscordID rendered a malformed mention (#504)
`server/evr_enforcement_journal.go`, `server/evr_enforcement_journal_test.go`

Enforcer attribution formatted `" by <@!%s>"` unconditionally; legacy/operator-initiated records with an empty `EnforcerDiscordID` rendered a broken `by <@!>` (now more visible to global operators cross-guild). Guarded on `EnforcerDiscordID != ""`, symmetric with the reporter path below it.

## FIX 4 — SEC-4: correct comments; document intentional correlated tags
`server/evr_metrics_tags.go`, `server/evr_pipeline_login.go`

On `login_success`, `headset_type` ≡ `device_type` and `build_number` ≡ `build_version` (each pair derives from the same payload field via the same bounding function). **Took the document path, not the dedup path:** collapsing would require editing `loginMetricFingerprintFields` (else the collapse loop re-adds the keys) — changing DoS-critical fingerprint/cap logic for a bytes-only benefit (correlated tags don't expand series space). Documented the intentional redundancy instead.

Also corrected two inaccurate comments (is_vr/is_pcvr called "non-attacker" — they're attacker-derived low-cardinality booleans intentionally uncapped; cap "collapses every attacker-controlled tag" — is_vr/is_pcvr are excluded) and the understated `maxTrackedPlayersForSystemLimit` memory note (~a few MB → realistic ~20-40 MB). No emission logic changed.

## Verification
- `gofmt -l` clean, `GOWORK=off go vet ./server/...` clean, `GOWORK=off go build ./server/...` clean
- All affected tests green under `-race`: `TestSEC1*`, `TestCheckReportRateLimit*`, `TestPlayerReportRPC*`, `TestSuspensionAttribution*`, `TestLoginSuccess*`, `TestSiblingMetricTagsBounded`, `TestSystemInfo*`, `TestSystemFingerprint*`
- FIX 2 and FIX 3 each show a red→green (new test fails before the fix, passes after)

🤖 Generated with [Claude Code](https://claude.com/claude-code)