### PR TITLE
fix(match): make CREATE-side reservation dedup UserID-keyed

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -533,7 +533,10 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 			// Reserve spots for party members for 5 minutes
 			reservation.Expiry = time.Now().Add(time.Minute * 5)
 		}
-		state.reservationMap[sessionID] = reservation
+		// Upsert by user ID so a member who reconnected (new session ID) does not
+		// leave a phantom reservation under their stale session ID. Symmetric with
+		// the UserID-aware consume path (LoadAndDeleteReservationByUserIDRaw).
+		state.upsertReservationByUserID(reservation)
 		state.joinTimestamps[sessionID] = time.Now()
 	}
 
@@ -880,9 +883,15 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 					}
 				} else {
 					// Non-leader is leaving: clear only THEIR OWN reservation.
-					if _, exists := state.reservationMap[mp.GetSessionId()]; exists {
-						delete(state.reservationMap, mp.GetSessionId())
-						cleared = 1
+					// Match by user ID, not just session ID: a member who
+					// reconnected holds their reservation under a NEW session ID
+					// (see upsertReservationByUserID), so a session-ID-only delete
+					// would orphan the old entry.
+					for sid, r := range state.reservationMap {
+						if r.Presence.UserID == mp.UserID {
+							delete(state.reservationMap, sid)
+							cleared++
+						}
 					}
 				}
 				if cleared > 0 {
@@ -1903,17 +1912,28 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 		}
 		created := 0
 		for _, member := range payload.Members {
-			sid := member.GetSessionId()
-			if _, exists := state.presenceMap[sid]; exists {
+			// Skip if the member is already an active presence. Match by user ID,
+			// not just session ID: a member who reconnected holds their presence
+			// under a NEW session ID, so a session-ID-only check would miss them
+			// and create a phantom reservation.
+			alreadyPresent := false
+			for _, p := range state.presenceMap {
+				if p.UserID == member.UserID {
+					alreadyPresent = true
+					break
+				}
+			}
+			if alreadyPresent {
 				continue // already in match
 			}
-			if _, exists := state.reservationMap[sid]; exists {
-				continue // already reserved
-			}
-			state.reservationMap[sid] = &slotReservation{
+			// Upsert by user ID: replace any existing reservation for this member
+			// (possibly under a stale session ID from a prior connection) so they
+			// end up with exactly one reservation. Symmetric with the UserID-aware
+			// consume path (LoadAndDeleteReservationByUserIDRaw).
+			state.upsertReservationByUserID(&slotReservation{
 				Presence: member,
 				Expiry:   time.Now().Add(5 * time.Minute),
-			}
+			})
 			created++
 		}
 		if created > 0 {

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -881,6 +881,15 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 							cleared++
 						}
 					}
+				} else if mp.UserID == uuid.Nil {
+					// Non-leader with a NIL user ID. A nil user ID is not a stable
+					// identity (mirrors upsertReservationByUserID): matching by it
+					// would delete EVERY nil-UserID reservation, collapsing unrelated
+					// members. Clear only this member's own reservation by session ID.
+					if _, ok := state.reservationMap[mp.GetSessionId()]; ok {
+						delete(state.reservationMap, mp.GetSessionId())
+						cleared++
+					}
 				} else {
 					// Non-leader is leaving: clear only THEIR OWN reservation.
 					// Match by user ID, not just session ID: a member who
@@ -1918,7 +1927,17 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			// and create a phantom reservation.
 			alreadyPresent := false
 			for _, p := range state.presenceMap {
-				if p.UserID == member.UserID {
+				if member.UserID == uuid.Nil {
+					// A nil user ID is not a stable identity (mirrors
+					// upsertReservationByUserID): matching by it would treat every
+					// nil-UserID presence as the same user and wrongly skip a needed
+					// reservation. Compare by session ID instead; the upsert below
+					// already keys nil reservations by session ID.
+					if p.GetSessionId() == member.GetSessionId() {
+						alreadyPresent = true
+						break
+					}
+				} else if p.UserID == member.UserID {
 					alreadyPresent = true
 					break
 				}

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -147,6 +147,37 @@ func (s *MatchLabel) LoadAndDeleteReservationByUserIDRaw(userID string) (*slotRe
 	return nil, false
 }
 
+// upsertReservationByUserID inserts a slot reservation keyed by its presence's
+// session ID, after first removing any existing reservation held by the SAME
+// user ID under a (possibly stale) different session ID.
+//
+// EVR clients receive a NEW nakama session ID on every WebSocket reconnect while
+// their user ID (from the auth token) stays stable. Keying create-side dedup on
+// session ID alone therefore lets a reconnected member acquire a SECOND
+// reservation while their original one is still un-expired -- a phantom seat that
+// counts toward capacity (OpenSlots/ReservationCount) until it expires. This
+// makes the CREATE side symmetric with the already-UserID-aware consume path
+// (LoadAndDeleteReservationByUserIDRaw): a member always ends with exactly one
+// reservation.
+//
+// Removal and insertion happen in the same call, so a re-seed/restore of the
+// same member can never net to zero reservations. Callers are expected to
+// rebuildCache() afterward (as the create paths already do) so the derived
+// capacity counters reflect the change.
+func (s *MatchLabel) upsertReservationByUserID(reservation *slotReservation) {
+	userID := reservation.Presence.UserID
+	// A nil user ID is not a stable identity; key on session ID only in that
+	// case so two distinct members that both lack a user ID are never collapsed.
+	if userID != uuid.Nil {
+		for sid, r := range s.reservationMap {
+			if r.Presence.UserID == userID {
+				delete(s.reservationMap, sid)
+			}
+		}
+	}
+	s.reservationMap[reservation.Presence.GetSessionId()] = reservation
+}
+
 func (s *MatchLabel) IsPublic() bool {
 	return s.LobbyType == PublicLobby
 }

--- a/server/evr_reservation_dedup_test.go
+++ b/server/evr_reservation_dedup_test.go
@@ -3,8 +3,10 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
 
@@ -203,5 +205,129 @@ func TestReservationDedup_DistinctMembersUnaffected(t *testing.T) {
 	}
 	if state.ReservationCount != 2 {
 		t.Errorf("expected ReservationCount=2 for two distinct members, got %d", state.ReservationCount)
+	}
+}
+
+// TestReservationDedup_NilUserIDLeaveOnlyClearsOwn pins Fix 1: two DISTINCT
+// members that both lack a user ID (UserID == uuid.Nil) hold party reservations.
+// When one leaves as a non-leader, only the LEAVER's own reservation (keyed by
+// session ID) must be cleared. A nil user ID is not a stable identity, so the
+// by-UserID delete loop must NOT be used for it -- otherwise it would wrongly
+// collapse the other nil-UserID member's still-valid reservation (mirrors
+// upsertReservationByUserID's nil handling).
+//
+// Red without the guard: the by-UserID loop deletes BOTH nil-UserID
+// reservations. Green with it: only the leaver's own reservation is deleted.
+func TestReservationDedup_NilUserIDLeaveOnlyClearsOwn(t *testing.T) {
+	m := &EvrMatch{}
+	state := reconnectTestState(evr.ModeSocialPublic)
+
+	partyID := uuid.Must(uuid.NewV4())
+	leaverSid := uuid.Must(uuid.NewV4())
+	otherSid := uuid.Must(uuid.NewV4())
+
+	// Two distinct members, both with a NIL user ID, in the SAME party.
+	leaver := &EvrMatchPresence{
+		Node:          "test-node",
+		UserID:        uuid.Nil,
+		SessionID:     leaverSid,
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "leaver",
+		DisplayName:   "Leaver",
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 1},
+		EntrantID:     uuid.Must(uuid.NewV4()),
+	}
+	other := &EvrMatchPresence{
+		Node:          "test-node",
+		UserID:        uuid.Nil,
+		SessionID:     otherSid,
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "other",
+		DisplayName:   "Other",
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 2},
+		EntrantID:     uuid.Must(uuid.NewV4()),
+	}
+
+	// Both are active presences and both hold reservations keyed by session ID.
+	state.presenceMap[leaverSid.String()] = leaver
+	state.presenceMap[otherSid.String()] = other
+	state.joinTimestamps[leaverSid.String()] = time.Now().Add(-time.Minute)
+	state.joinTimestamps[otherSid.String()] = time.Now().Add(-time.Minute)
+	state.reservationMap[leaverSid.String()] = &slotReservation{Presence: leaver, Expiry: time.Now().Add(5 * time.Minute)}
+	state.reservationMap[otherSid.String()] = &slotReservation{Presence: other, Expiry: time.Now().Add(5 * time.Minute)}
+	state.rebuildCache()
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &reconnectTestDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	// Non-leader voluntary leave (nk is not *RuntimeGoNakamaModule, so the
+	// leadership lookup falls through to the non-leader path).
+	leavePresence := reconnectTestPresence{EvrMatchPresence: leaver, reason: runtime.PresenceReasonLeave}
+
+	got := m.MatchLeave(ctx, reconnectTestLogger(), nil, nk, dispatcher, 1, state, []runtime.Presence{leavePresence})
+	stateAfter, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchLeave returned non-*MatchLabel state: %T", got)
+	}
+
+	// The leaver's own reservation must be gone.
+	if _, ok := stateAfter.reservationMap[leaverSid.String()]; ok {
+		t.Errorf("expected leaver's own reservation (sid %s) to be cleared", leaverSid)
+	}
+	// The OTHER nil-UserID member's reservation must REMAIN.
+	if _, ok := stateAfter.reservationMap[otherSid.String()]; !ok {
+		t.Errorf("other nil-UserID member's reservation (sid %s) was wrongly collapsed by the by-UserID delete", otherSid)
+	}
+	if got := len(stateAfter.reservationMap); got != 1 {
+		t.Errorf("expected exactly 1 reservation remaining (the other member's), got %d", got)
+	}
+}
+
+// TestReservationDedup_NilUserIDCreateNotSkipped pins Fix 2: a member with a
+// NIL user ID whose session ID is NOT already an active presence must get a
+// reservation created, even when some OTHER nil-UserID presence exists. A nil
+// user ID is not a stable identity, so the "alreadyPresent" short-circuit must
+// NOT treat all nil-UserID presences as the same user (mirrors
+// upsertReservationByUserID, which keys nil reservations by session ID).
+//
+// Red without the guard: the by-UserID alreadyPresent check matches the other
+// nil-UserID presence and skips creation (0 reservations). Green with it: the
+// session-ID comparison finds no match and the reservation is created.
+func TestReservationDedup_NilUserIDCreateNotSkipped(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	// An UNRELATED active presence that also lacks a user ID.
+	otherSid := uuid.Must(uuid.NewV4())
+	state.presenceMap[otherSid.String()] = &EvrMatchPresence{
+		UserID:        uuid.Nil,
+		SessionID:     otherSid,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "other",
+		DisplayName:   "Other",
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 9},
+	}
+	state.rebuildCache()
+
+	// A DIFFERENT member, also nil UserID, whose session ID is NOT in presenceMap.
+	newSid := uuid.Must(uuid.NewV4())
+	member := &EvrMatchPresence{
+		UserID:        uuid.Nil,
+		SessionID:     newSid,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "new",
+		DisplayName:   "New",
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 10},
+	}
+	state = signalCreatePartyReservations(t, m, state, member)
+
+	// The reservation must be created, keyed by the member's own session ID.
+	if _, ok := state.reservationMap[newSid.String()]; !ok {
+		t.Errorf("expected a reservation created for nil-UserID member (sid %s); it was wrongly skipped as already-present", newSid)
+	}
+	if got := len(state.reservationMap); got != 1 {
+		t.Errorf("expected exactly 1 reservation, got %d", got)
 	}
 }

--- a/server/evr_reservation_dedup_test.go
+++ b/server/evr_reservation_dedup_test.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// These tests cover the CREATE-side reservation-dedup fix: match slot
+// reservations are keyed by session ID, but an EVR client gets a NEW session ID
+// on every WebSocket reconnect while its user ID (from the auth token) stays
+// stable. Without a UserID-keyed create-side guard, a reconnecting member could
+// acquire a SECOND reservation (under the new session ID) while the original is
+// still un-expired -- a phantom seat that counts toward capacity until it
+// expires. The consume side already falls back to user ID
+// (LoadAndDeleteReservationByUserIDRaw); these tests pin the create side to the
+// same behavior.
+
+// signalCreatePartyReservations drives the real SignalCreatePartyReservations
+// handler (the primary create-dedup site) through MatchSignal, returning the
+// updated state.
+func signalCreatePartyReservations(t *testing.T, m *EvrMatch, state *MatchLabel, members ...*EvrMatchPresence) *MatchLabel {
+	t.Helper()
+	env := NewSignalEnvelope("", SignalCreatePartyReservations, SignalCreatePartyReservationsPayload{Members: members})
+	newState, resp := m.MatchSignal(context.Background(), reconnectTestLogger(), nil, &reconnectTestNakamaModule{}, nil, 1, state, env.String())
+	ns, ok := newState.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchSignal returned non-*MatchLabel state; response=%q", resp)
+	}
+	return ns
+}
+
+func newDedupTestState() *MatchLabel {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.MaxSize = SocialLobbyMaxSize
+	state.PlayerLimit = SocialLobbyMaxSize
+	return state
+}
+
+func reservationsForUser(state *MatchLabel, userID uuid.UUID) []string {
+	sids := make([]string, 0, 1)
+	for sid, r := range state.reservationMap {
+		if r.Presence.UserID == userID {
+			sids = append(sids, sid)
+		}
+	}
+	return sids
+}
+
+// TestReservationDedup_ReconnectDoesNotDoubleCount is RED test A: a member who
+// reconnects (same user ID, new session ID) must end with exactly ONE
+// reservation, not a second phantom one under the new session ID.
+func TestReservationDedup_ReconnectDoesNotDoubleCount(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	userID := uuid.Must(uuid.NewV4())
+	sidA := uuid.Must(uuid.NewV4())
+	sidB := uuid.Must(uuid.NewV4())
+
+	memberA := &EvrMatchPresence{
+		UserID:        userID,
+		SessionID:     sidA,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "M",
+		DisplayName:   "M",
+		EvrID:         evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, memberA)
+
+	if got := len(state.reservationMap); got != 1 {
+		t.Fatalf("setup: expected 1 reservation after first create, got %d", got)
+	}
+
+	// M's client reconnects: a NEW session ID (sidB), SAME user ID. The create
+	// path re-fires for M under sidB.
+	memberB := &EvrMatchPresence{
+		UserID:        userID,
+		SessionID:     sidB,
+		RoleAlignment: evr.TeamSocial,
+		Username:      "M",
+		DisplayName:   "M",
+		EvrID:         evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, memberB)
+
+	// Exactly ONE reservation for M overall (no phantom orphan under sidA).
+	if got := len(state.reservationMap); got != 1 {
+		t.Errorf("expected exactly 1 reservation after reconnect, got %d (phantom seat leak)", got)
+	}
+	if sids := reservationsForUser(state, userID); len(sids) != 1 {
+		t.Errorf("expected exactly 1 reservation for user M, got %d: %v", len(sids), sids)
+	}
+	if _, ok := state.reservationMap[sidB.String()]; !ok {
+		t.Errorf("expected M's reservation to be keyed under the new session ID sidB")
+	}
+	if _, ok := state.reservationMap[sidA.String()]; ok {
+		t.Errorf("stale reservation under old session ID sidA is still present (orphan not reclaimed)")
+	}
+	// ReservationCount must reflect ONE held seat, not two.
+	if state.ReservationCount != 1 {
+		t.Errorf("expected ReservationCount=1 (one held seat), got %d", state.ReservationCount)
+	}
+}
+
+// TestReservationDedup_OpenSlotsCorrectAfterReconnect is RED test B: OpenSlots
+// after the reconnect reservation must equal the value for a single held seat
+// (proving the phantom seat is gone).
+func TestReservationDedup_OpenSlotsCorrectAfterReconnect(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	userID := uuid.Must(uuid.NewV4())
+	sidA := uuid.Must(uuid.NewV4())
+	sidB := uuid.Must(uuid.NewV4())
+
+	base := &EvrMatchPresence{
+		UserID: userID, SessionID: sidA, RoleAlignment: evr.TeamSocial,
+		Username: "M", DisplayName: "M", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, base)
+
+	reconnect := &EvrMatchPresence{
+		UserID: userID, SessionID: sidB, RoleAlignment: evr.TeamSocial,
+		Username: "M", DisplayName: "M", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, reconnect)
+
+	// One held seat: OpenSlots = MaxSize - Size(0) - ReservationCount(1).
+	wantOpen := SocialLobbyMaxSize - 1
+	if got := state.OpenSlots(); got != wantOpen {
+		t.Errorf("expected OpenSlots()=%d (one held seat), got %d (phantom seat still counted)", wantOpen, got)
+	}
+}
+
+// TestReservationDedup_SameMemberReseedKeepsSeat is the restore/re-seed
+// regression: a create re-fire for the SAME member under the SAME session ID
+// (as a legitimate restore/seed would produce) must end with exactly ONE
+// reservation, never zero. Proves the UserID upsert (remove-then-insert) does
+// not eat a legitimate restore of the same member.
+func TestReservationDedup_SameMemberReseedKeepsSeat(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	userID := uuid.Must(uuid.NewV4())
+	sid := uuid.Must(uuid.NewV4())
+
+	member := &EvrMatchPresence{
+		UserID: userID, SessionID: sid, RoleAlignment: evr.TeamSocial,
+		Username: "M", DisplayName: "M", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, member)
+	// Re-seed / restore the same member under the same session ID.
+	reseed := &EvrMatchPresence{
+		UserID: userID, SessionID: sid, RoleAlignment: evr.TeamSocial,
+		Username: "M", DisplayName: "M", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	state = signalCreatePartyReservations(t, m, state, reseed)
+
+	if got := len(reservationsForUser(state, userID)); got != 1 {
+		t.Errorf("expected exactly 1 reservation for re-seeded member M, got %d", got)
+	}
+	if _, ok := state.reservationMap[sid.String()]; !ok {
+		t.Errorf("re-seed lost the seat: no reservation under session ID %s", sid)
+	}
+}
+
+// TestReservationDedup_DistinctMembersUnaffected is the distinct-members
+// regression: reservations for two DIFFERENT users under different session IDs
+// must both remain (proving the UserID dedup does not collapse different
+// members).
+func TestReservationDedup_DistinctMembersUnaffected(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	user1 := uuid.Must(uuid.NewV4())
+	user2 := uuid.Must(uuid.NewV4())
+	sid1 := uuid.Must(uuid.NewV4())
+	sid2 := uuid.Must(uuid.NewV4())
+
+	member1 := &EvrMatchPresence{
+		UserID: user1, SessionID: sid1, RoleAlignment: evr.TeamSocial,
+		Username: "One", DisplayName: "One", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 1},
+	}
+	member2 := &EvrMatchPresence{
+		UserID: user2, SessionID: sid2, RoleAlignment: evr.TeamSocial,
+		Username: "Two", DisplayName: "Two", EvrID: evr.EvrId{PlatformCode: 1, AccountId: 2},
+	}
+	state = signalCreatePartyReservations(t, m, state, member1)
+	state = signalCreatePartyReservations(t, m, state, member2)
+
+	if got := len(state.reservationMap); got != 2 {
+		t.Errorf("expected 2 reservations for 2 distinct members, got %d", got)
+	}
+	if _, ok := state.reservationMap[sid1.String()]; !ok {
+		t.Errorf("member One's reservation was collapsed away")
+	}
+	if _, ok := state.reservationMap[sid2.String()]; !ok {
+		t.Errorf("member Two's reservation was collapsed away")
+	}
+	if state.ReservationCount != 2 {
+		t.Errorf("expected ReservationCount=2 for two distinct members, got %d", state.ReservationCount)
+	}
+}


### PR DESCRIPTION
## Root cause: sessionID-keyed create, UserID-stable identity

Match slot reservations live in `state.reservationMap` keyed by **sessionID**. But an EVR client gets a **new nakama sessionID on every WebSocket reconnect** (`server/socket_ws.go:126` — `sessionID := uuid.Must(sessionIdGen.NewV1())`), while the **UserID** from the auth token is stable.

The **consume** side already handles this: `MatchJoinAttempt` does `LoadAndDeleteReservationRaw(sessionID)` then falls back to `LoadAndDeleteReservationByUserIDRaw(userID)` (`evr_match.go:416-421`), documented in `evr_match_label.go:97-98`. The **create** side had **no UserID guard**.

## The reconnect seat-leak trace

1. Member M reserved under `sidA`.
2. M's client reconnects → new session `sidB`; a create path re-fires for M under `sidB`.
3. Create-dedup checks `reservationMap[sidB]` → MISS (orphan is under `sidA`) → creates a **second** entry.
4. Both count toward capacity: `OpenSlots() = MaxSize - Size - ReservationCount`, and `ReservationCount` counts every non-expired `reservationMap` entry (`rebuildCache`, `evr_match_label.go:407-432`).
5. On M's real join under `sidB`, `LoadAndDeleteReservationRaw(sidB)` consumes `sidB` and returns early — the UserID fallback is never reached — so the `sidA` **orphan is never reclaimed** and holds a phantom seat until its 5-min expiry.

Net effect: a spurious `LobbyFull`/`ReservationViolated` rejection for an unrelated joiner during the window.

## The fix: one shared UserID-keyed upsert helper

New `MatchLabel.upsertReservationByUserID(reservation)` (`evr_match_label.go`) removes any existing `reservationMap` entry for the same UserID (any sessionID), then inserts the new entry under its sessionID — making CREATE symmetric with the UserID-aware consume. Deduped on `EvrMatchPresence.UserID` (the auth-token UUID, stable across reconnects — the exact field the consume path already uses). A nil UserID falls back to sessionID-only keying so identity-less members are never collapsed.

Wired into both create sites:
- **`SignalCreatePartyReservations`** (`evr_match.go`) — now skips members already present **by UserID** and upserts by UserID.
- **`MatchJoinAttempt` placeholder write-in** (`evr_match.go`) — now upserts by UserID (previously a raw sessionID insert with no dedup).
- **Non-leader `MatchLeave` clear** (`evr_match.go`) — now deletes the leaving member's reservation **by UserID**, closing the same orphan blind spot.

## Blast-radius verified safe

- `restoreSlotReservation` and the `MatchInit`/`SignalPrepareSession` seed are **untouched** (raw sessionID inserts). The upsert's remove-then-insert happens in one call, so a same-member restore/re-seed can never net to zero — regression-tested.
- The separate, already-UserID-keyed `reconnectReservations` map is **not touched**.
- Guild isolation untouched: dedup is per-match `reservationMap`; no `GroupID` normalization.
- Both feeder paths (`createPartyReservations`, `createReservationForNewPartyMember`) supply a real auth UserID (`pp.UserID` / `memberSession.userID`).

## Red → green evidence

New `server/evr_reservation_dedup_test.go` drives the real `SignalCreatePartyReservations` handler via `MatchSignal`:

**Against base (RED):**
```
--- FAIL: TestReservationDedup_ReconnectDoesNotDoubleCount
    expected exactly 1 reservation after reconnect, got 2 (phantom seat leak)
    stale reservation under old session ID sidA is still present (orphan not reclaimed)
    expected ReservationCount=1 (one held seat), got 2
--- FAIL: TestReservationDedup_OpenSlotsCorrectAfterReconnect
    expected OpenSlots()=11 (one held seat), got 10 (phantom seat still counted)
```

**After fix (GREEN):**
```
--- PASS: TestReservationDedup_ReconnectDoesNotDoubleCount
--- PASS: TestReservationDedup_OpenSlotsCorrectAfterReconnect
--- PASS: TestReservationDedup_SameMemberReseedKeepsSeat      (restore keeps exactly one seat)
--- PASS: TestReservationDedup_DistinctMembersUnaffected      (two users not collapsed)
```

Checks run: `gofmt -l` clean, `GOWORK=off go vet ./server/...` clean, `GOWORK=off go build ./...` clean, tests with `-race`. The targeted suite (`-run 'Reservation|Capacity|MatchJoin|OpenSlots|Party'`) shows the **identical** pre-existing failure set on this branch and on untouched base (`TestLobbyCapacity_*`, `TestEvrMatch_MatchJoinAttempt_Counts`, `TestGroupEntriesPartyAtomicity/party_exactly_fills_candidate`) — **no new failures** introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)