### PR TITLE
fix: truncate guild name/description for group writes; reconcile orphan guilds before prune-leave

### DIFF
--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -542,7 +542,12 @@ func truncateRuneSafe(s string, maxBytes int) string {
 	return ""
 }
 
-func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, guild *discordgo.Guild) error {
+// guildSync registers (or updates) the Nakama group backing a Discord guild.
+// When the guild owner is globally banned, the sync normally leaves the guild;
+// leaveOnBannedOwner controls that. Reconciliation during pruning passes false
+// so that leaving is deferred to the safety-threshold-checked prune path and
+// no guild is left before the threshold check can run.
+func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, guild *discordgo.Guild, leaveOnBannedOwner bool) error {
 	logger = logger.With(zap.String("guild_id", guild.ID), zap.String("guild_name", guild.Name))
 
 	var err error
@@ -562,8 +567,11 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 
 		ownerUserID, _, _, err = AuthenticateCustom(ctx, logger, d.db, ownerMember.User.ID, ownerMember.User.Username, true)
 		if err != nil {
-			// Leave guilds where the owner is globally banned.
-			if status.Code(err) == codes.PermissionDenied {
+			// Leave guilds where the owner is globally banned. When called
+			// from reconciliation (leaveOnBannedOwner=false), the leave is
+			// deferred: the guild remains an orphan candidate and is left by
+			// the safety-threshold-checked prune path instead.
+			if leaveOnBannedOwner && status.Code(err) == codes.PermissionDenied {
 				logger.Warn("Guild owner is globally banned. Leaving guild.", zap.String("guild_id", guild.ID), zap.String("owner_id", guild.OwnerID))
 				if err := d.dg.GuildLeave(guild.ID); err != nil {
 					return fmt.Errorf("error leaving guild: %w", err)
@@ -580,15 +588,21 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 	}
 
 	if ownerAccount.GetDisableTime() != nil {
-		message := fmt.Sprintf("The owner of the guild `%s` (ID: %s) owned by <@%s> is globally banned. The guild will be removed.", guild.Name, guild.ID, guild.OwnerID)
-		d.LogServiceAuditMessage(ctx, message, false)
+		if leaveOnBannedOwner {
+			message := fmt.Sprintf("The owner of the guild `%s` (ID: %s) owned by <@%s> is globally banned. The guild will be removed.", guild.Name, guild.ID, guild.OwnerID)
+			d.LogServiceAuditMessage(ctx, message, false)
 
-		logger.Warn("Guild owner is globally banned. Leaving guild.", zap.String("guild_id", guild.ID), zap.String("owner_id", guild.OwnerID))
-		if err := d.dg.GuildLeave(guild.ID); err != nil {
-			return fmt.Errorf("error leaving guild: %w", err)
+			logger.Warn("Guild owner is globally banned. Leaving guild.", zap.String("guild_id", guild.ID), zap.String("owner_id", guild.OwnerID))
+			if err := d.dg.GuildLeave(guild.ID); err != nil {
+				return fmt.Errorf("error leaving guild: %w", err)
+			}
+
+			return nil
 		}
-
-		return nil
+		// Reconciliation must not leave guilds: leave decisions belong to the
+		// safety-threshold-checked prune path. Report the failure so the guild
+		// remains an orphan candidate and is left there instead.
+		return fmt.Errorf("guild owner %s is globally banned", guild.OwnerID)
 	}
 
 	// Fit within the groups table's VARCHAR(255) name/description columns;
@@ -655,7 +669,7 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 
 func (d *DiscordIntegrator) handleGuildCreate(logger *zap.Logger, _ *discordgo.Session, e *discordgo.GuildCreate) error {
 	logger.Info("Guild Create", zap.Any("guild", e.Guild.ID))
-	if err := d.guildSync(d.ctx, logger, e.Guild); err != nil {
+	if err := d.guildSync(d.ctx, logger, e.Guild, true); err != nil {
 		return fmt.Errorf("error during guild sync: %w", err)
 	}
 	return nil
@@ -663,7 +677,7 @@ func (d *DiscordIntegrator) handleGuildCreate(logger *zap.Logger, _ *discordgo.S
 
 func (d *DiscordIntegrator) handleGuildUpdate(logger *zap.Logger, _ *discordgo.Session, e *discordgo.GuildUpdate) error {
 	logger.Info("Guild Update", zap.Any("guild", e.Guild.ID))
-	if err := d.guildSync(d.ctx, logger, e.Guild); err != nil {
+	if err := d.guildSync(d.ctx, logger, e.Guild, true); err != nil {
 		return fmt.Errorf("error during guild sync: %w", err)
 	}
 	return nil

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/gofrs/uuid/v5"
@@ -516,6 +517,31 @@ func (c *DiscordIntegrator) GuildMember(guildID, discordID string) (member *disc
 	return member, nil
 }
 
+// maxGroupTextLength is the column size of the groups table's name and
+// description columns (VARCHAR(255), migrate/sql/20180103142001_initial_schema.sql:182-183).
+// Discord guild descriptions can exceed it, which makes GroupCreate/GroupUpdate
+// fail with SQLSTATE 22001 ("value too long for type character varying(255)")
+// and permanently prevents the guild's group from being registered.
+const maxGroupTextLength = 255
+
+// truncateRuneSafe truncates s so its byte length is at most maxBytes without
+// splitting a multi-byte character (Discord descriptions contain emoji). The
+// byte limit is conservative for PostgreSQL VARCHAR(n), which counts characters.
+func truncateRuneSafe(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	if maxBytes <= 0 {
+		return ""
+	}
+	for i := maxBytes; i > 0; i-- {
+		if utf8.RuneStart(s[i]) {
+			return s[:i]
+		}
+	}
+	return ""
+}
+
 func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, guild *discordgo.Guild) error {
 	logger = logger.With(zap.String("guild_id", guild.ID), zap.String("guild_name", guild.Name))
 
@@ -565,6 +591,11 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 		return nil
 	}
 
+	// Fit within the groups table's VARCHAR(255) name/description columns;
+	// oversize values fail with SQLSTATE 22001 and the guild can never register.
+	groupName := truncateRuneSafe(guild.Name, maxGroupTextLength)
+	groupDescription := truncateRuneSafe(guild.Description, maxGroupTextLength)
+
 	groupID = d.GuildIDToGroupID(guild.ID)
 	if groupID == "" {
 		// This is a new guild.
@@ -581,7 +612,7 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 			return fmt.Errorf("error marshalling guild group metadata: %w", err)
 		}
 
-		group, err := d.nk.GroupCreate(ctx, ownerUserID, guild.Name, botUserID, GuildGroupLangTag, guild.Description, guild.IconURL("512"), false, metadataMap, 100000)
+		group, err := d.nk.GroupCreate(ctx, ownerUserID, groupName, botUserID, GuildGroupLangTag, groupDescription, guild.IconURL("512"), false, metadataMap, 100000)
 		if err != nil {
 			return fmt.Errorf("error creating group: %w", err)
 		}
@@ -591,7 +622,7 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 		// Invite the owner to the game service guild.
 	} else {
 		// Update the group data
-		if err := d.nk.GroupUpdate(ctx, groupID, SystemUserID, guild.Name, botUserID, GuildGroupLangTag, guild.Description, guild.IconURL("512"), false, nil, 100000); err != nil {
+		if err := d.nk.GroupUpdate(ctx, groupID, SystemUserID, groupName, botUserID, GuildGroupLangTag, groupDescription, guild.IconURL("512"), false, nil, 100000); err != nil {
 			return fmt.Errorf("error updating group: %w", err)
 		}
 	}

--- a/server/evr_discord_integrator_guildsync_test.go
+++ b/server/evr_discord_integrator_guildsync_test.go
@@ -1,0 +1,86 @@
+package server
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateRuneSafe(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		maxBytes int
+		want     string
+	}{
+		{
+			name:     "empty string",
+			in:       "",
+			maxBytes: 255,
+			want:     "",
+		},
+		{
+			name:     "shorter than limit is unchanged",
+			in:       "Jett's Hangout!",
+			maxBytes: 255,
+			want:     "Jett's Hangout!",
+		},
+		{
+			name:     "exactly at limit is unchanged",
+			in:       strings.Repeat("a", 255),
+			maxBytes: 255,
+			want:     strings.Repeat("a", 255),
+		},
+		{
+			name:     "one over limit is truncated to limit",
+			in:       strings.Repeat("a", 256),
+			maxBytes: 255,
+			want:     strings.Repeat("a", 255),
+		},
+		{
+			name:     "265 chars truncated to 255 (the Jett's Hangout incident shape)",
+			in:       strings.Repeat("a", 265),
+			maxBytes: 255,
+			want:     strings.Repeat("a", 255),
+		},
+		{
+			name:     "emoji straddling the boundary is dropped whole",
+			in:       strings.Repeat("a", 253) + "\U0001F30A", // 253 bytes + 4-byte emoji = 257 bytes
+			maxBytes: 255,
+			want:     strings.Repeat("a", 253),
+		},
+		{
+			name:     "emoji ending exactly at the boundary is kept",
+			in:       strings.Repeat("a", 251) + "\U0001F30A", // 251 bytes + 4-byte emoji = 255 bytes
+			maxBytes: 255,
+			want:     strings.Repeat("a", 251) + "\U0001F30A",
+		},
+		{
+			name:     "all-emoji string truncates on a rune boundary",
+			in:       strings.Repeat("\U0001F30A", 100), // 400 bytes
+			maxBytes: 255,
+			want:     strings.Repeat("\U0001F30A", 63), // 63*4 = 252 bytes
+		},
+		{
+			name:     "zero max yields empty",
+			in:       "abc",
+			maxBytes: 0,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateRuneSafe(tt.in, tt.maxBytes)
+			if got != tt.want {
+				t.Errorf("truncateRuneSafe(%q, %d) = %q, want %q", tt.in, tt.maxBytes, got, tt.want)
+			}
+			if len(got) > tt.maxBytes {
+				t.Errorf("result byte length %d exceeds max %d", len(got), tt.maxBytes)
+			}
+			if !utf8.ValidString(got) {
+				t.Errorf("result is not valid UTF-8: %q", got)
+			}
+		})
+	}
+}

--- a/server/evr_discord_integrator_pruning.go
+++ b/server/evr_discord_integrator_pruning.go
@@ -12,6 +12,34 @@ import (
 
 // pruneSafetyThreshold is the maximum number of orphaned groups or guilds that can be deleted/left before the pruning operation is aborted.
 
+// reconcileOrphanGuilds attempts to repair each orphan guild (bot is a member,
+// but no matching Nakama group exists) by invoking syncFn — the same guildSync
+// that runs on guild join — before the guild is considered for prune-leave.
+// This covers guilds whose sync failed at join time (e.g. an oversize guild
+// description failing GroupCreate with SQLSTATE 22001, as with guild
+// 1522261692355055849), since gateway Guild Create events are not replayed
+// on reconnect.
+// Guilds whose sync attempt fails are returned as the remaining orphan
+// candidates for the leave/safety-threshold logic. Note that syncFn itself may
+// leave a guild whose owner is globally banned; that is existing behavior.
+func reconcileOrphanGuilds(logger runtime.Logger, orphanGuilds []*discordgo.Guild, syncFn func(*discordgo.Guild) error) []*discordgo.Guild {
+	var remaining []*discordgo.Guild
+	for _, guild := range orphanGuilds {
+		fields := map[string]any{
+			"guild_id":   guild.ID,
+			"guild_name": guild.Name,
+		}
+		logger.WithFields(fields).Info("Attempting to reconcile orphan guild via guild sync")
+		if err := syncFn(guild); err != nil {
+			logger.WithFields(fields).WithField("error", err.Error()).Warn("Failed to reconcile orphan guild; it remains an orphan candidate")
+			remaining = append(remaining, guild)
+			continue
+		}
+		logger.WithFields(fields).Info("Reconciled orphan guild, group created")
+	}
+	return remaining
+}
+
 func (d *DiscordIntegrator) pruneGuildGroups(ctx context.Context, logger runtime.Logger, doGuildLeaves, doGroupDeletes bool, pruneSafetyThreshold int) error {
 	var (
 		groupByGuildID = make(map[string]*api.Group)
@@ -72,6 +100,13 @@ func (d *DiscordIntegrator) pruneGuildGroups(ctx context.Context, logger runtime
 			orphanGuilds = append(orphanGuilds, g)
 		}
 	}
+
+	// Try to repair orphan guilds before treating them as prune candidates:
+	// re-run guildSync so a guild whose join-time sync failed gets its group
+	// created instead of the bot leaving a healthy community.
+	orphanGuilds = reconcileOrphanGuilds(logger, orphanGuilds, func(guild *discordgo.Guild) error {
+		return d.guildSync(ctx, d.logger, guild)
+	})
 
 	// Safety check to ensure this is not a mass leave operation
 	if len(orphanGroups) > pruneSafetyThreshold || len(orphanGuilds) > pruneSafetyThreshold {

--- a/server/evr_discord_integrator_pruning.go
+++ b/server/evr_discord_integrator_pruning.go
@@ -20,8 +20,9 @@ import (
 // 1522261692355055849), since gateway Guild Create events are not replayed
 // on reconnect.
 // Guilds whose sync attempt fails are returned as the remaining orphan
-// candidates for the leave/safety-threshold logic. Note that syncFn itself may
-// leave a guild whose owner is globally banned; that is existing behavior.
+// candidates for the leave/safety-threshold logic. syncFn must be
+// non-destructive: it must not leave the guild, so that every guild leave is
+// performed by the caller's safety-checked prune path.
 func reconcileOrphanGuilds(logger runtime.Logger, orphanGuilds []*discordgo.Guild, syncFn func(*discordgo.Guild) error) []*discordgo.Guild {
 	var remaining []*discordgo.Guild
 	for _, guild := range orphanGuilds {
@@ -35,7 +36,7 @@ func reconcileOrphanGuilds(logger runtime.Logger, orphanGuilds []*discordgo.Guil
 			remaining = append(remaining, guild)
 			continue
 		}
-		logger.WithFields(fields).Info("Reconciled orphan guild, group created")
+		logger.WithFields(fields).Info("Orphan guild sync succeeded")
 	}
 	return remaining
 }
@@ -103,9 +104,12 @@ func (d *DiscordIntegrator) pruneGuildGroups(ctx context.Context, logger runtime
 
 	// Try to repair orphan guilds before treating them as prune candidates:
 	// re-run guildSync so a guild whose join-time sync failed gets its group
-	// created instead of the bot leaving a healthy community.
+	// created instead of the bot leaving a healthy community. The sync runs
+	// non-destructively (leaveOnBannedOwner=false): a guild that cannot be
+	// synced (e.g. a globally banned owner) stays an orphan candidate and is
+	// only left by the safety-threshold-checked prune path below.
 	orphanGuilds = reconcileOrphanGuilds(logger, orphanGuilds, func(guild *discordgo.Guild) error {
-		return d.guildSync(ctx, d.logger, guild)
+		return d.guildSync(ctx, d.logger, guild, false)
 	})
 
 	// Safety check to ensure this is not a mass leave operation

--- a/server/evr_discord_integrator_pruning_test.go
+++ b/server/evr_discord_integrator_pruning_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"go.uber.org/zap"
+)
+
+func TestReconcileOrphanGuilds(t *testing.T) {
+	guildA := &discordgo.Guild{ID: "1111", Name: "Guild A"}
+	guildB := &discordgo.Guild{ID: "2222", Name: "Guild B"}
+	guildC := &discordgo.Guild{ID: "3333", Name: "Guild C"}
+
+	tests := []struct {
+		name          string
+		orphans       []*discordgo.Guild
+		failIDs       map[string]bool
+		wantRemaining []string
+	}{
+		{
+			name:          "all syncs succeed leaves no orphan candidates",
+			orphans:       []*discordgo.Guild{guildA, guildB},
+			failIDs:       map[string]bool{},
+			wantRemaining: nil,
+		},
+		{
+			name:          "all syncs fail leaves all orphan candidates",
+			orphans:       []*discordgo.Guild{guildA, guildB},
+			failIDs:       map[string]bool{"1111": true, "2222": true},
+			wantRemaining: []string{"1111", "2222"},
+		},
+		{
+			name:          "only failed syncs remain orphan candidates",
+			orphans:       []*discordgo.Guild{guildA, guildB, guildC},
+			failIDs:       map[string]bool{"2222": true},
+			wantRemaining: []string{"2222"},
+		},
+		{
+			name:          "no orphans means no sync attempts and no candidates",
+			orphans:       nil,
+			failIDs:       map[string]bool{},
+			wantRemaining: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewRuntimeGoLogger(zap.NewNop())
+
+			syncCalls := make(map[string]int)
+			syncFn := func(guild *discordgo.Guild) error {
+				syncCalls[guild.ID]++
+				if tt.failIDs[guild.ID] {
+					return errors.New("sync failed")
+				}
+				return nil
+			}
+
+			remaining := reconcileOrphanGuilds(logger, tt.orphans, syncFn)
+
+			// Every orphan gets exactly one sync attempt.
+			for _, g := range tt.orphans {
+				if syncCalls[g.ID] != 1 {
+					t.Errorf("guild %s: got %d sync attempts, want 1", g.ID, syncCalls[g.ID])
+				}
+			}
+			if len(syncCalls) != len(tt.orphans) {
+				t.Errorf("got sync attempts for %d guilds, want %d", len(syncCalls), len(tt.orphans))
+			}
+
+			var remainingIDs []string
+			for _, g := range remaining {
+				remainingIDs = append(remainingIDs, g.ID)
+			}
+			if len(remainingIDs) != len(tt.wantRemaining) {
+				t.Fatalf("got remaining %v, want %v", remainingIDs, tt.wantRemaining)
+			}
+			for i, id := range tt.wantRemaining {
+				if remainingIDs[i] != id {
+					t.Errorf("remaining[%d] = %s, want %s", i, remainingIDs[i], id)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

A Discord guild whose description exceeds 255 characters can never be registered: `guildSync` passes `guild.Name`/`guild.Description` straight into `GroupCreate`/`GroupUpdate`, and the `groups` table stores both as `VARCHAR(255)` (`migrate/sql/20180103142001_initial_schema.sql:182-183`). The insert fails with SQLSTATE 22001 (`value too long for type character varying(255)`), and since gateway Guild Create events are not replayed on reconnect, there is no retry — the guild stays permanently group-less.

The pruner (`pruneGuildGroups`) then detects exactly this state as an "orphan guild" (bot in guild, no group) every run, and its only remedy is `GuildLeave`. The system detects the broken state and threatens to abandon the community instead of repairing it.

## Fix

1. **Truncate before group writes** (`server/evr_discord_integrator.go`): `guildSync` now rune-safely truncates guild name and description to 255 bytes (`truncateRuneSafe`, conservative for PG's per-character `VARCHAR(255)`; never splits an emoji/multi-byte character) before both `GroupCreate` and `GroupUpdate`.

2. **Reconcile orphan guilds before prune-leave** (`server/evr_discord_integrator_pruning.go`): when the pruner finds orphan guilds, it first re-runs `guildSync` on each (`reconcileOrphanGuilds`); only guilds whose sync attempt fails remain leave candidates for the safety-threshold logic. Each attempt and outcome is logged. Orphan **group** handling (group exists, bot gone) is unchanged, as is `guildSync`'s existing leave-on-globally-banned-owner behavior.

## Evidence (production, 2026-07-06)

- Bot joined "Jett's Hangout!" (`1522261692355055849`, 56 members) on 2026-07-02; no nakama group was ever created.
- Guild owner edited server settings at 19:31 UTC today → GuildUpdate fired 3x → each `guildSync` failed: `server/core_group.go:145 "Error creating group." error: "ERROR: value too long for type character varying(255) (SQLSTATE 22001)"`.
- The guild's description is 265 characters; prod schema confirmed via `information_schema`: `name`/`description` are `varchar(255)`.
- Pruner logged `"Pruning Discord guilds and groups will leave more than 0, skipping to avoid mass leave"` ~80x/day. Only the SafetyLimit of 0 prevented the bot from leaving the healthy guild.
- Exactly 1 "Guild Create" log line since last restart despite the bot being in 110 guilds — join-time sync is one-shot; failures were unrecoverable before this PR.

## Testing

TDD (both tests written first and observed red):

- `TestTruncateRuneSafe` — table test: empty, under/at/over the 255 limit, the incident's 265-char shape, 4-byte emoji straddling and exactly at the boundary, all-emoji string, zero max. Asserts byte length ≤ max and valid UTF-8.
- `TestReconcileOrphanGuilds` — table test: all syncs succeed / all fail / mixed / no orphans; asserts exactly one sync attempt per orphan and that only failed guilds remain leave candidates.

Ran:
- `go test ./server/ -run 'TestTruncateRuneSafe|TestReconcileOrphanGuilds' -count=1` — PASS
- `go vet ./server/` — clean
- Full `go test ./server/ -count=1` — only pre-existing environmental failures (`TestLocalStorageIndex_*`, which require a local CockroachDB at `127.0.0.1:26257`; they fail identically without this change)

Not exercised against live Discord; the truncation path will be validated when the pruner next reconciles guild `1522261692355055849`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
