### PR TITLE
fix(evr): stop cosmetic equips from being lost on profile write conflicts

### DIFF
--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -461,6 +461,27 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 	return fmt.Errorf("failed to write profile storage: %w", lastErr)
 }
 
+// this is EVRProfileUpdate, but on a version conflict it re-reads the fresh profile and calls reapply (must be idempotent)
+// to reapply the caller's mutation before retrying
+func EVRProfileUpdateWithRetry(ctx context.Context, nk runtime.NakamaModule, userID string, md *EVRProfile, reapply func() error) error {
+	if userID == SystemUserID {
+		return fmt.Errorf("cannot set metadata for system user")
+	}
+	if md == nil {
+		return fmt.Errorf("profile cannot be nil")
+	}
+
+	if err := StorableWriteWithRetry(ctx, nk, userID, md, reapply); err != nil {
+		return fmt.Errorf("failed to write profile storage: %w", err)
+	}
+
+	// Invalidate any cached ServerProfile so it will be regenerated with the updated data
+	_ = ServerProfileInvalidate(ctx, nk, userID)
+
+	// Also update the account metadata to keep it in sync
+	return nk.AccountUpdateId(ctx, userID, "", md.MarshalMap(), "", "", "", "", "")
+}
+
 func BuildEVRProfileFromAccount(account *api.Account) (*EVRProfile, error) {
 	if account == nil || account.User == nil {
 		return nil, fmt.Errorf("account is nil")

--- a/server/evr_discord_loadout.go
+++ b/server/evr_discord_loadout.go
@@ -403,8 +403,14 @@ func (d *DiscordAppBot) handleLoadoutCommand(ctx context.Context, s *discordgo.S
 			return editInteractionResponse(s, i, fmt.Sprintf("Loadout `%s` does not exist.", name))
 		}
 
-		profile.LoadoutCosmetics = *outfit
-		if err := EVRProfileUpdate(ctx, d.nk, userID, profile); err != nil {
+		applyOutfit := func() error {
+			profile.LoadoutCosmetics = *outfit
+			return nil
+		}
+		if err := applyOutfit(); err != nil {
+			return fmt.Errorf("failed to apply loadout: %w", err)
+		}
+		if err := EVRProfileUpdateWithRetry(ctx, d.nk, userID, profile, applyOutfit); err != nil {
 			return fmt.Errorf("failed to apply loadout: %w", err)
 		}
 		return editInteractionResponse(s, i, fmt.Sprintf("Applied loadout `%s`.", name))
@@ -474,8 +480,14 @@ func (d *DiscordAppBot) handleLoadoutCommand(ctx context.Context, s *discordgo.S
 			return editInteractionResponse(s, i, "That VRML cosmetic is not entitled for your account.")
 		}
 
-		applyLoadoutSlot(&profile.LoadoutCosmetics.Loadout, slot, value)
-		if err := EVRProfileUpdate(ctx, d.nk, userID, profile); err != nil {
+		applySlot := func() error {
+			applyLoadoutSlot(&profile.LoadoutCosmetics.Loadout, slot, value)
+			return nil
+		}
+		if err := applySlot(); err != nil {
+			return fmt.Errorf("failed to set loadout slot: %w", err)
+		}
+		if err := EVRProfileUpdateWithRetry(ctx, d.nk, userID, profile, applySlot); err != nil {
 			return fmt.Errorf("failed to set loadout slot: %w", err)
 		}
 

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -77,114 +77,113 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		return fmt.Errorf("failed to load EVR profile: %w", err)
 	}
 
-	// Convert the hash-based items to CosmeticLoadout fields
-	loadout := profile.LoadoutCosmetics.Loadout
+	// applyPayload maps the hash-based slot/item pairs onto profile.LoadoutCosmetics
+	// and rejects any cosmetic the player doesn't own (COSMETIC-1)
+	applyPayload := func() error {
+		loadout := profile.LoadoutCosmetics.Loadout
 
-	// Process each loadout instance
-	for _, instance := range payload.LoadoutInstances {
-		for slotHex, equippedHex := range instance.Items {
-			slotSymbol := evr.ToSymbol(slotHex)
-			if slotSymbol == 0 {
-				logger.Warn("Failed to parse slot hash", zap.String("slot", slotHex))
-				continue
-			}
-			equippedSymbol := evr.ToSymbol(equippedHex)
-			if equippedSymbol == 0 {
-				logger.Warn("Failed to parse equipped hash", zap.String("equipped", equippedHex))
-				continue
-			}
+		// Process each loadout instance
+		for _, instance := range payload.LoadoutInstances {
+			for slotHex, equippedHex := range instance.Items {
+				slotSymbol := evr.ToSymbol(slotHex)
+				if slotSymbol == 0 {
+					logger.Warn("Failed to parse slot hash", zap.String("slot", slotHex))
+					continue
+				}
+				equippedSymbol := evr.ToSymbol(equippedHex)
+				if equippedSymbol == 0 {
+					logger.Warn("Failed to parse equipped hash", zap.String("equipped", equippedHex))
+					continue
+				}
 
-			// Convert symbols to their string names
-			slotName := slotSymbol.String()
-			equippedName := equippedSymbol.String()
+				// Convert symbols to their string names
+				slotName := slotSymbol.String()
+				equippedName := equippedSymbol.String()
 
-			logger.Debug("Processing loadout item",
-				zap.String("slot_hash", slotHex),
-				zap.String("slot_name", slotName),
-				zap.String("equipped_hash", equippedHex),
-				zap.String("equipped_name", equippedName))
+				logger.Debug("Processing loadout item",
+					zap.String("slot_hash", slotHex),
+					zap.String("slot_name", slotName),
+					zap.String("equipped_hash", equippedHex),
+					zap.String("equipped_name", equippedName))
 
-			// Map slot names to CosmeticLoadout fields
-			switch slotName {
-			case "banner":
-				loadout.Banner = equippedName
-			case "booster":
-				loadout.Booster = equippedName
-			case "bracer":
-				loadout.Bracer = equippedName
-			case "chassis":
-				loadout.Chassis = equippedName
-			case "decal":
-				loadout.Decal = equippedName
-			case "decal_body":
-				loadout.DecalBody = equippedName
-			case "decalborder":
-				loadout.DecalBorder = equippedName
-			case "decalback":
-				loadout.DecalBack = equippedName
-			case "emissive":
-				loadout.Emissive = equippedName
-			case "emote":
-				loadout.Emote = equippedName
-			case "goal_fx":
-				loadout.GoalFX = equippedName
-			case "medal":
-				loadout.Medal = equippedName
-			case "pattern":
-				loadout.Pattern = equippedName
-			case "pattern_body":
-				loadout.PatternBody = equippedName
-			case "pip":
-				loadout.PIP = equippedName
-			case "secondemote":
-				loadout.SecondEmote = equippedName
-			case "tag":
-				loadout.Tag = equippedName
-			case "tint":
-				loadout.Tint = equippedName
-			case "tint_alignment_a":
-				loadout.TintAlignmentA = equippedName
-			case "tint_alignment_b":
-				loadout.TintAlignmentB = equippedName
-			case "tint_body":
-				loadout.TintBody = equippedName
-			case "title":
-				loadout.Title = equippedName
-			default:
-				logger.Debug("Unknown slot type", zap.String("slot", slotName))
+				// Map slot names to CosmeticLoadout fields
+				switch slotName {
+				case "banner":
+					loadout.Banner = equippedName
+				case "booster":
+					loadout.Booster = equippedName
+				case "bracer":
+					loadout.Bracer = equippedName
+				case "chassis":
+					loadout.Chassis = equippedName
+				case "decal":
+					loadout.Decal = equippedName
+				case "decal_body":
+					loadout.DecalBody = equippedName
+				case "decalborder":
+					loadout.DecalBorder = equippedName
+				case "decalback":
+					loadout.DecalBack = equippedName
+				case "emissive":
+					loadout.Emissive = equippedName
+				case "emote":
+					loadout.Emote = equippedName
+				case "goal_fx":
+					loadout.GoalFX = equippedName
+				case "medal":
+					loadout.Medal = equippedName
+				case "pattern":
+					loadout.Pattern = equippedName
+				case "pattern_body":
+					loadout.PatternBody = equippedName
+				case "pip":
+					loadout.PIP = equippedName
+				case "secondemote":
+					loadout.SecondEmote = equippedName
+				case "tag":
+					loadout.Tag = equippedName
+				case "tint":
+					loadout.Tint = equippedName
+				case "tint_alignment_a":
+					loadout.TintAlignmentA = equippedName
+				case "tint_alignment_b":
+					loadout.TintAlignmentB = equippedName
+				case "tint_body":
+					loadout.TintBody = equippedName
+				case "title":
+					loadout.Title = equippedName
+				default:
+					logger.Debug("Unknown slot type", zap.String("slot", slotName))
+				}
 			}
 		}
+
+		sanitized, err := sanitizeGameServerLoadout(loadout, profile)
+		if err != nil {
+			return fmt.Errorf("failed to compute owned cosmetics: %w", err)
+		}
+		profile.LoadoutCosmetics.Loadout = sanitized
+
+		// Update jersey number if present
+		if payload.Number >= 0 {
+			profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
+		}
+
+		return nil
 	}
 
-	// Update profile with new loadout, rejecting any cosmetic the player does not own
-	// (COSMETIC-1). This handler is the *sole* persistence path for game servers with
-	// NativeSupport: evr_runtime_event_remotelogset.go's equip handler explicitly skips
-	// itself for NativeSupport matches ("NEVR (non-legacy) servers already persist
-	// loadout equips themselves"), so the ownership fix applied there does not run for
-	// those servers at all. Without this check, a NativeSupport-hosted character
-	// customization equip would persist an unowned cosmetic (e.g. a VRML finalist tag)
-	// exactly like the original remotelogset bug.
-	sanitized, err := sanitizeGameServerLoadout(loadout, profile)
-	if err != nil {
-		return fmt.Errorf("failed to compute owned cosmetics: %w", err)
-	}
-	profile.LoadoutCosmetics.Loadout = sanitized
-
-	// Update jersey number if present
-	if payload.Number >= 0 {
-		profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
-		logger.Info("Updated jersey number", zap.Int("number", payload.Number))
+	if err := applyPayload(); err != nil {
+		return err
 	}
 
-	// Save the updated profile
-	if err := EVRProfileUpdate(ctx, p.nk, userID, profile); err != nil {
+	if err := EVRProfileUpdateWithRetry(ctx, p.nk, userID, profile, applyPayload); err != nil {
 		return fmt.Errorf("failed to store EVR profile: %w", err)
 	}
 
 	logger.Info("Successfully saved loadout update",
 		zap.String("user_id", userID),
 		zap.String("evr_id", request.EvrID.String()),
-		zap.Any("loadout", loadout))
+		zap.Any("loadout", profile.LoadoutCosmetics.Loadout))
 
 	return nil
 }

--- a/server/evr_profile_update_retry_test.go
+++ b/server/evr_profile_update_retry_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// JSON-encodes profile and seeds it as the current stored EVRProfile object
+func seedEVRProfile(t *testing.T, nk *occTestNakamaModule, userID string, profile *EVRProfile) {
+	t.Helper()
+	data, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatalf("marshal seed profile: %v", err)
+	}
+	nk.seedObject(userID, StorageCollectionEVRProfile, StorageKeyEVRProfile, string(data))
+}
+
+// stubs the extra NakamaModule methods
+// EVRProfileUpdate(WithRetry) needs beyond StorageRead/Write
+type failOnceAccountUpdateNoopNakamaModule struct {
+	*failOnceNakamaModule
+}
+
+func (m *failOnceAccountUpdateNoopNakamaModule) AccountUpdateId(ctx context.Context, userID, username string, metadata map[string]interface{}, displayName, timezone, location, langTag, avatarUrl string) error {
+	return nil
+}
+
+func (m *failOnceAccountUpdateNoopNakamaModule) StorageDelete(ctx context.Context, deletes []*runtime.StorageDelete) error {
+	return nil
+}
+
+func (m *failOnceAccountUpdateNoopNakamaModule) AccountGetId(ctx context.Context, userID string) (*api.Account, error) {
+	return &api.Account{User: &api.User{Id: userID}}, nil
+}
+
+// pins down EVRProfileUpdate's behavior, it drops the caller's mutation on conflict but still reports success
+func TestEVRProfileUpdate_LosesMutationOnVersionConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	base := newOCCTestNakamaModule()
+
+	// Concurrent writer already advanced the stored profile
+	winner := &EVRProfile{}
+	winner.TeamName = "concurrent-writer-value"
+	seedEVRProfile(t, base, occTestUserID, winner)
+
+	failing := &failOnceAccountUpdateNoopNakamaModule{&failOnceNakamaModule{occTestNakamaModule: base}}
+
+	// Caller holds a stale copy and equips a cosmetic
+	profile := &EVRProfile{}
+	profile.LoadoutCosmetics.Loadout.Tag = "rwd_tag_s1_a_secondary"
+
+	if err := EVRProfileUpdate(ctx, failing, occTestUserID, profile); err != nil {
+		t.Fatalf("EVRProfileUpdate: %v", err)
+	}
+
+	final := &EVRProfile{}
+	if err := StorableRead(ctx, failing, occTestUserID, final, false); err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if final.LoadoutCosmetics.Loadout.Tag == "rwd_tag_s1_a_secondary" {
+		t.Fatal("expected EVRProfileUpdate to drop the equip on conflict; it persisted instead — this test's premise is stale")
+	}
+}
+
+// this is the regression test for the fix, the same conflict must not lose the equip, and must still pick up the concurrent writer's own change
+func TestEVRProfileUpdateWithRetry_PreservesCosmeticEquipOnConflict(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	base := newOCCTestNakamaModule()
+
+	winner := &EVRProfile{}
+	winner.TeamName = "concurrent-writer-value"
+	seedEVRProfile(t, base, occTestUserID, winner)
+
+	failing := &failOnceAccountUpdateNoopNakamaModule{&failOnceNakamaModule{occTestNakamaModule: base}}
+
+	profile := &EVRProfile{}
+	const equippedTag = "rwd_tag_s1_a_secondary"
+	reapply := func() error {
+		profile.LoadoutCosmetics.Loadout.Tag = equippedTag
+		return nil
+	}
+	if err := reapply(); err != nil {
+		t.Fatalf("reapply: %v", err)
+	}
+
+	if err := EVRProfileUpdateWithRetry(ctx, failing, occTestUserID, profile, reapply); err != nil {
+		t.Fatalf("EVRProfileUpdateWithRetry: %v", err)
+	}
+
+	final := &EVRProfile{}
+	if err := StorableRead(ctx, failing, occTestUserID, final, false); err != nil {
+		t.Fatalf("final read: %v", err)
+	}
+	if final.LoadoutCosmetics.Loadout.Tag != equippedTag {
+		t.Errorf("cosmetic equip was lost on version conflict: got tag %q, want %q", final.LoadoutCosmetics.Loadout.Tag, equippedTag)
+	}
+	if final.TeamName != "concurrent-writer-value" {
+		t.Errorf("concurrent writer's change was clobbered: got TeamName %q, want %q", final.TeamName, "concurrent-writer-value")
+	}
+}

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -334,11 +334,19 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				logger.WithField("error", err).Warn("Failed to compute owned cosmetics")
 				continue
 			}
-			if profile.LoadoutCosmetics.Loadout, err = EquipAndSanitize(profile.LoadoutCosmetics.Loadout, category, name, owned); err != nil {
+			applyEquip := func() error {
+				updated, err := EquipAndSanitize(profile.LoadoutCosmetics.Loadout, category, name, owned)
+				if err != nil {
+					return err
+				}
+				profile.LoadoutCosmetics.Loadout = updated
+				return nil
+			}
+			if err := applyEquip(); err != nil {
 				return fmt.Errorf("failed to update equipped item: %w", err)
 			}
 
-			if err := EVRProfileUpdate(ctx, nk, session.UserID().String(), profile); err != nil {
+			if err := EVRProfileUpdateWithRetry(ctx, nk, session.UserID().String(), profile, applyEquip); err != nil {
 				logger.WithField("error", err).Warn("Failed to set account metadata")
 			}
 


### PR DESCRIPTION
Replaces #515 after repository history pruning.

Original PR by brysonak — rebased onto current main.

----

EVRProfileUpdate discarded the caller's pending mutation on a storage version conflict (reload-then-rewrite-unchanged), so a cosmetic equip could vanish.

Adds EVRProfileUpdateWithRetry which wraps StorableWriteWithRetry with a reapply callback, and converts three call sites: Discord loadout commands, RemoteLogSet equip handler, and game server save loadout.