### PR TITLE
fix(party): unify group-name parties onto slot-reservation machinery

### DIFF
--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"errors"
 
 	"github.com/gofrs/uuid/v5"
@@ -199,6 +200,27 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 	// The player is a member of the party, they will follow the leader to lobbies.
 	leader := lobbyGroup.GetLeader()
 	isLeader := leader != nil && leader.SessionId == session.id.String()
+
+	// Unify group-name parties onto the existing party-reservation machinery.
+	// A group-name party is the party the user is in, exactly like a native/SNS
+	// party. Populating currentPartyID (mirroring snsPartyTrackAndJoin) makes the
+	// leader-connect reservation trigger (lobbyEntrantConnected) and the
+	// matchmaker cancel path engage for group parties too. Without this the
+	// signal-based reservation path is dead for the only party type real clients
+	// use.
+	if params, ok := LoadParams(session.Context()); ok {
+		params.currentPartyID = ph.ID
+		StoreParams(session.Context(), params)
+	}
+
+	// The leader-connect trigger only fires once, when the leader connects. A
+	// member that joins the party AFTER the leader is already sitting in a social
+	// lobby would never get a reserved seat. Create one now if the leader is
+	// currently in a social lobby. createReservationForNewPartyMember no-ops when
+	// this session is the leader, or when the leader is not in a social match.
+	if !isLeader && session.evrPipeline != nil {
+		go session.evrPipeline.createReservationForNewPartyMember(context.WithoutCancel(session.Context()), session.logger, session, ph.ID)
+	}
 
 	return lobbyGroup, isLeader, nil
 }

--- a/server/evr_lobby_group_reservation_test.go
+++ b/server/evr_lobby_group_reservation_test.go
@@ -1,0 +1,290 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/rtapi"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// ===========================================================================
+// Group-party reservation unification (production: group-name parties only)
+// ===========================================================================
+//
+// Real clients form parties via LobbyGroupName -> JoinPartyGroup, which never
+// set params.currentPartyID. That left two reservation mechanisms dead for the
+// only party type in use:
+//
+//  1. The leader-connect trigger in lobbyEntrantConnected fires only when the
+//     connecting player's params.currentPartyID != uuid.Nil.
+//  2. The matchmaker cancel path (lobbyPendingSessionCancel) cancels the whole
+//     party only when params.currentPartyID != uuid.Nil.
+//
+// These tests pin the two entry points that unify group parties onto the
+// existing reservation machinery:
+//   - JoinPartyGroup populates params.currentPartyID.
+//   - JoinPartyGroup creates a reservation for a member that joins AFTER the
+//     leader is already sitting in a social lobby (the one-shot leader-connect
+//     trigger cannot cover this member).
+
+// reservationRecordingRegistry records SignalCreatePartyReservations payloads
+// so a test can observe whether (and for whom) a reservation was created. It
+// embeds mockFollowMatchRegistry for the GetMatch/SetMatch label plumbing that
+// MatchLabelByID needs.
+type reservationRecordingRegistry struct {
+	*mockFollowMatchRegistry
+
+	mu      sync.Mutex
+	signals []SignalCreatePartyReservationsPayload
+}
+
+func (r *reservationRecordingRegistry) Signal(_ context.Context, _ string, data string) (string, error) {
+	env := SignalEnvelope{}
+	if err := json.Unmarshal([]byte(data), &env); err == nil && env.OpCode == SignalCreatePartyReservations {
+		payload := SignalCreatePartyReservationsPayload{}
+		if err := json.Unmarshal(env.Payload, &payload); err == nil {
+			r.mu.Lock()
+			r.signals = append(r.signals, payload)
+			r.mu.Unlock()
+		}
+	}
+	return SignalResponse{Success: true}.String(), nil
+}
+
+// reservedSessionIDs returns the flattened set of member session IDs across all
+// recorded reservation signals.
+func (r *reservationRecordingRegistry) reservedSessionIDs() []uuid.UUID {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []uuid.UUID
+	for _, sig := range r.signals {
+		for _, m := range sig.Members {
+			out = append(out, m.SessionID)
+		}
+	}
+	return out
+}
+
+func (r *reservationRecordingRegistry) signalCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.signals)
+}
+
+// newPartyMemberSession builds a sessionWS whose context carries
+// SessionParameters (so LoadParams/StoreParams work) and whose evrPipeline and
+// registries are wired for the reservation path.
+func newPartyMemberSession(t *testing.T, username string, tracker Tracker, pr PartyRegistry, ep *EvrPipeline) *sessionWS {
+	t.Helper()
+
+	params := &SessionParameters{
+		xpID:    evr.EvrId{},
+		profile: &EVRProfile{}, // non-nil: DisplayName() dereferences the pointer
+	}
+	baseCtx := context.WithValue(context.Background(), ctxSessionParametersKey{}, atomic.NewPointer(params))
+	ctx, cancel := context.WithCancel(baseCtx)
+	t.Cleanup(cancel)
+
+	s := &sessionWS{}
+	s.id = uuid.Must(uuid.NewV4())
+	s.userID = uuid.Must(uuid.NewV4())
+	s.username = atomic.NewString(username)
+	s.ctx = ctx
+	s.ctxCancelFn = cancel
+	s.logger = loggerForTest(t)
+	s.format = SessionFormatProtobuf
+	s.outgoingCh = make(chan []byte, 16)
+	s.tracker = tracker
+	s.pipeline = &Pipeline{node: "testnode", tracker: tracker, partyRegistry: pr}
+	s.pipeline.partyRegistry = pr
+	s.evrPipeline = ep
+	return s
+}
+
+// mkGroupReservationEnv creates a party in the registry, promotes the leader
+// (mirroring the party-stream Join callback that fires in production when the
+// leader is tracked on the party stream), and returns the wired EvrPipeline.
+func mkGroupReservationEnv(t *testing.T, groupName string, leaderSID, leaderUID uuid.UUID) (*reservationRecordingRegistry, *mockMatchmakingTracker, PartyRegistry, *EvrPipeline) {
+	t.Helper()
+
+	logger := loggerForTest(t)
+	tracker := newMockMatchmakingTracker()
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	t.Cleanup(mmCleanup)
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	leaderUP := &rtapi.UserPresence{
+		UserId:    leaderUID.String(),
+		SessionId: leaderSID.String(),
+		Username:  "leader",
+	}
+	ph, created, err := pr.GetOrCreateByGroupName(groupName, true, 4, leaderUP)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	// Promote the leader from expectedInitialLeader -> ph.leader, as the
+	// party-stream Join callback does in production when the leader is tracked
+	// on the party stream. createReservationForNewPartyMember reads ph.leader.
+	ph.Join([]*Presence{{
+		ID:     PresenceID{SessionID: leaderSID, Node: "testnode"},
+		UserID: leaderUID,
+		Meta:   PresenceMeta{Username: "leader"},
+	}})
+
+	registry := &reservationRecordingRegistry{mockFollowMatchRegistry: newMockFollowMatchRegistry()}
+
+	ep := &EvrPipeline{
+		node: "testnode",
+		nk: &RuntimeGoNakamaModule{
+			logger:        logger,
+			matchRegistry: registry,
+			partyRegistry: pr,
+			tracker:       tracker,
+			node:          "testnode",
+		},
+	}
+	return registry, tracker, pr, ep
+}
+
+func mkGroupSocialLabel(id MatchID, groupID uuid.UUID) *MatchLabel {
+	gid := groupID
+	return &MatchLabel{
+		ID:          id,
+		Open:        true,
+		LobbyType:   PublicLobby,
+		Mode:        evr.ModeSocialPublic,
+		Level:       evr.LevelSocial,
+		GroupID:     &gid,
+		MaxSize:     SocialLobbyMaxSize,
+		PlayerLimit: SocialLobbyMaxSize,
+		Players:     make([]PlayerInfo, 0),
+	}
+}
+
+// TestJoinPartyGroup_PopulatesCurrentPartyID pins entry point #1: after a
+// group-name join, the session's params.currentPartyID equals the registry
+// party ID. Before the fix this stayed uuid.Nil, so the leader-connect and
+// matchmaker-cancel paths never engaged for group parties.
+func TestJoinPartyGroup_PopulatesCurrentPartyID(t *testing.T) {
+	logger := loggerForTest(t)
+	tracker := newMockMatchmakingTracker()
+	mm, mmCleanup := createLightMatchmaker(t, logger)
+	defer mmCleanup()
+
+	tsm := testStreamManager{}
+	dmr := &DummyMessageRouter{}
+	pr := NewLocalPartyRegistry(logger, cfg, mm, tracker, tsm, dmr, "testnode")
+
+	session := newPartyMemberSession(t, "leader", tracker, pr, nil)
+
+	params, ok := LoadParams(session.Context())
+	require.True(t, ok)
+	require.Equal(t, uuid.Nil, params.currentPartyID, "precondition: currentPartyID starts nil")
+
+	lobbyGroup, _, err := JoinPartyGroup(session, "reservation_group", MatchID{})
+	require.NoError(t, err)
+	require.NotNil(t, lobbyGroup)
+
+	params, ok = LoadParams(session.Context())
+	require.True(t, ok)
+	assert.Equal(t, lobbyGroup.ID(), params.currentPartyID,
+		"JoinPartyGroup must populate currentPartyID with the registry party ID")
+	assert.NotEqual(t, uuid.Nil, params.currentPartyID)
+}
+
+// TestJoinPartyGroup_LeaderInSocial_CreatesReservationForJoiner pins entry
+// point #2: a member that joins the group AFTER the leader is already in a
+// social lobby gets a reservation created for them in the leader's match.
+func TestJoinPartyGroup_LeaderInSocial_CreatesReservationForJoiner(t *testing.T) {
+	groupName := "reservation_group"
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	registry, tracker, pr, ep := mkGroupReservationEnv(t, groupName, leaderSID, leaderUID)
+
+	// Leader is sitting in a social lobby: service stream -> match, social label.
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	tracker.Track(context.Background(), leaderSID,
+		PresenceStream{Mode: StreamModeService, Subject: leaderSID, Label: StreamLabelMatchService},
+		leaderUID,
+		PresenceMeta{Status: socialMatchID.String()})
+	registry.SetMatch(socialMatchID, mkGroupSocialLabel(socialMatchID, groupID))
+
+	member := newPartyMemberSession(t, "joiner", tracker, pr, ep)
+
+	_, isLeader, err := JoinPartyGroup(member, groupName, MatchID{})
+	require.NoError(t, err)
+	require.False(t, isLeader, "the joining member must not be the leader")
+
+	require.Eventually(t, func() bool {
+		for _, sid := range registry.reservedSessionIDs() {
+			if sid == member.id {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 10*time.Millisecond,
+		"a reservation must be created for the member joining after the leader landed in a social lobby")
+}
+
+// TestJoinPartyGroup_LeaderInArena_NoReservation: no reservation when the
+// leader is in a non-social (arena) match.
+func TestJoinPartyGroup_LeaderInArena_NoReservation(t *testing.T) {
+	groupName := "reservation_group"
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	registry, tracker, pr, ep := mkGroupReservationEnv(t, groupName, leaderSID, leaderUID)
+
+	arenaMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	tracker.Track(context.Background(), leaderSID,
+		PresenceStream{Mode: StreamModeService, Subject: leaderSID, Label: StreamLabelMatchService},
+		leaderUID,
+		PresenceMeta{Status: arenaMatchID.String()})
+	arenaLabel := mkGroupSocialLabel(arenaMatchID, groupID)
+	arenaLabel.Mode = evr.ModeArenaPublic // not social
+	arenaLabel.Level = evr.LevelUnspecified
+	registry.SetMatch(arenaMatchID, arenaLabel)
+
+	member := newPartyMemberSession(t, "joiner", tracker, pr, ep)
+
+	_, _, err := JoinPartyGroup(member, groupName, MatchID{})
+	require.NoError(t, err)
+
+	require.Never(t, func() bool { return registry.signalCount() > 0 },
+		300*time.Millisecond, 20*time.Millisecond,
+		"no reservation should be created when the leader is in a non-social match")
+}
+
+// TestJoinPartyGroup_LeaderNotInLobby_NoReservation: no reservation when the
+// leader is not in any match (matchmaking / at menu).
+func TestJoinPartyGroup_LeaderNotInLobby_NoReservation(t *testing.T) {
+	groupName := "reservation_group"
+	leaderSID := uuid.Must(uuid.NewV4())
+	leaderUID := uuid.Must(uuid.NewV4())
+
+	registry, tracker, pr, ep := mkGroupReservationEnv(t, groupName, leaderSID, leaderUID)
+	// Deliberately do NOT track the leader on any service stream.
+
+	member := newPartyMemberSession(t, "joiner", tracker, pr, ep)
+
+	_, _, err := JoinPartyGroup(member, groupName, MatchID{})
+	require.NoError(t, err)
+
+	require.Never(t, func() bool { return registry.signalCount() > 0 },
+		300*time.Millisecond, 20*time.Millisecond,
+		"no reservation should be created when the leader is not in any match")
+}

--- a/server/evr_session_parameters.go
+++ b/server/evr_session_parameters.go
@@ -58,7 +58,7 @@ type SessionParameters struct {
 
 	isAmbassadorMatch *atomic.Bool // True if the player is ambassadoring in the current match
 
-	currentPartyID    uuid.UUID // Nakama party UUID the user is currently in (SNS party)
+	currentPartyID    uuid.UUID // Nakama party UUID the user is currently in (native/SNS or group-name party)
 	currentSNSPartyID uint64    // SNS wire party ID
 
 	sessionDurationOnce sync.Once // Ensures the session-duration metrics goroutine is spawned exactly once


### PR DESCRIPTION
## The dead signal path

Slot reservations hold seats so a party lands together in a social lobby. Two mechanisms exist; only one worked for real clients:

- **Placeholder path (works):** the leader appends placeholder reservations at its own social-lobby join.
- **Signal path (was dead in prod):** `createPartyReservations` -> `SignalCreatePartyReservations`, triggered in `lobbyEntrantConnected` **only when `params.currentPartyID != uuid.Nil`**.

`currentPartyID` was set **exclusively** by the native/SNS party handlers (`snsPartyTrackAndJoin`). Real clients never form native/SNS parties (0 SNS party messages in prod) — they form **group-name parties** via `LobbyGroupName` -> `JoinPartyGroup`, which never set `currentPartyID`. So the signal reservation path never fired for the only party type in use.

## The fix — two entry points, no new mechanism

The correct, party-type-independent rule: *a player in a party whose leader is currently in a social lobby should have a seat reserved for them in that lobby.*

1. **Populate `currentPartyID` in `JoinPartyGroup`** (mirroring `snsPartyTrackAndJoin`). This alone makes the existing leader-connect trigger (`lobbyEntrantConnected`) fire for group parties, and enables the matchmaker cancel path for them. Field comment at `evr_session_parameters.go` updated (no longer "SNS party" only).
2. **On-join reservation trigger:** a member that joins the party AFTER the leader is already in a social lobby is missed by the one-shot leader-connect trigger. `JoinPartyGroup` now calls the existing single-member helper `createReservationForNewPartyMember` for the non-leader joiner. That helper already gates on "leader is in a social match" (reusing the `StreamModeService` -> match -> `MatchLabelByID` -> `IsSocial()` lookup), so no parallel mechanism was introduced.

The placeholder path is left intact. The change is localized to the success path of `JoinPartyGroup` (kept clear of PR #510's ctx-fail-fast / rollback region for a trivial merge).

## Consumers verified

- `snsPartyLeaveCleanup`: only reachable from the SNS message handlers, which group clients never trigger — dormant, unaffected.
- Matchmaker cancel (`lobbyPendingSessionCancel`): now correctly cancels the whole party when a group member cancels (group parties previously missed this — a correctness improvement, per spec).

## Tests (TDD, red -> green)

New `server/evr_lobby_group_reservation_test.go`:

- `TestJoinPartyGroup_PopulatesCurrentPartyID` — red: `currentPartyID` stayed `uuid.Nil`; green: equals the registry party ID.
- `TestJoinPartyGroup_LeaderInSocial_CreatesReservationForJoiner` — red: "Condition never satisfied" (no reservation signal); green: a `SignalCreatePartyReservations` fires for the joining member.
- `TestJoinPartyGroup_LeaderInArena_NoReservation` and `TestJoinPartyGroup_LeaderNotInLobby_NoReservation` — no spurious reservation (green before and after).

Regression (`GOWORK=off go test ./server/ -race -run 'Follow|Party|Reservation|JoinPartyGroup|Matchmak|LobbyGroup'`): the failing set is **identical** to the pristine `main` baseline (environmental: file-fixture `Characterization*` matchmaker tests, `LobbyCapacity_*`, `GroupEntriesPartyAtomicity` — all fail without this change too). Zero new failures.

Gates: `gofmt` clean, `GOWORK=off go vet ./server/` clean, `GOWORK=off go build ./...` clean, targeted `-race` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)