### PR TITLE
fix(party): patient follow poll — wait for the leader to land, not 3s

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -1717,22 +1717,37 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 	}
 	pollDeadline := time.Now().Add(maxPollDuration)
 
-	for {
+	// pollWait sleeps for one poll interval, bounded by the time remaining in
+	// the overall budget so the total wait can never overshoot maxPollDuration
+	// by a full interval. It reports done=true when the caller should stop
+	// polling — because the budget is exhausted or the context was canceled —
+	// and converged=true when the matchmaker placed the follower during a
+	// canceled wait.
+	pollWait := func() (converged, done bool) {
+		remaining := time.Until(pollDeadline)
+		if remaining <= 0 {
+			logger.Debug("Poll budget exhausted; leader did not become joinable, releasing to independent matchmaking")
+			return false, true
+		}
+		wait := pollInterval
+		if wait > remaining {
+			wait = remaining
+		}
 		select {
 		case <-ctx.Done():
 			if isFollowerInLeaderMatch() {
 				logger.Debug("Context canceled but follower is in leader's match (placed by matchmaker)")
-				return true
+				return true, true
 			}
-			return false
-		case <-time.After(pollInterval):
+			return false, true
+		case <-time.After(wait):
+			return false, false
 		}
+	}
 
-		// Give up once the overall poll budget is exhausted — the leader never
-		// landed in a joinable lobby within the wait window.
-		if time.Now().After(pollDeadline) {
-			logger.Debug("Poll budget exhausted; leader did not become joinable, releasing to independent matchmaking")
-			return false
+	for {
+		if converged, done := pollWait(); done {
+			return converged
 		}
 
 		// Re-check convergence after the poll interval. The matchmaker may
@@ -1779,15 +1794,10 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 			continue
 		}
 
-		// Wait for the leader to settle into the match before attempting to join.
-		select {
-		case <-ctx.Done():
-			if isFollowerInLeaderMatch() {
-				logger.Debug("Context canceled during settle but follower is in leader's match")
-				return true
-			}
-			return false
-		case <-time.After(pollInterval):
+		// Wait for the leader to settle into the match before attempting to join
+		// (also bounded by the remaining budget so it can't overshoot).
+		if converged, done := pollWait(); done {
+			return converged
 		}
 
 		// Re-check convergence after the settle wait.

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -1607,6 +1607,17 @@ func (p *EvrPipeline) TryFollowPartyLeader(ctx context.Context, logger *zap.Logg
 }
 
 // pollFollowPartyLeader polls for the party leader to join a match.
+const (
+	// pollFollowIntervalDefault is how often the follow poll re-checks whether
+	// the leader has landed in a joinable lobby.
+	pollFollowIntervalDefault = 3 * time.Second
+	// pollFollowMaxDurationDefault is how long a follower keeps trying to
+	// converge on the leader before falling back to solo matchmaking. 60s
+	// comfortably covers a slow ("potato") leader that is between matches while
+	// still bounding the wait.
+	pollFollowMaxDurationDefault = 60 * time.Second
+)
+
 func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Logger, session *sessionWS, params *LobbySessionParameters, lobbyGroup *LobbyGroup) bool {
 	logger.Debug("Polling to follow party leader")
 
@@ -1690,6 +1701,22 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 	const maxNonJoinableCycles = 3
 	nonJoinableCycles := 0
 
+	// A follower waits up to maxPollDuration for the leader to land in a
+	// joinable lobby before falling back to independent (solo) matchmaking.
+	// After a match ends the leader is frequently "between matches" (has no
+	// match presence) for several seconds — longer on slow clients — so the
+	// poll must be patient and keep waiting for the leader to reappear rather
+	// than bailing on the first tick. The overall budget bounds the wait.
+	pollInterval := p.pollFollowInterval
+	if pollInterval <= 0 {
+		pollInterval = pollFollowIntervalDefault
+	}
+	maxPollDuration := p.pollFollowMaxDuration
+	if maxPollDuration <= 0 {
+		maxPollDuration = pollFollowMaxDurationDefault
+	}
+	pollDeadline := time.Now().Add(maxPollDuration)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1698,7 +1725,14 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 				return true
 			}
 			return false
-		case <-time.After(3 * time.Second):
+		case <-time.After(pollInterval):
+		}
+
+		// Give up once the overall poll budget is exhausted — the leader never
+		// landed in a joinable lobby within the wait window.
+		if time.Now().After(pollDeadline) {
+			logger.Debug("Poll budget exhausted; leader did not become joinable, releasing to independent matchmaking")
+			return false
 		}
 
 		// Re-check convergence after the poll interval. The matchmaker may
@@ -1731,8 +1765,13 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 
 		presence := session.pipeline.tracker.GetLocalBySessionIDStreamUserID(leaderSessionID, stream, leaderUserID)
 		if presence == nil {
-			logger.Debug("Leader left match during poll")
-			return false
+			// Leader is between matches — they left the previous lobby and have
+			// not yet landed in the next. This is the normal post-match
+			// transition, not a reason to abandon the party. Keep polling (the
+			// pollDeadline above bounds the total wait) instead of releasing the
+			// follower to solo the instant the leader has no match.
+			logger.Debug("Leader is between matches during poll, continuing to wait for them to land")
+			continue
 		}
 
 		leaderMatchID := MatchIDFromStringOrNil(presence.GetStatus())
@@ -1748,7 +1787,7 @@ func (p *EvrPipeline) pollFollowPartyLeader(ctx context.Context, logger *zap.Log
 				return true
 			}
 			return false
-		case <-time.After(3 * time.Second):
+		case <-time.After(pollInterval):
 		}
 
 		// Re-check convergence after the settle wait.

--- a/server/evr_lobby_poll_patience_test.go
+++ b/server/evr_lobby_poll_patience_test.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestPollFollowPartyLeader_WaitsForLeaderBetweenMatches proves the patience
+// fix. When the leader has no match presence — the normal post-match moment
+// where they've left the previous lobby and not yet landed in the next — the
+// follow poll must keep waiting for them to reappear (up to its budget) rather
+// than bailing to solo on the first tick.
+//
+// Before the fix, `presence == nil` returned immediately ("Leader left match
+// during poll"), so a follower gave up after ~one poll interval. This test uses
+// a tiny per-pipeline interval/budget and asserts the poll actually spends
+// ~maxPollDuration waiting, which only happens if it keeps polling.
+func TestPollFollowPartyLeader_WaitsForLeaderBetweenMatches(t *testing.T) {
+	env := newFollowTestEnv(t)
+
+	// Speed the poll up for the test (per-pipeline, no global state / race).
+	env.pipeline.pollFollowInterval = 1 * time.Millisecond
+	env.pipeline.pollFollowMaxDuration = 30 * time.Millisecond
+
+	// Leader has NO match presence for the whole test (permanently "between
+	// matches"): deliberately do NOT call setLeaderMatch. The old code bailed
+	// on the first tick; the new code waits the full budget for them to land.
+
+	start := time.Now()
+	result := env.pipeline.pollFollowPartyLeader(
+		context.Background(), loggerForTest(t), env.session, env.params, env.lobbyGroup)
+	elapsed := time.Since(start)
+
+	require.False(t, result, "poll gives up eventually when the leader never lands")
+	// Waited its (tiny) budget rather than returning on the first presence==nil.
+	require.GreaterOrEqual(t, elapsed, 25*time.Millisecond,
+		"poll must keep waiting for a between-matches leader (~maxPollDuration), "+
+			"not give up on the first tick")
+	// And it honored the fast per-pipeline interval — the pre-fix path waited a
+	// hardcoded 3s before bailing on presence==nil, so it could never finish
+	// this fast. This is the assertion that fails without the fix.
+	require.Less(t, elapsed, 1*time.Second,
+		"poll must use the configured interval/budget, not the old hardcoded 3s-then-bail path")
+}
+
+// TestPollFollowPartyLeader_StopsAtContextCancel confirms the patient poll
+// still terminates promptly when the matchmaking context is canceled (it must
+// not ignore cancellation just because it now waits longer for the leader).
+func TestPollFollowPartyLeader_StopsAtContextCancel(t *testing.T) {
+	env := newFollowTestEnv(t)
+	env.pipeline.pollFollowInterval = 5 * time.Millisecond
+	env.pipeline.pollFollowMaxDuration = 10 * time.Second // long budget
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled
+
+	start := time.Now()
+	result := env.pipeline.pollFollowPartyLeader(
+		ctx, loggerForTest(t), env.session, env.params, env.lobbyGroup)
+	elapsed := time.Since(start)
+
+	require.False(t, result)
+	require.Less(t, elapsed, 1*time.Second,
+		"a canceled context must end the poll promptly, not wait the full budget")
+}

--- a/server/evr_pipeline.go
+++ b/server/evr_pipeline.go
@@ -59,6 +59,12 @@ type EvrPipeline struct {
 	config  Config
 	version string
 
+	// Party-follow poll timing. Zero means use the package defaults
+	// (pollFollowIntervalDefault / pollFollowMaxDurationDefault). Overridable in
+	// tests to avoid multi-second real waits.
+	pollFollowInterval    time.Duration
+	pollFollowMaxDuration time.Duration
+
 	sessionRegistry SessionRegistry
 	runtime         *Runtime
 	nk              *RuntimeGoNakamaModule


### PR DESCRIPTION
## Problem
`pollFollowPartyLeader` gave up the instant the leader had no match presence:

```go
presence := ...GetLocalBySessionIDStreamUserID(...)
if presence == nil {
    logger.Debug("Leader left match during poll")
    return false   // ← follower released to solo
}
```

That `presence == nil` is the **normal post-match transition** — the leader left the previous lobby and hasn't yet picked the next one. So a follower waited **one 3s tick**, saw the leader "between matches," and bailed to independent matchmaking — splitting the party — even though the leader was about to reappear. In production this shows as `"Leader left match during poll"` immediately followed by `"Follower cannot join leader's match, releasing to independent matchmaking"`.

## Fix
Make the poll **patient**: treat "leader between matches" as *keep waiting*, and poll up to a bounded budget (**default 60s**) for the leader to land in a joinable lobby before falling back to solo. 60s comfortably covers a slow ("potato") leader.

- `presence == nil` now `continue`s instead of returning.
- Added an overall `pollDeadline` so the loop still terminates (it previously relied on that bail for one of its exits).
- Poll interval / max duration are per-pipeline fields with zero-value fallback to `pollFollowIntervalDefault` (3s) / `pollFollowMaxDurationDefault` (60s) — so it's unit-testable without multi-second waits, with **no global state**.
- Context cancellation still ends the poll promptly (covered by a test).

## Tests (red→green)
- `TestPollFollowPartyLeader_WaitsForLeaderBetweenMatches` — a permanently between-matches leader; asserts the poll spends its (tiny, overridden) budget waiting instead of bailing on the first tick. **Without the fix it takes the hardcoded 3s and fails the assertion** (verified: `3.0s is not less than 1s`).
- `TestPollFollowPartyLeader_StopsAtContextCancel` — a canceled context ends the poll promptly despite the long budget.

## Companion
Pairs with #508 (self-follow guard). Both touch the follow path but in different regions; the self-follow ghost case is handled there, the genuine-slow-leader case here.

Co-Authored-By: Andrew Bates <a@sprock.io>