### PR TITLE
fix(party): never follow your own other session (self-follow guard)

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -1464,6 +1464,17 @@ func (p *EvrPipeline) TryFollowPartyLeader(ctx context.Context, logger *zap.Logg
 		return false
 	}
 
+	// Self-follow guard: never follow another of your own sessions. The party
+	// leader being the same user on a different session means a stale/ghost
+	// session (e.g. a dropped connection whose presence lingered) is holding
+	// leadership — following it would chase a session that is not in a real
+	// match and get released to solo. Fall through to normal matchmaking.
+	if leader.UserId == session.userID.String() {
+		logger.Debug("Party leader is this player's own (different) session, not self-following",
+			zap.String("leader_sid", leader.SessionId))
+		return false
+	}
+
 	leaderSessionID := uuid.FromStringOrNil(leader.SessionId)
 	leaderUserID := uuid.FromStringOrNil(leader.UserId)
 
@@ -1609,6 +1620,16 @@ func (p *EvrPipeline) TryFollowPartyLeader(ctx context.Context, logger *zap.Logg
 // pollFollowPartyLeader polls for the party leader to join a match.
 func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Logger, session *sessionWS, params *LobbySessionParameters, lobbyGroup *LobbyGroup) bool {
 	logger.Debug("Polling to follow party leader")
+
+	// Self-follow guard (mirrors TryFollowPartyLeader): never poll to follow
+	// another of your own sessions. A same-user, different-session leader is a
+	// stale/ghost session holding party leadership — polling it never converges.
+	if leader := lobbyGroup.GetLeader(); leader != nil &&
+		leader.UserId == session.userID.String() &&
+		leader.SessionId != session.id.String() {
+		logger.Debug("Party leader is this player's own session, not self-following in poll")
+		return false
+	}
 
 	// isFollowerInLeaderMatch checks if the follower was placed into the
 	// leader's match (e.g., by the matchmaker).

--- a/server/evr_lobby_matchmaking_monitor_test.go
+++ b/server/evr_lobby_matchmaking_monitor_test.go
@@ -19,6 +19,7 @@ type mockMatchmakingTracker struct {
 	mu              sync.RWMutex
 	presences       map[presenceKey]*PresenceMeta
 	untrackAllCount atomic.Int32
+	getLocalCount   atomic.Int32
 }
 
 type presenceKey struct {
@@ -51,6 +52,7 @@ func (t *mockMatchmakingTracker) Update(ctx context.Context, sessionID uuid.UUID
 }
 
 func (t *mockMatchmakingTracker) GetLocalBySessionIDStreamUserID(sessionID uuid.UUID, stream PresenceStream, userID uuid.UUID) *PresenceMeta {
+	t.getLocalCount.Add(1)
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	key := presenceKey{sessionID: sessionID, stream: stream, userID: userID}

--- a/server/evr_lobby_self_follow_test.go
+++ b/server/evr_lobby_self_follow_test.go
@@ -1,0 +1,61 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTryFollowPartyLeader_DoesNotSelfFollow proves the self-follow guard.
+//
+// When the party "leader" is the SAME user as the follower on a DIFFERENT
+// session — a stale/ghost session (e.g. a dropped connection whose presence
+// lingered) still holding party leadership — TryFollowPartyLeader must fall
+// through to normal matchmaking WITHOUT chasing that ghost. Concretely it must
+// short-circuit before ever consulting the tracker to look up the leader's
+// match; otherwise it would follow a session that is not in a real match and
+// get released to solo (the production self-follow "split").
+func TestTryFollowPartyLeader_DoesNotSelfFollow(t *testing.T) {
+	env := newFollowTestEnv(t)
+
+	// Make the party leader this player's own account on a different session.
+	// (leaderSID != followerSID by construction — a distinct, ghost session.)
+	env.ph.leader.UserPresence.UserId = env.followerUID.String()
+	require.NotEqual(t, env.session.id.String(), env.ph.leader.UserPresence.SessionId,
+		"leader must be a different session than the follower")
+
+	// Put the ghost leader "in a match" so that, WITHOUT the guard, the code
+	// would advance past the early checks and consult the tracker's service
+	// stream to try to follow it.
+	env.setLeaderMatch(MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"})
+
+	before := env.tracker.getLocalCount.Load()
+	result := env.pipeline.TryFollowPartyLeader(
+		context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
+
+	require.False(t, result, "must not follow your own other session")
+	require.Equal(t, before, env.tracker.getLocalCount.Load(),
+		"self-follow guard must short-circuit before consulting the tracker")
+}
+
+// TestTryFollowPartyLeader_RealLeaderStillConsultsTracker is the control: a
+// genuine party (leader is a DIFFERENT user) must NOT be short-circuited by the
+// self-follow guard — it proceeds to consult the tracker exactly as before.
+func TestTryFollowPartyLeader_RealLeaderStillConsultsTracker(t *testing.T) {
+	env := newFollowTestEnv(t) // leader is a different user by default
+	env.setLeaderMatch(MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"})
+
+	before := env.tracker.getLocalCount.Load()
+	// Past the guard, the test's nil nk may panic downstream (MatchLabelByID);
+	// we only assert the guard did NOT short-circuit — i.e. the tracker WAS
+	// consulted for a real leader.
+	func() {
+		defer func() { _ = recover() }()
+		env.pipeline.TryFollowPartyLeader(
+			context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
+	}()
+	require.Greater(t, env.tracker.getLocalCount.Load(), before,
+		"a real (different-user) leader must still be looked up via the tracker")
+}

--- a/server/evr_lobby_self_follow_test.go
+++ b/server/evr_lobby_self_follow_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/gofrs/uuid/v5"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,11 +25,11 @@ func TestTryFollowPartyLeader_DoesNotSelfFollow(t *testing.T) {
 	require.NotEqual(t, env.session.id.String(), env.ph.leader.UserPresence.SessionId,
 		"leader must be a different session than the follower")
 
-	// Put the ghost leader "in a match" so that, WITHOUT the guard, the code
-	// would advance past the early checks and consult the tracker's service
-	// stream to try to follow it.
-	env.setLeaderMatch(MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"})
-
+	// No tracker state is set up on purpose: WITHOUT the guard the code advances
+	// past the early checks and queries the tracker for the leader's streams
+	// (incrementing getLocalCount). WITH the guard it must return before any of
+	// that. So the assertion below distinguishes the two regardless of what the
+	// tracker would have returned.
 	before := env.tracker.getLocalCount.Load()
 	result := env.pipeline.TryFollowPartyLeader(
 		context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
@@ -45,17 +44,18 @@ func TestTryFollowPartyLeader_DoesNotSelfFollow(t *testing.T) {
 // self-follow guard — it proceeds to consult the tracker exactly as before.
 func TestTryFollowPartyLeader_RealLeaderStillConsultsTracker(t *testing.T) {
 	env := newFollowTestEnv(t) // leader is a different user by default
-	env.setLeaderMatch(MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"})
+
+	// Put the (real) leader on the matchmaking stream. The guard does not fire
+	// for a different user, so the code proceeds to consult the tracker and then
+	// returns cleanly at the "leader is currently matchmaking" check — no nil-nk
+	// panic, so no recover() is needed to observe the tracker consultation.
+	env.setLeaderMatchmaking()
 
 	before := env.tracker.getLocalCount.Load()
-	// Past the guard, the test's nil nk may panic downstream (MatchLabelByID);
-	// we only assert the guard did NOT short-circuit — i.e. the tracker WAS
-	// consulted for a real leader.
-	func() {
-		defer func() { _ = recover() }()
-		env.pipeline.TryFollowPartyLeader(
-			context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
-	}()
+	result := env.pipeline.TryFollowPartyLeader(
+		context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
+
+	require.False(t, result, "leader is matchmaking → follower falls through")
 	require.Greater(t, env.tracker.getLocalCount.Load(), before,
 		"a real (different-user) leader must still be looked up via the tracker")
 }


### PR DESCRIPTION
## Problem (from production logs)
Some party "splits" are actually **one account following itself**. A stale/ghost session — a dropped connection whose party presence lingered as leader — is chased by the same account's live matchmaking session, which can't converge on it (it's not in a real match) and gets released to solo (`"Follower cannot join leader's match, releasing to independent matchmaking"`).

In a ~5.5h production sample, **6 of 9** release events were same-user self-follows (fatboy4tray ×3, eclipse_6.7 ×3). The `leader_sid` in each was **another of that account's own sessions** — never a login session. (The remaining 3 were a real multi-user split, handled separately.)

## Why the existing check missed it
`TryFollowPartyLeader` only short-circuited when the leader was the **same session** (`leader.SessionId == session.id`). A same-**user**/different-**session** leader (the ghost) slipped through into the follow path.

## Fix
Add a guard: if `leader.UserId == session.userID` (same account, different session), don't follow — fall through to normal matchmaking. Following yourself is always wrong **regardless of why** the duplicate/ghost session exists, so this is safe and independent of the deeper party-presence-cleanup question. Mirrored in `pollFollowPartyLeader`.

## Test (red→green)
`TestTryFollowPartyLeader_DoesNotSelfFollow` sets the leader to the follower's own account on a different session, puts that ghost "in a match," and asserts the call returns `false` **and never consults the tracker** (proving the guard short-circuits). Without the guard the tracker is queried → assertion fails (verified). A control test confirms a genuine different-user leader is still looked up as before.

## Not in this PR
The real multi-user split (leader present but no reservation created) and the underlying ghost-presence-cleanup-on-disconnect are separate follow-ups.

Co-Authored-By: Andrew Bates <a@sprock.io>