### PR TITLE
fix(party): make JoinPartyGroup transactional to kill ghost members

### DIFF
--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -778,7 +778,15 @@ func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.L
 		// tracker-read priority join path.
 		if ws, ok := session.(*sessionWS); ok {
 			if lobbyParams.PartyGroupName != "" && lobbyParams.PartyGroupName != "tablet" {
-				if lobbyGroup, _, err := JoinPartyGroup(ws, lobbyParams.PartyGroupName, lobbyParams.CurrentMatchID); err == nil && lobbyGroup != nil {
+				lobbyGroup, _, err := JoinPartyGroup(ws, lobbyParams.PartyGroupName, lobbyParams.CurrentMatchID)
+				if err != nil {
+					logger.Warn("Failed to join party group in social lobby path",
+						zap.String("username", ws.Username()),
+						zap.String("sid", ws.ID().String()),
+						zap.String("group_name", lobbyParams.PartyGroupName),
+						zap.Error(err))
+				}
+				if err == nil && lobbyGroup != nil {
 					if reservationMatchID, found := p.findReservation(ctx, logger, ws, lobbyGroup); found {
 						logger.Info("Found party reservation in social lobby path, joining directly",
 							zap.String("reservation_mid", reservationMatchID.String()))
@@ -806,6 +814,13 @@ func (p *EvrPipeline) lobbyFindOrCreateSocial(ctx context.Context, logger *zap.L
 			ws, ok := session.(*sessionWS)
 			if ok {
 				lobbyGroup, _, err := JoinPartyGroup(ws, lobbyParams.PartyGroupName, lobbyParams.CurrentMatchID)
+				if err != nil {
+					logger.Warn("Failed to join party group in priority join path",
+						zap.String("username", ws.Username()),
+						zap.String("sid", ws.ID().String()),
+						zap.String("group_name", lobbyParams.PartyGroupName),
+						zap.Error(err))
+				}
 				if err == nil && lobbyGroup != nil {
 					leader := lobbyGroup.GetLeader()
 					if leader != nil && leader.SessionId != session.ID().String() {

--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -202,14 +202,28 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 		if addedMember {
 			ph.members.Leave([]*Presence{&presence})
 		}
-		if created {
+		// Only delete the party if THIS call created it AND it is still empty.
+		// `created` alone is not sufficient: two sessions can converge on the
+		// same LobbyGroupName, with one creating the party (created=true) and a
+		// second concurrently joining it (created=false) — the second's
+		// JoinRequest commits it into ph.members before this creator's async
+		// tracker Join resolves. The creator never self-adds via JoinRequest
+		// (only via the tracker Join event that just failed), so on Track
+		// failure the creator is not in ph.members and Size() reflects only
+		// other, legitimate members. Deleting a party another session has
+		// already joined would evict a real member and orphan their party.
+		//
+		// Size()==0-then-Delete carries a strictly narrower residual window
+		// than the bug it fixes (see commit notes); it cannot recreate the
+		// evict-a-committed-member failure this guards against.
+		if created && ph.members.Size() == 0 {
 			session.pipeline.partyRegistry.Delete(ph.ID)
 		}
 		_ = session.Send(&rtapi.Envelope{Message: &rtapi.Envelope_Error{Error: &rtapi.Error{
 			Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),
-			Message: "Error tracking party creation",
+			Message: "Error tracking party membership",
 		}}}, true)
-		return nil, false, errors.New("failed to track party creation")
+		return nil, false, errors.New("failed to track party membership")
 	} else if isNew {
 		out := &rtapi.Envelope{Message: &rtapi.Envelope_Party{Party: &rtapi.Party{
 			PartyId:   ph.IDStr,

--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/rtapi"
@@ -120,6 +121,18 @@ func (g *LobbyGroup) MatchmakerRemoveSessionAll(sessionID string) error {
 
 func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID) (*LobbyGroup, bool, error) {
 
+	// Fail fast: if the session is already dying (its context is canceled),
+	// refuse the join before creating a party or adding any member. This is the
+	// common source of party "ghost members": the social-find loop re-invokes
+	// JoinPartyGroup after the session's connection has dropped. Without this
+	// guard, JoinRequest would insert the session into ph.members but the
+	// subsequent tracker.Track would fail (LocalTracker.Track guards on
+	// ctx.Err()), leaving a member with no party-stream presence that the
+	// stream-driven disconnect-eviction path can never evict.
+	if err := session.Context().Err(); err != nil {
+		return nil, false, fmt.Errorf("session context done, refusing party join: %w", err)
+	}
+
 	userPresence := &rtapi.UserPresence{
 		UserId:    session.UserID().String(),
 		SessionId: session.ID().String(),
@@ -150,6 +163,10 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 		return nil, false, err
 	}
 
+	// addedMember records whether THIS call inserted the session into
+	// ph.members via JoinRequest. It gates the rollback below so we only ever
+	// remove state this call created.
+	addedMember := false
 	if !created {
 		isMember := false
 		// Check if the player is already a member of the party
@@ -170,11 +187,24 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 			if !success {
 				return nil, false, errors.New("failed to join party")
 			}
+			addedMember = true
 		}
 	}
 
-	// If successful, the creator becomes the first user to join the party.
+	// Track the session on the party stream. This must be transactional: if
+	// Track fails, roll back any state this call created so that ph.members
+	// never retains a session that is not tracked on the party stream (the
+	// ghost-member invariant). The just-added member (if any) is guaranteed not
+	// to be the party leader here — leader assignment only happens via the
+	// tracker Join event, which requires a successful Track — so removing it
+	// directly from ph.members is the precise inverse of JoinRequest.
 	if success, isNew := session.pipeline.tracker.Track(session.Context(), session.ID(), ph.Stream, session.UserID(), presenceMeta); !success {
+		if addedMember {
+			ph.members.Leave([]*Presence{&presence})
+		}
+		if created {
+			session.pipeline.partyRegistry.Delete(ph.ID)
+		}
 		_ = session.Send(&rtapi.Envelope{Message: &rtapi.Envelope_Error{Error: &rtapi.Error{
 			Code:    int32(rtapi.Error_RUNTIME_EXCEPTION),
 			Message: "Error tracking party creation",

--- a/server/evr_lobby_group_ghost_test.go
+++ b/server/evr_lobby_group_ghost_test.go
@@ -58,6 +58,25 @@ func (t *ghostFailTracker) Track(ctx context.Context, sessionID uuid.UUID, strea
 	return false, false
 }
 
+// coMemberInjectTracker fails Track, but runs an injection hook first. It is
+// used to deterministically reproduce the concurrency the party-delete guard
+// protects against: the creator (user A) makes the group-name party
+// (created=true) and relies on the async tracker Join for its own membership;
+// before A's Track resolves, a concurrent joiner (user B) joins the
+// just-created party and becomes a committed member of ph.members. A's Track
+// then fails. The rollback must NOT delete the party out from under B.
+type coMemberInjectTracker struct {
+	*mockMatchmakingTracker
+	inject func()
+}
+
+func (t *coMemberInjectTracker) Track(ctx context.Context, sessionID uuid.UUID, stream PresenceStream, userID uuid.UUID, meta PresenceMeta) (bool, bool) {
+	if t.inject != nil {
+		t.inject()
+	}
+	return false, false
+}
+
 // membersContainUser reports whether ph.members holds a presence for userID.
 func membersContainUser(ph *PartyHandler, userID uuid.UUID) bool {
 	for _, m := range ph.members.List() {
@@ -194,6 +213,67 @@ func TestJoinPartyGroup_Rollback_DeletesParty_OnTrackFailure(t *testing.T) {
 	_, found := pr.LookupGroupPartyID(groupName)
 	assert.False(t, found,
 		"ORPHAN: the just-created party must be deleted from the registry when Track fails")
+}
+
+// TestJoinPartyGroup_Rollback_PreservesParty_WithCoMember_OnTrackFailure proves
+// the party-delete rollback is guarded on emptiness. The creator (user A) makes
+// a new group-name party (created=true); before A's Track resolves, a concurrent
+// joiner (user B) becomes a committed member. A's Track then fails.
+//
+// Because B is a legitimate member, the rollback must NOT delete the party.
+// Against unconditional `if created { Delete }` this FAILS: A deletes the party
+// out from under B. With the `ph.members.Size() == 0` guard it PASSES: the
+// non-empty party is preserved and B is retained.
+func TestJoinPartyGroup_Rollback_PreservesParty_WithCoMember_OnTrackFailure(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &coMemberInjectTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "insurgent"
+
+	// User B is the concurrent co-member. Build B's presence up front so the
+	// injection hook can add it to ph.members exactly as a real JoinRequest on
+	// an open party would (members.Join).
+	bUserID := uuid.Must(uuid.NewV4())
+	bSessionID := uuid.Must(uuid.NewV4())
+	bPresence := &Presence{
+		ID:     PresenceID{Node: "testnode", SessionID: bSessionID},
+		UserID: bUserID,
+		Meta:   PresenceMeta{Username: "co-member"},
+	}
+
+	// The hook runs during the creator's Track: the party already exists in the
+	// registry by then, so look it up and add B as a committed member.
+	tracker.inject = func() {
+		id, ok := pr.LookupGroupPartyID(groupName)
+		require.True(t, ok, "party must exist in registry during the creator's Track")
+		ph, ok := pr.Get(id)
+		require.True(t, ok)
+		_, err := ph.members.Join([]*Presence{bPresence})
+		require.NoError(t, err)
+	}
+
+	// User A (live context) creates the group-name party; its Track fails after
+	// B has joined.
+	creator := newTestSessionForParty(t, "creator", tracker, pr)
+	_, _, err := JoinPartyGroup(creator, groupName, MatchID{})
+	require.Error(t, err, "creator's join must fail when Track fails")
+
+	// The party must be preserved because B is a committed member.
+	id, found := pr.LookupGroupPartyID(groupName)
+	require.True(t, found,
+		"party with a co-member must NOT be deleted when the creator's Track fails")
+	ph, ok := pr.Get(id)
+	require.True(t, ok, "party handler must still be registered")
+	assert.True(t, membersContainUser(ph, bUserID),
+		"co-member B must remain in ph.members after the creator's failed join")
+	assert.False(t, membersContainUser(ph, creator.UserID()),
+		"creator must not linger in ph.members (its Track never succeeded)")
 }
 
 // TestJoinPartyGroup_HappyPath_JoinsExistingParty is the control/regression:

--- a/server/evr_lobby_group_ghost_test.go
+++ b/server/evr_lobby_group_ghost_test.go
@@ -1,0 +1,228 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Ghost-member regression tests for JoinPartyGroup.
+//
+// A party "ghost member" is a session that lives in ph.members but was never
+// tracked on the party stream. Because disconnect eviction is entirely
+// stream-driven (session close -> tracker untrack -> partyLeaveListener ->
+// partyRegistry.Leave -> ph.Leave), a member that is in ph.members but not on
+// the stream can never be evicted. It lingers, gets promoted to leader via
+// Oldest(), and leads a party for hours.
+//
+// The root cause: JoinPartyGroup was not transactional. For an already-open
+// group-name party it called ph.JoinRequest (which synchronously inserts into
+// ph.members) and THEN called tracker.Track. When Track failed — which it does
+// when the session's context is already canceled, because LocalTracker.Track
+// guards on ctx.Err() — the added member was never removed and a just-created
+// party was never deleted.
+//
+// These tests reproduce the two failure classes and assert the invariant:
+//
+//	ph.members must never retain a session that is not (or never became)
+//	tracked on the party stream.
+// ---------------------------------------------------------------------------
+
+// ghostCtxTracker mirrors the real LocalTracker guard: Track fails when the
+// session's context is already canceled. This is the exact production
+// condition that produced the confirmed ghost (session bb06b40c).
+type ghostCtxTracker struct {
+	*mockMatchmakingTracker
+}
+
+func (t *ghostCtxTracker) Track(ctx context.Context, sessionID uuid.UUID, stream PresenceStream, userID uuid.UUID, meta PresenceMeta) (bool, bool) {
+	if ctx.Err() != nil {
+		return false, false
+	}
+	return t.mockMatchmakingTracker.Track(ctx, sessionID, stream, userID, meta)
+}
+
+// ghostFailTracker always fails Track, regardless of context state. It models
+// a Track failure on a still-live session (e.g. the tracker's getSession race
+// on a session tearing down) so the rollback path can be exercised
+// deterministically without depending on fail-fast.
+type ghostFailTracker struct {
+	*mockMatchmakingTracker
+}
+
+func (t *ghostFailTracker) Track(ctx context.Context, sessionID uuid.UUID, stream PresenceStream, userID uuid.UUID, meta PresenceMeta) (bool, bool) {
+	return false, false
+}
+
+// membersContainUser reports whether ph.members holds a presence for userID.
+func membersContainUser(ph *PartyHandler, userID uuid.UUID) bool {
+	for _, m := range ph.members.List() {
+		if m.Presence.GetUserId() == userID.String() {
+			return true
+		}
+	}
+	return false
+}
+
+// TestJoinPartyGroup_NoGhost_OnDeadSessionJoin is RED test A.
+//
+// A group-name party already exists. A second joiner whose context is already
+// canceled calls JoinPartyGroup. It must return an error AND must NOT leave a
+// ghost member in ph.members.
+//
+// Against the pre-fix code this FAILS: JoinRequest adds the member, Track fails
+// on the canceled context, and the member lingers as a ghost.
+func TestJoinPartyGroup_NoGhost_OnDeadSessionJoin(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &ghostCtxTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "monarch12"
+	currentMatchID := MatchID{}
+
+	// First joiner has a live context and creates the group-name party.
+	leaderSession := newTestSessionForParty(t, "leader", tracker, pr)
+	leaderGroup, _, err := JoinPartyGroup(leaderSession, groupName, currentMatchID)
+	require.NoError(t, err)
+	require.NotNil(t, leaderGroup)
+	ph := leaderGroup.ph
+
+	// Second joiner's connection is already dying: its context is canceled.
+	ghostSession := newTestSessionForParty(t, "ghost", tracker, pr)
+	ghostSession.ctxCancelFn()
+
+	_, _, err = JoinPartyGroup(ghostSession, groupName, currentMatchID)
+
+	require.Error(t, err, "JoinPartyGroup must return an error for a dead-session join")
+	assert.False(t, membersContainUser(ph, ghostSession.UserID()),
+		"GHOST: dead session must NOT remain in ph.members after a failed join")
+}
+
+// TestJoinPartyGroup_NoOrphanParty_OnDeadSessionCreate is RED test B.
+//
+// A brand-new group name is joined by a session whose context is already
+// canceled — so JoinPartyGroup would create the party. It must return an error
+// AND must NOT leave an orphaned party registered under that group name.
+//
+// Against the pre-fix code this FAILS: the party is created, Track fails, and
+// the orphan party lingers in the registry.
+func TestJoinPartyGroup_NoOrphanParty_OnDeadSessionCreate(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &ghostCtxTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "divergent"
+	currentMatchID := MatchID{}
+
+	ghostSession := newTestSessionForParty(t, "ghost", tracker, pr)
+	ghostSession.ctxCancelFn()
+
+	_, _, err := JoinPartyGroup(ghostSession, groupName, currentMatchID)
+
+	require.Error(t, err, "JoinPartyGroup must return an error for a dead-session create")
+
+	_, found := pr.LookupGroupPartyID(groupName)
+	assert.False(t, found,
+		"ORPHAN: no party must remain registered for the group name after a failed create")
+}
+
+// TestJoinPartyGroup_Rollback_RemovesMember_OnTrackFailure exercises the
+// transactional rollback directly (safeguard 2), independent of fail-fast: the
+// session is LIVE but Track fails. The member added by JoinRequest must be
+// rolled back out of ph.members.
+func TestJoinPartyGroup_Rollback_RemovesMember_OnTrackFailure(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &ghostFailTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "monarch12"
+
+	// Pre-create the party directly so it exists without needing a Track.
+	leader := makeTestUserPresence("leader")
+	ph, created, err := pr.GetOrCreateByGroupName(groupName, true, 4, leader)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Live session joins the existing open party; Track fails.
+	joiner := newTestSessionForParty(t, "joiner", tracker, pr)
+	_, _, err = JoinPartyGroup(joiner, groupName, MatchID{})
+
+	require.Error(t, err, "JoinPartyGroup must return an error when Track fails")
+	assert.False(t, membersContainUser(ph, joiner.UserID()),
+		"GHOST: member added by JoinRequest must be rolled back when Track fails")
+}
+
+// TestJoinPartyGroup_Rollback_DeletesParty_OnTrackFailure exercises the
+// party-creation rollback directly: a LIVE session creates a new party but
+// Track fails; the just-created party must be deleted from the registry.
+func TestJoinPartyGroup_Rollback_DeletesParty_OnTrackFailure(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &ghostFailTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "divergent"
+
+	joiner := newTestSessionForParty(t, "joiner", tracker, pr)
+	_, _, err := JoinPartyGroup(joiner, groupName, MatchID{})
+
+	require.Error(t, err, "JoinPartyGroup must return an error when Track fails on create")
+
+	_, found := pr.LookupGroupPartyID(groupName)
+	assert.False(t, found,
+		"ORPHAN: the just-created party must be deleted from the registry when Track fails")
+}
+
+// TestJoinPartyGroup_HappyPath_JoinsExistingParty is the control/regression:
+// a healthy session (live context, successful Track) joins an existing party
+// and ends up in ph.members. This must pass before and after the fix.
+func TestJoinPartyGroup_HappyPath_JoinsExistingParty(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := &ghostCtxTracker{mockMatchmakingTracker: newMockMatchmakingTracker()}
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	groupName := "monarch12"
+
+	// Pre-create the open party.
+	leader := makeTestUserPresence("leader")
+	ph, created, err := pr.GetOrCreateByGroupName(groupName, true, 4, leader)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Healthy joiner with a live context joins successfully.
+	joiner := newTestSessionForParty(t, "joiner", tracker, pr)
+	lobbyGroup, _, err := JoinPartyGroup(joiner, groupName, MatchID{})
+
+	require.NoError(t, err, "healthy join must succeed")
+	require.NotNil(t, lobbyGroup)
+	assert.True(t, membersContainUser(ph, joiner.UserID()),
+		"healthy joiner must be present in ph.members")
+}


### PR DESCRIPTION
## The ghost

Party **ghost members** originate in `JoinPartyGroup` (`server/evr_lobby_group.go`), which was **not transactional**. For an already-existing open group-name party it calls `ph.JoinRequest(&presence)`, which for an OPEN party **synchronously inserts the session into `ph.members`** (`party_handler.go:121-129`). It THEN calls `tracker.Track(...)`.

When that `Track` **fails** — which it does when the session's context is already canceled (a dropped/dying connection; `LocalTracker.Track` guards on `ctx.Err()`) — the function sends an error envelope and returns an error, but **never removes the member it just added** and **never deletes a party it just created**.

That orphaned member has membership but **no party-stream presence**, so the disconnect-eviction path (which is entirely stream-driven: session close → tracker untrack → `partyLeaveListener` → `partyRegistry.Leave` → `ph.Leave`) can never fire for it. It becomes a permanent ghost — later promoted to leader via `Oldest()` and leading a party for hours.

Confirmed against a real production ghost: session `bb06b40c`, ~350ms alive, then **2.7h as an unevictable party leader**.

Worse, the two callers in the still-running social-find loop (`server/evr_lobby_find.go`) **swallowed the error** (`if lobbyGroup, _, err := JoinPartyGroup(...); err == nil && ...`), so the failure was silent.

## The fix — transactional + error-visible

**`JoinPartyGroup`:**
- **Fail fast:** if `session.Context().Err() != nil` (session already dying), return an error immediately, before creating a party or adding any member. This is the common case for the ghost — a re-entrant call on a dead session.
- **Roll back on Track failure:** if `Track` returns `!success`, undo any state this call created before returning:
  - member added via `ph.JoinRequest` → `ph.members.Leave([]*Presence{&presence})`
  - party created via `GetOrCreateByGroupName` → `partyRegistry.Delete(ph.ID)`

The restored invariant: **`ph.members` must never retain a session that is not tracked on the party stream.** The just-added member is guaranteed not to be the leader at rollback time (leader assignment only happens via the tracker Join event, which requires a successful Track), so `ph.members.Leave` is the precise inverse of `JoinRequest` — no leader/stop reshuffle needed. The healthy success paths are byte-identical.

**Error visibility (`evr_lobby_find.go`, both call sites):** stop swallowing the error — log at `warn` with username / sid / group name / error, per the log-discipline rule (`warn` = someone should look). Control flow is otherwise unchanged; a failed join still falls through as before.

## Tests (TDD, red → green)

New `server/evr_lobby_group_ghost_test.go`. A `ghostCtxTracker` mirrors the real `LocalTracker` guard (Track fails when the session ctx is canceled); a `ghostFailTracker` fails Track on a live session to exercise the rollback deterministically.

| Test | Asserts | Pre-fix | Post-fix |
|---|---|---|---|
| `NoGhost_OnDeadSessionJoin` | dead-session join → error, no ghost in `ph.members` | FAIL (member lingers) | PASS |
| `NoOrphanParty_OnDeadSessionCreate` | dead-session create → error, no orphan party in registry | FAIL (orphan party) | PASS |
| `Rollback_RemovesMember_OnTrackFailure` | live session, Track fails → member rolled back | FAIL (ghost) | PASS |
| `Rollback_DeletesParty_OnTrackFailure` | live session, Track fails on create → party deleted | FAIL (orphan) | PASS |
| `HappyPath_JoinsExistingParty` | healthy join succeeds, member present | PASS | PASS |

Regression: full `-run 'Follow|Party|JoinPartyGroup|TryFollow|LobbyGroup'` party/follow suite passes (151 tests). The only failures are pre-existing/environmental and unrelated to this change: `TestGroupEntriesPartyAtomicity/party_exactly_fills_candidate` fails identically on the untouched base HEAD `8979ec6d5`, and a full-runtime InitModule test aborts on the unset `DISCORD_BOT_TOKEN`.

Gates: `gofmt`, `GOWORK=off go vet ./server/...`, `GOWORK=off go build ./...`, targeted `-race` tests — all clean.

Co-Authored-By: Andrew Bates <a@sprock.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)