### PR TITLE
feat: guild-level early-quit enforcement gating

### DIFF
--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -266,16 +266,36 @@ func (s *EarlyQuitPlayerState) IsPenaltyActive() bool {
 }
 
 // earlyQuitEnforcementTestUserIDs is the set of Nakama user IDs for whom
-// server-side early-quit enforcement is active during validation. When
-// guild-level config lands, this gate is replaced by a per-guild setting.
-// Until then, only these users are blocked from matchmaking while under
-// an active early-quit penalty.
+// server-side early-quit enforcement is active during validation. The
+// guild-level EnforceEarlyQuitPenalty setting gates this further: refusal
+// requires the test user AND a guild that has opted in (or is not cached —
+// the lookup is lenient, never requiring guild presence to enforce).
 var earlyQuitEnforcementTestUserIDs = map[string]bool{
 	"580230ee-3866-446f-8f3f-6cc68e3c8621": true, // sprockee / Andrew
 }
 
 func isEarlyQuitEnforcementTestUser(userID string) bool {
 	return earlyQuitEnforcementTestUserIDs[userID]
+}
+
+// earlyQuitEnforcementEnabled reports whether server-side early-quit
+// enforcement is active for the given group (the guild hosting the match, or
+// the player's active group when queueing). Enforcement is enabled unless the
+// guild is present in the session parameters AND its metadata explicitly
+// opted out via EnforceEarlyQuitPenalty. When the guild is not cached (no
+// session parameters, or the group is not in them), enforcement remains
+// enabled — the lookup is lenient and never blocks enforcement on a cache
+// miss. Only a known guild with the flag unset/false disables it.
+func earlyQuitEnforcementEnabled(ctx context.Context, groupID string) bool {
+	params, ok := LoadParams(ctx)
+	if !ok {
+		return true
+	}
+	gg, ok := params.guildGroups[groupID]
+	if !ok {
+		return true
+	}
+	return gg.GetEnforceEarlyQuitPenalty()
 }
 
 func (s *EarlyQuitPlayerState) GetPenaltyLevel() int {

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -280,12 +280,13 @@ func isEarlyQuitEnforcementTestUser(userID string) bool {
 
 // earlyQuitEnforcementEnabled reports whether server-side early-quit
 // enforcement is active for the given group (the guild hosting the match, or
-// the player's active group when queueing). Enforcement is enabled unless the
-// guild is present in the session parameters AND its metadata explicitly
-// opted out via EnforceEarlyQuitPenalty. When the guild is not cached (no
-// session parameters, or the group is not in them), enforcement remains
-// enabled — the lookup is lenient and never blocks enforcement on a cache
-// miss. Only a known guild with the flag unset/false disables it.
+// the player's active group when queueing). Enforcement is opt-in: it is
+// enabled only when the guild is present in the session parameters AND its
+// metadata explicitly opts in via EnforceEarlyQuitPenalty (which defaults to
+// false when unset). When the guild is not cached (no session parameters, or
+// the group is not in them), enforcement remains enabled — the lookup is
+// lenient and never blocks enforcement on a cache miss. Only a known guild
+// with the flag explicitly set true enables it.
 func earlyQuitEnforcementEnabled(ctx context.Context, groupID string) bool {
 	params, ok := LoadParams(ctx)
 	if !ok {

--- a/server/evr_earlyquit_charge_test.go
+++ b/server/evr_earlyquit_charge_test.go
@@ -8,8 +8,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/atomic"
 )
 
 // chargeTestLeaderboardCache is a LeaderboardCache test double whose Get returns
@@ -142,6 +144,119 @@ func TestEarlyQuitChargeGate_SetsPenaltyState(t *testing.T) {
 		t.Errorf("expected lockout ~120s, got %ds", d)
 	}
 }
+
+// TestEarlyQuitChargeGate_GuildEnforcementFlag proves the charge gate is gated
+// by the guild's EnforceEarlyQuitPenalty flag (GroupMetadata). A guild that has
+// not opted in — flag nil (default) or explicitly false — must NOT be charged
+// a penalty for an early quit; an opted-in guild (flag true) must be charged
+// exactly as before.
+func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
+	cases := []struct {
+		name       string
+		enforce    *bool
+		wantQuits  int32
+		wantActive bool
+	}{
+		{"guild-flag-nil", nil, 2, false},
+		{"guild-flag-false", boolPtr(false), 2, false},
+		{"guild-flag-true", boolPtr(true), 3, true},
+	}
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := loggerForTest(t)
+			db := NewDB(t)
+			cfg := NewConfig(logger)
+
+			storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
+			if err != nil {
+				t.Fatalf("failed to create storage index: %v", err)
+			}
+			nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
+				nil, &chargeTestLeaderboardCache{}, nil, nil,
+				&testSessionRegistry{}, nil, nil, nil,
+				&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
+				storageIndex, nil)
+
+			ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+			writeEarlyQuitServiceConfig(t, ctx, nk, defaultEarlyQuitConfigJSON(t))
+
+			// The guild hosting the match, with the enforcement flag under test.
+			guildID := uuid.Must(uuid.NewV4())
+			ctx = withGuildEnforcement(ctx, guildID, tc.enforce)
+
+			// Player with 2 prior early quits (3rd quit crosses into penalty level 1).
+			player := reconnectTestPlayer(fmt.Sprintf("charge-guild-flag-%d", i), evr.TeamBlue)
+			InsertUser(t, db, player.UserID)
+
+			if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
+				Collection:      StorageCollectionEarlyQuit,
+				Key:             StorageKeyEarlyQuit,
+				UserID:          player.GetUserId(),
+				Value:           `{"num_early_quits":2,"num_steady_early_quits":2,"matchmaking_tier":1}`,
+				Version:         "",
+				PermissionRead:  int(runtime.STORAGE_PERMISSION_NO_READ),
+				PermissionWrite: int(runtime.STORAGE_PERMISSION_NO_WRITE),
+			}}); err != nil {
+				t.Fatalf("preseed early quit state failed: %v", err)
+			}
+
+			// Arena-public, pre-matchover match hosted by the guild.
+			state := reconnectTestState(evr.ModeArenaPublic)
+			state.ID.Node = "test-node"
+			state.GroupID = &guildID
+			state.presenceMap[player.GetSessionId()] = player
+			state.presenceByEvrID[player.EvrID] = player
+			state.joinTimestamps[player.GetSessionId()] = time.Now().Add(-2 * time.Minute)
+			state.participations[player.GetUserId()] = &PlayerParticipation{
+				UserID:      player.GetUserId(),
+				Username:    player.Username,
+				DisplayName: player.DisplayName,
+				Team:        BlueTeam,
+				JoinTime:    time.Now().Add(-2 * time.Minute),
+			}
+			state.rebuildCache()
+
+			// Voluntary leave.
+			dispatcher := &reconnectTestDispatcher{}
+			leavePresence := reconnectTestPresence{EvrMatchPresence: player, reason: runtime.PresenceReasonLeave}
+
+			m := &EvrMatch{}
+			if _, ok := m.MatchLeave(ctx, reconnectTestLogger(), db, nk, dispatcher, 1, state, []runtime.Presence{leavePresence}).(*MatchLabel); !ok {
+				t.Fatalf("MatchLeave returned non-*MatchLabel state")
+			}
+
+			// Read back what the charge gate wrote to storage.
+			eqconfig := NewEarlyQuitPlayerState()
+			if err := StorableRead(ctx, nk, player.GetUserId(), eqconfig, false); err != nil {
+				t.Fatalf("failed to read back early quit state: %v", err)
+			}
+
+			if eqconfig.NumEarlyQuits != tc.wantQuits {
+				t.Errorf("expected %d early quits, got %d", tc.wantQuits, eqconfig.NumEarlyQuits)
+			}
+			if got := eqconfig.IsPenaltyActive(); got != tc.wantActive {
+				t.Errorf("expected penalty active=%v, got %v (penalty_level=%d penalty_ts=%d)", tc.wantActive, got, eqconfig.PenaltyLevel, eqconfig.PenaltyTimestamp)
+			}
+		})
+	}
+}
+
+// withGuildEnforcement returns a copy of ctx whose session parameters map the
+// given guild to a GuildGroup carrying the given EnforceEarlyQuitPenalty flag
+// (nil leaves the flag unset — the getter's default). This is how the charge
+// gate learns whether a guild has opted in to server-side enforcement.
+func withGuildEnforcement(ctx context.Context, guildID uuid.UUID, enforce *bool) context.Context {
+	params := &SessionParameters{
+		guildGroups: map[string]*GuildGroup{
+			guildID.String(): {
+				GroupMetadata: GroupMetadata{EnforceEarlyQuitPenalty: enforce},
+			},
+		},
+	}
+	return context.WithValue(ctx, ctxSessionParametersKey{}, atomic.NewPointer(params))
+}
+
+func boolPtr(b bool) *bool { return &b }
 
 // writeEarlyQuitServiceConfig pins the stored EarlyQuit|config row under
 // SystemUserID — the row LoadEarlyQuitServiceConfig reads. Tests that drive the

--- a/server/evr_group_metadata.go
+++ b/server/evr_group_metadata.go
@@ -49,10 +49,11 @@ type GroupMetadata struct {
 
 	RestrictEnforcerNoteVisibility bool `json:"restrict_enforcer_note_visibility"` // Enforcers only see notes on their own records; auditors see all
 
-	KickPlayerAllowPrivates  *bool    `json:"kick_player_allow_privates"` // Default allow_privates for /kick-player suspensions (default: true)
-	LoadoutCommandUsernames  []string `json:"loadout_command_usernames"`  // Discord usernames allowed to use /loadout (legacy, prefer IDs)
-	LoadoutCommandDiscordIDs []string `json:"loadout_command_user_ids"`   // Discord user IDs allowed to use /loadout
-	SuspensionDMFooter       string   `json:"suspension_dm_footer"`       // Custom footer for suspension DM notifications; empty = default footer
+	KickPlayerAllowPrivates  *bool    `json:"kick_player_allow_privates"`           // Default allow_privates for /kick-player suspensions (default: true)
+	EnforceEarlyQuitPenalty  *bool    `json:"enforce_early_quit_penalty,omitempty"` // Enforce early quit penalties (default: false)
+	LoadoutCommandUsernames  []string `json:"loadout_command_usernames"`            // Discord usernames allowed to use /loadout (legacy, prefer IDs)
+	LoadoutCommandDiscordIDs []string `json:"loadout_command_user_ids"`             // Discord user IDs allowed to use /loadout
+	SuspensionDMFooter       string   `json:"suspension_dm_footer"`                 // Custom footer for suspension DM notifications; empty = default footer
 }
 
 func NewGuildGroupMetadata(guildID string) *GroupMetadata {
@@ -94,6 +95,15 @@ func (g *GroupMetadata) GetKickPlayerAllowPrivates() bool {
 		return true
 	}
 	return *g.KickPlayerAllowPrivates
+}
+
+// GetEnforceEarlyQuitPenalty returns whether the guild has opted in to
+// server-side early quit enforcement. Defaults to false when unset.
+func (g *GroupMetadata) GetEnforceEarlyQuitPenalty() bool {
+	if g == nil || g.EnforceEarlyQuitPenalty == nil {
+		return false
+	}
+	return *g.EnforceEarlyQuitPenalty
 }
 
 func (g *GroupMetadata) MarshalMap() map[string]any {

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -308,7 +308,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 			logger.Debug("Failed to load early quit config for logging", zap.Error(err))
 		} else if eqConfig.PenaltyTimestamp > 0 && time.Now().Unix() < eqConfig.PenaltyTimestamp {
 			remainingTime := time.Until(time.Unix(eqConfig.PenaltyTimestamp, 0))
-			if isEarlyQuitEnforcementTestUser(lobbyParams.UserID.String()) {
+			if isEarlyQuitEnforcementTestUser(lobbyParams.UserID.String()) && earlyQuitEnforcementEnabled(ctx, lobbyParams.GroupID.String()) {
 				return NewLobbyErrorf(KickedFromLobbyGroup,
 					"complete matches to reduce your early quit penalty [exp: %s]",
 					FormatDuration(remainingTime))

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -961,121 +961,122 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 						leaveReason = participation.LeaveReason
 					}
 
-					tags["leave_reason"] = string(leaveReason)
-					nk.MetricsCounterAdd("match_entrant_early_quit", tags, 1)
-
-					recordEarlyQuitForPlayer(ctx, logger, nk, state, mp, leaveReason)
-
-					eqconfig := NewEarlyQuitPlayerState()
-					_nk, ok := nk.(*RuntimeGoNakamaModule)
-					if !ok {
-						logger.Warn("nk is not *RuntimeGoNakamaModule, skipping early quit penalty")
-						continue
-					}
-					if err := StorableRead(ctx, nk, mp.GetUserId(), eqconfig, true); err != nil {
-						logger.WithField("error", err).Warn("Failed to load early quitter config")
-					} else {
-
-						// Skip penalty if player is exempt for this guild, or the
-						// guild hosting the match has not opted in to server-side
-						// enforcement (EnforceEarlyQuitPenalty).
-						groupID := state.GetGroupID().String()
-						enforce := earlyQuitEnforcementEnabled(ctx, groupID)
-						if eqconfig.IsExempt(groupID) {
-							logger.WithFields(map[string]any{
-								"uid":      mp.GetUserId(),
-								"group_id": groupID,
-							}).Info("Player exempt from early quit penalty in this guild")
-						} else if !enforce {
-							logger.WithFields(map[string]any{
-								"uid":      mp.GetUserId(),
-								"group_id": groupID,
-							}).Info("Early quit penalty skipped: guild has not opted in to enforcement")
-						} else if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
-							// Differential penalty: only apply immediate penalty for voluntary leaves.
-							eqconfig.IncrementEarlyQuit()
-
-							// Resolve the penalty level from the STORED ladder and set the
-							// lockout expiry so the matchmaker can enforce it. Reading the
-							// stored EarlyQuit|config row (SystemUserID) keeps this path
-							// consistent with the ladder the login/profile path enforces.
-							resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
-						} else {
-							// For disconnects: still record the quit but don't increment penalty.
-							// The logout forgiveness goroutine handles cleanup.
-							logger.WithFields(map[string]any{
-								"uid":          mp.GetUserId(),
-								"leave_reason": leaveReason,
-							}).Info("Disconnect detected — deferring penalty to logout check")
-						}
-						eqconfig.LastEarlyQuitMatchID = state.ID
-
-						// Check for tier change after early quit
-						serviceSettings := ServiceSettings()
-						if serviceSettings == nil {
-							serviceSettings = &ServiceSettingsData{}
-						}
-						oldTier, newTier, tierChanged := eqconfig.UpdateTier(serviceSettings.Matchmaking.EarlyQuitTier1Threshold)
-
+					// Suppress ALL early-quit side effects when the guild hosting
+					// the match has not opted in to server-side enforcement
+					// (EnforceEarlyQuitPenalty): the metric, the leaderboard stat
+					// and quit-history record, the eqconfig mutation/write, and
+					// the notifications/DMs.
+					groupID := state.GetGroupID().String()
+					enforce := earlyQuitEnforcementEnabled(ctx, groupID)
+					if !enforce {
 						logger.WithFields(map[string]any{
-							"old_tier":     oldTier,
-							"new_tier":     newTier,
-							"tier_changed": tierChanged,
-							"eqconfig":     eqconfig,
-						}).Debug("Early quitter tier update.")
+							"uid":      mp.GetUserId(),
+							"group_id": groupID,
+						}).Info("Early quit penalty skipped: guild has not opted in to enforcement")
+					} else {
+						tags["leave_reason"] = string(leaveReason)
+						nk.MetricsCounterAdd("match_entrant_early_quit", tags, 1)
 
-						if err := StorableWrite(ctx, nk, mp.GetUserId(), eqconfig); err != nil {
-							logger.Warn("Failed to write early quitter config", zap.Error(err))
+						recordEarlyQuitForPlayer(ctx, logger, nk, state, mp, leaveReason)
+
+						eqconfig := NewEarlyQuitPlayerState()
+						_nk, ok := nk.(*RuntimeGoNakamaModule)
+						if !ok {
+							logger.Warn("nk is not *RuntimeGoNakamaModule, skipping early quit penalty")
+							continue
+						}
+						if err := StorableRead(ctx, nk, mp.GetUserId(), eqconfig, true); err != nil {
+							logger.WithField("error", err).Warn("Failed to load early quitter config")
 						} else {
-							if s := _nk.sessionRegistry.Get(uuid.FromStringOrNil(mp.GetSessionId())); s != nil {
-								if params, ok := LoadParams(s.Context()); ok {
-									params.earlyQuitConfig.Store(eqconfig)
-								}
+
+							// Skip penalty if player is exempt for this guild.
+							if eqconfig.IsExempt(groupID) {
+								logger.WithFields(map[string]any{
+									"uid":      mp.GetUserId(),
+									"group_id": groupID,
+								}).Info("Player exempt from early quit penalty in this guild")
+							} else if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+								// Differential penalty: only apply immediate penalty for voluntary leaves.
+								eqconfig.IncrementEarlyQuit()
+
+								// Resolve the penalty level from the STORED ladder and set the
+								// lockout expiry so the matchmaker can enforce it. Reading the
+								// stored EarlyQuit|config row (SystemUserID) keeps this path
+								// consistent with the ladder the login/profile path enforces.
+								resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
+							} else {
+								// For disconnects: still record the quit but don't increment penalty.
+								// The logout forgiveness goroutine handles cleanup.
+								logger.WithFields(map[string]any{
+									"uid":          mp.GetUserId(),
+									"leave_reason": leaveReason,
+								}).Info("Disconnect detected — deferring penalty to logout check")
 							}
+							eqconfig.LastEarlyQuitMatchID = state.ID
 
-							// Send early quit penalty notification to player (unless penalty system is disabled or silent mode)
-							if serviceSettings.Matchmaking.EnableEarlyQuitPenalty && !serviceSettings.Matchmaking.SilentEarlyQuitSystem {
-								if messageTrigger := globalEarlyQuitMessageTrigger.Load(); messageTrigger != nil {
-									messageTrigger.SendEarlyQuitUpdateNotification(ctx, mp.GetUserId(), eqconfig)
-
-									// Trigger auto-report at penalty level 3
-									penaltyLevel := int32(eqconfig.PenaltyLevel)
-									if penaltyLevel > MaxEarlyQuitPenaltyLevel {
-										penaltyLevel = int32(MaxEarlyQuitPenaltyLevel)
-									}
-									if penaltyLevel >= 3 {
-										if evr.DefaultEarlyQuitFeatureFlags()&evr.EarlyQuitFlagAutoReport != 0 {
-											TriggerAutoReport(ctx, logger, mp.GetUserId(), penaltyLevel)
-										}
-									}
-								}
-
-								// Send Discord DM if tier changed
-								if tierChanged {
-									discordID, err := GetDiscordIDByUserID(ctx, db, mp.GetUserId())
-									if err != nil {
-										logger.Warn("Failed to get Discord ID for tier notification", zap.Error(err))
-									} else if appBot := globalAppBot.Load(); appBot != nil && appBot.dg != nil {
-										var message string
-										if oldTier > newTier {
-											// Degraded to Tier 2+
-											message = TierDegradedMessage
-										} else {
-											// Recovered to Tier 1
-											message = TierRestoredMessage
-										}
-										if _, err := SendUserMessage(ctx, appBot.dg, discordID, message); err != nil {
-											logger.Warn("Failed to send tier change DM", zap.Error(err))
-										}
-									}
-								}
+							// Check for tier change after early quit
+							serviceSettings := ServiceSettings()
+							if serviceSettings == nil {
+								serviceSettings = &ServiceSettingsData{}
 							}
+							oldTier, newTier, tierChanged := eqconfig.UpdateTier(serviceSettings.Matchmaking.EarlyQuitTier1Threshold)
 
-							// Launch goroutine for deferred penalty resolution.
-							// Use background context to ensure goroutine isn't cancelled when match ends.
-							// Only when the guild opted in: a skipped charge must not be
-							// retroactively applied (or forgiven) by the goroutines.
-							if enforce {
+							logger.WithFields(map[string]any{
+								"old_tier":     oldTier,
+								"new_tier":     newTier,
+								"tier_changed": tierChanged,
+								"eqconfig":     eqconfig,
+							}).Debug("Early quitter tier update.")
+
+							if err := StorableWrite(ctx, nk, mp.GetUserId(), eqconfig); err != nil {
+								logger.Warn("Failed to write early quitter config", zap.Error(err))
+							} else {
+								if s := _nk.sessionRegistry.Get(uuid.FromStringOrNil(mp.GetSessionId())); s != nil {
+									if params, ok := LoadParams(s.Context()); ok {
+										params.earlyQuitConfig.Store(eqconfig)
+									}
+								}
+
+								// Send early quit penalty notification to player (unless penalty system is disabled or silent mode)
+								if serviceSettings.Matchmaking.EnableEarlyQuitPenalty && !serviceSettings.Matchmaking.SilentEarlyQuitSystem {
+									if messageTrigger := globalEarlyQuitMessageTrigger.Load(); messageTrigger != nil {
+										messageTrigger.SendEarlyQuitUpdateNotification(ctx, mp.GetUserId(), eqconfig)
+
+										// Trigger auto-report at penalty level 3
+										penaltyLevel := int32(eqconfig.PenaltyLevel)
+										if penaltyLevel > MaxEarlyQuitPenaltyLevel {
+											penaltyLevel = int32(MaxEarlyQuitPenaltyLevel)
+										}
+										if penaltyLevel >= 3 {
+											if evr.DefaultEarlyQuitFeatureFlags()&evr.EarlyQuitFlagAutoReport != 0 {
+												TriggerAutoReport(ctx, logger, mp.GetUserId(), penaltyLevel)
+											}
+										}
+									}
+
+									// Send Discord DM if tier changed
+									if tierChanged {
+										discordID, err := GetDiscordIDByUserID(ctx, db, mp.GetUserId())
+										if err != nil {
+											logger.Warn("Failed to get Discord ID for tier notification", zap.Error(err))
+										} else if appBot := globalAppBot.Load(); appBot != nil && appBot.dg != nil {
+											var message string
+											if oldTier > newTier {
+												// Degraded to Tier 2+
+												message = TierDegradedMessage
+											} else {
+												// Recovered to Tier 1
+												message = TierRestoredMessage
+											}
+											if _, err := SendUserMessage(ctx, appBot.dg, discordID, message); err != nil {
+												logger.Warn("Failed to send tier change DM", zap.Error(err))
+											}
+										}
+									}
+								}
+
+								// Launch goroutine for deferred penalty resolution.
+								// Use background context to ensure goroutine isn't cancelled when match ends.
 								if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
 									// Voluntary leave: penalty applied immediately. If player logs out
 									// within 5 minutes, forgive the penalty (crash during quit flow).
@@ -1358,27 +1359,30 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 					participation.LeaveReason = LeaveReasonReservationExp
 				}
 
-				eqconfig := NewEarlyQuitPlayerState()
-				if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
-					logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")
-				} else {
-					// Charge only when the guild hosting the match opted in to
-					// server-side enforcement (EnforceEarlyQuitPenalty).
-					if earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
+				// Charge only when the guild hosting the match opted in to
+				// server-side enforcement (EnforceEarlyQuitPenalty). When
+				// enforcement is disabled, suppress ALL side effects: the
+				// eqconfig mutation/write and the leaderboard/quit-history
+				// record.
+				if earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
+					eqconfig := NewEarlyQuitPlayerState()
+					if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
+						logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")
+					} else {
 						eqconfig.IncrementEarlyQuit()
 						resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
+						eqconfig.LastEarlyQuitMatchID = state.ID
+						if err := StorableWrite(ctx, nk, rr.UserID, eqconfig); err != nil {
+							logger.WithField("error", err).Warn("Failed to write early quitter config for deferred penalty")
+						}
 					}
-					eqconfig.LastEarlyQuitMatchID = state.ID
-					if err := StorableWrite(ctx, nk, rr.UserID, eqconfig); err != nil {
-						logger.WithField("error", err).Warn("Failed to write early quitter config for deferred penalty")
-					}
-				}
 
-				// A deferred penalty must produce the same side effects as the
-				// immediate charge path in MatchLeave: the increment log line,
-				// the leaderboard stat, and the quit-history record.
-				if rr.Presence != nil {
-					recordEarlyQuitForPlayer(ctx, logger, nk, state, rr.Presence, LeaveReasonReservationExp)
+					// A deferred penalty must produce the same side effects as the
+					// immediate charge path in MatchLeave: the increment log line,
+					// the leaderboard stat, and the quit-history record.
+					if rr.Presence != nil {
+						recordEarlyQuitForPlayer(ctx, logger, nk, state, rr.Presence, LeaveReasonReservationExp)
+					}
 				}
 			}
 		}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -289,7 +289,7 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 			logger.Debug("Failed to load early quit config for logging", zap.Error(err))
 			} else if eqConfig.PenaltyLevel > 0 && eqConfig.PenaltyTimestamp > 0 && time.Now().Unix() < eqConfig.PenaltyTimestamp {
 				remainingTime := time.Until(time.Unix(eqConfig.PenaltyTimestamp, 0))
-				if isEarlyQuitEnforcementTestUser(joinPresence.GetUserId()) {
+				if isEarlyQuitEnforcementTestUser(joinPresence.GetUserId()) && earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
 					return state, false, fmt.Sprintf("early quit penalty active [exp: %s]", FormatDuration(remainingTime))
 				}
 				logger.Info("Player joining with active early quit penalty (client-side enforcement expected)",
@@ -976,13 +976,21 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 						logger.WithField("error", err).Warn("Failed to load early quitter config")
 					} else {
 
-						// Skip penalty if player is exempt for this guild.
+						// Skip penalty if player is exempt for this guild, or the
+						// guild hosting the match has not opted in to server-side
+						// enforcement (EnforceEarlyQuitPenalty).
 						groupID := state.GetGroupID().String()
+						enforce := earlyQuitEnforcementEnabled(ctx, groupID)
 						if eqconfig.IsExempt(groupID) {
 							logger.WithFields(map[string]any{
 								"uid":      mp.GetUserId(),
 								"group_id": groupID,
 							}).Info("Player exempt from early quit penalty in this guild")
+						} else if !enforce {
+							logger.WithFields(map[string]any{
+								"uid":      mp.GetUserId(),
+								"group_id": groupID,
+							}).Info("Early quit penalty skipped: guild has not opted in to enforcement")
 						} else if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
 							// Differential penalty: only apply immediate penalty for voluntary leaves.
 							eqconfig.IncrementEarlyQuit()
@@ -1065,20 +1073,24 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 
 							// Launch goroutine for deferred penalty resolution.
 							// Use background context to ensure goroutine isn't cancelled when match ends.
-							if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
-								// Voluntary leave: penalty applied immediately. If player logs out
-								// within 5 minutes, forgive the penalty (crash during quit flow).
-								go func(userID, sessionID string) {
-									bgCtx := context.Background()
-									CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, 5*time.Minute)
-								}(mp.GetUserId(), mp.GetSessionId())
-							} else {
-								// Disconnect: penalty deferred. If player is still online after
-								// 5 minutes, they force-closed intentionally — apply the penalty.
-								go func(userID, sessionID string, matchID MatchID) {
-									bgCtx := context.Background()
-									CheckAndApplyEarlyQuitIfStillOnline(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, matchID, 5*time.Minute)
-								}(mp.GetUserId(), mp.GetSessionId(), state.ID)
+							// Only when the guild opted in: a skipped charge must not be
+							// retroactively applied (or forgiven) by the goroutines.
+							if enforce {
+								if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+									// Voluntary leave: penalty applied immediately. If player logs out
+									// within 5 minutes, forgive the penalty (crash during quit flow).
+									go func(userID, sessionID string) {
+										bgCtx := context.Background()
+										CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, 5*time.Minute)
+									}(mp.GetUserId(), mp.GetSessionId())
+								} else {
+									// Disconnect: penalty deferred. If player is still online after
+									// 5 minutes, they force-closed intentionally — apply the penalty.
+									go func(userID, sessionID string, matchID MatchID) {
+										bgCtx := context.Background()
+										CheckAndApplyEarlyQuitIfStillOnline(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, matchID, 5*time.Minute)
+									}(mp.GetUserId(), mp.GetSessionId(), state.ID)
+								}
 							}
 						}
 					}
@@ -1350,8 +1362,12 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
 					logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")
 				} else {
-					eqconfig.IncrementEarlyQuit()
-					resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
+					// Charge only when the guild hosting the match opted in to
+					// server-side enforcement (EnforceEarlyQuitPenalty).
+					if earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
+						eqconfig.IncrementEarlyQuit()
+						resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
+					}
 					eqconfig.LastEarlyQuitMatchID = state.ID
 					if err := StorableWrite(ctx, nk, rr.UserID, eqconfig); err != nil {
 						logger.WithField("error", err).Warn("Failed to write early quitter config for deferred penalty")


### PR DESCRIPTION
## What

Adds `EnforceEarlyQuitPenalty` to `GroupMetadata` (default **false** — no guild is enforced until it opts in) and gates every server-side early-quit charge and refusal site on it.

## Changes

- **`server/evr_group_metadata.go`** — new `EnforceEarlyQuitPenalty *bool` field (`enforce_early_quit_penalty,omitempty`) + `GetEnforceEarlyQuitPenalty()` getter (nil → false).
- **`server/evr_match.go` `MatchLeave`** — the charge gate skips `IncrementEarlyQuit` + `resolveAndApplyPenaltyLockout` when the guild hosting the match has not opted in. The deferred-resolution goroutines (`CheckAndStrikeEarlyQuitIfLoggedOut` / `CheckAndApplyEarlyQuitIfStillOnline`) are only spawned when enforced, so a skipped charge is never retroactively applied or forgiven.
- **`server/evr_match.go` `MatchLoop`** — the reconnect-reservation expiry charge site is gated the same way.
- **`server/evr_lobby_find.go` / `server/evr_match.go`** — the test-user enforcement refusal (`isEarlyQuitEnforcementTestUser`) now also requires the guild to be opted in. The lookup is lenient: a guild that is not cached never blocks enforcement — only a known guild with the flag unset/false disables it.
- **`server/evr_earlyquit.go`** — `earlyQuitEnforcementEnabled(ctx, groupID)` helper.

## Tests (red → green)

`TestEarlyQuitChargeGate_GuildEnforcementFlag` in `server/evr_earlyquit_charge_test.go` drives the real `MatchLeave` charge gate:
- guild flag `nil` → quit → penalty **not** charged
- guild flag `false` → quit → penalty **not** charged
- guild flag `true` → quit → penalty **is** charged (3rd quit → level 1, 120s lockout)

Test command: `GOWORK=off TEST_DB_URL=... go test ./server/ -run 'TestGuild|TestEarlyQuit' -count=1` — 38/38 pass. `go build ./server/... && go vet ./server/` clean.

Note: `MatchLeave`/`MatchJoinAttempt` run on the match context, which today carries no session parameters, so the charge gate reads the guild from `LoadParams(ctx)` — the flag takes full effect at those sites once session params flow into the match context (the lobby-find refusal site already resolves the player's active guild). Until then, un-cached guilds default to enforcement, preserving current behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)