### PR TITLE
refactor(evr): extract I/O so every evr_ test runs with no database

### DIFF
--- a/server/evr_early_quit_message_trigger.go
+++ b/server/evr_early_quit_message_trigger.go
@@ -49,7 +49,13 @@ func (c *EarlyQuitServiceConfigStorable) SetStorageMeta(meta StorableMetadata) {
 
 // LoadEarlyQuitServiceConfig loads the early quit service config from storage,
 // or creates it with defaults if not found or blank. The config is validated and fixed if invalid.
-func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, logger *zap.Logger) *evr.SNSEarlyQuitConfig {
+//
+// logger is a runtime.Logger, not a *zap.Logger, so that callers holding the
+// runtime logger can pass it straight through. It previously took *zap.Logger,
+// which forced its only match-path caller to hard-cast logger.(*RuntimeGoLogger)
+// to reach the wrapped zap logger — a cast that panics on any other
+// implementation. nil is still accepted and silences the warnings.
+func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger) *evr.SNSEarlyQuitConfig {
 	configStorable := &EarlyQuitServiceConfigStorable{
 		SNSEarlyQuitConfig: evr.NewDefaultSNSEarlyQuitConfig(),
 	}
@@ -65,8 +71,7 @@ func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, lo
 			configStorable.SNSEarlyQuitConfig = config
 			if writeErr := StorableWrite(ctx, nk, SystemUserID, configStorable); writeErr != nil {
 				if logger != nil {
-					logger.Warn("Failed to write early quit config to storage",
-						zap.Error(writeErr))
+					logger.WithField("error", writeErr).Warn("Failed to write early quit config to storage")
 				}
 			}
 			return config
@@ -75,8 +80,7 @@ func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, lo
 		// Some other error occurred; suppress logs if the context was canceled.
 		if ctx.Err() == nil {
 			if logger != nil {
-				logger.Warn("Failed to load early quit config from storage, using defaults",
-					zap.Error(err))
+				logger.WithField("error", err).Warn("Failed to load early quit config from storage, using defaults")
 			}
 		}
 		config := evr.NewDefaultSNSEarlyQuitConfig()
@@ -100,8 +104,7 @@ func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, lo
 		configStorable.SNSEarlyQuitConfig = config
 		if writeErr := StorableWrite(ctx, nk, SystemUserID, configStorable); writeErr != nil {
 			if logger != nil {
-				logger.Warn("Failed to write populated early quit config to storage",
-					zap.Error(writeErr))
+				logger.WithField("error", writeErr).Warn("Failed to write populated early quit config to storage")
 			}
 		}
 	}
@@ -128,8 +131,7 @@ func LoadEarlyQuitServiceConfig(ctx context.Context, nk runtime.NakamaModule, lo
 		configStorable.SNSEarlyQuitConfig = config
 		if writeErr := StorableWrite(ctx, nk, SystemUserID, configStorable); writeErr != nil {
 			if logger != nil {
-				logger.Warn("Failed to write validated early quit config to storage",
-					zap.Error(writeErr))
+				logger.WithField("error", writeErr).Warn("Failed to write validated early quit config to storage")
 			}
 		}
 	}
@@ -197,7 +199,7 @@ func (t *SNSEarlyQuitMessageTrigger) SendEarlyQuitConfigOnLogin(ctx context.Cont
 	}
 
 	// Load the configuration from storage (or defaults)
-	config := LoadEarlyQuitServiceConfig(ctx, t.nk, t.logger)
+	config := LoadEarlyQuitServiceConfig(ctx, t.nk, NewRuntimeGoLogger(t.logger))
 
 	// Send to the player
 	if err := session.SendEvr(config); err != nil {

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
-	"go.uber.org/zap"
 )
 
 const (
@@ -140,14 +139,7 @@ func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int
 // new quit count is reflected. When the count maps to a level with no lockout
 // (level 0), any stale PenaltyLevel/PenaltyTimestamp are cleared to zero.
 func resolveAndApplyPenaltyLockout(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, eqconfig *EarlyQuitPlayerState) {
-	// RuntimeLoggerToZapLogger hard-casts to *RuntimeGoLogger, which test
-	// doubles (e.g. captureLogger) do not satisfy. LoadEarlyQuitServiceConfig
-	// tolerates a nil logger, so degrade gracefully instead of panicking.
-	var zapLogger *zap.Logger
-	if zl, ok := logger.(*RuntimeGoLogger); ok {
-		zapLogger = zl.logger
-	}
-	config := LoadEarlyQuitServiceConfig(ctx, nk, zapLogger)
+	config := LoadEarlyQuitServiceConfig(ctx, nk, logger)
 	level, lockoutSec := ResolvePenaltyLevel(eqconfig.NumEarlyQuits, config)
 	if lockoutSec > 0 {
 		eqconfig.PenaltyLevel = level

--- a/server/evr_earlyquit_charge_test.go
+++ b/server/evr_earlyquit_charge_test.go
@@ -52,23 +52,10 @@ func (c *chargeTestLeaderboardCache) Remove(id string) {}
 // penalty level from the ladder, setting PenaltyLevel and a future
 // PenaltyTimestamp so IsPenaltyActive() reports a live lockout.
 //
-// Requires a real Postgres (TEST_DB_URL) — the gate's StorableRead/StorableWrite
-// run through RuntimeGoNakamaModule, which uses pgx connections directly.
+// Runs against the in-memory evrTestNakamaModule: no database, no services.
 func TestEarlyQuitChargeGate_SetsPenaltyState(t *testing.T) {
-	// --- setup: real module over the test DB ---
-	logger := loggerForTest(t)
-	db := NewDB(t)
-	cfg := NewConfig(logger)
-
-	storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
-	if err != nil {
-		t.Fatalf("failed to create storage index: %v", err)
-	}
-	nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
-		nil, &chargeTestLeaderboardCache{}, nil, nil,
-		&testSessionRegistry{}, nil, nil, nil,
-		&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
-		storageIndex, nil)
+	// --- setup: in-memory module, no database required ---
+	nk, db := newChargeModule(t)
 
 	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 
@@ -79,7 +66,6 @@ func TestEarlyQuitChargeGate_SetsPenaltyState(t *testing.T) {
 
 	// --- player with 2 prior early quits on record (3rd quit crosses into penalty level 1) ---
 	player := reconnectTestPlayer("b1-charge", evr.TeamBlue)
-	InsertUser(t, db, player.UserID)
 
 	if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
 		Collection:      StorageCollectionEarlyQuit,
@@ -163,19 +149,7 @@ func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
 	}
 	for i, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			logger := loggerForTest(t)
-			db := NewDB(t)
-			cfg := NewConfig(logger)
-
-			storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
-			if err != nil {
-				t.Fatalf("failed to create storage index: %v", err)
-			}
-			nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
-				nil, &chargeTestLeaderboardCache{}, nil, nil,
-				&testSessionRegistry{}, nil, nil, nil,
-				&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
-				storageIndex, nil)
+			nk, db := newChargeModule(t)
 
 			ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 			writeEarlyQuitServiceConfig(t, ctx, nk, defaultEarlyQuitConfigJSON(t))
@@ -186,7 +160,6 @@ func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
 
 			// Player with 2 prior early quits (3rd quit crosses into penalty level 1).
 			player := reconnectTestPlayer(fmt.Sprintf("charge-guild-flag-%d", i), evr.TeamBlue)
-			InsertUser(t, db, player.UserID)
 
 			if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
 				Collection:      StorageCollectionEarlyQuit,
@@ -257,9 +230,17 @@ func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
 // production earlyQuitEnforcementEnabled cannot find the session parameters, so
 // LoadParams fails and it takes its fail-open `return true` branch — every guild
 // is treated as opted in and the flag never suppresses anything. That is a real
-// production bug; it is deliberately NOT fixed here (this change set is
-// test/build tooling only) and needs its own PR. Do not read a green run of this
-// test as evidence the gate is enforced.
+// production bug; it is deliberately NOT fixed here (this change set is a
+// testability refactor and must not alter behaviour) and needs its own PR. Do
+// not read a green run of this test as evidence the gate is enforced.
+//
+// What the test DOES now prove, which it could not before: the subtests actually
+// execute. Until the *RuntimeGoNakamaModule assertion was removed from the charge
+// gate they were skipped for want of a database, and before that a test double
+// fell straight through the assertion's `continue`. Flipping
+// earlyQuitEnforcementEnabled to an unconditional `return true` now turns the
+// guild-flag-nil and guild-flag-false cases red, so the suppression branch is
+// genuinely exercised — just from a context production never constructs.
 func withGuildEnforcement(ctx context.Context, guildID uuid.UUID, enforce *bool) context.Context {
 	params := &SessionParameters{
 		guildGroups: map[string]*GuildGroup{
@@ -309,19 +290,7 @@ func defaultEarlyQuitConfigJSON(t *testing.T) string {
 // defaults B1 used. Regression for BUG-3: a custom ladder that puts level 1 at
 // 2 quits with a 60s lockout must be honored (defaults would say level 0).
 func TestEarlyQuitChargeGate_UsesStoredConfigLadder(t *testing.T) {
-	logger := loggerForTest(t)
-	db := NewDB(t)
-	cfg := NewConfig(logger)
-
-	storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
-	if err != nil {
-		t.Fatalf("failed to create storage index: %v", err)
-	}
-	nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
-		nil, &chargeTestLeaderboardCache{}, nil, nil,
-		&testSessionRegistry{}, nil, nil, nil,
-		&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
-		storageIndex, nil)
+	nk, db := newChargeModule(t)
 
 	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 
@@ -333,7 +302,6 @@ func TestEarlyQuitChargeGate_UsesStoredConfigLadder(t *testing.T) {
 
 	// --- player with 1 prior early quit (2nd quit crosses into custom level 1) ---
 	player := reconnectTestPlayer("b2-stored-ladder", evr.TeamBlue)
-	InsertUser(t, db, player.UserID)
 
 	if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
 		Collection:      StorageCollectionEarlyQuit,
@@ -392,19 +360,7 @@ func TestEarlyQuitChargeGate_UsesStoredConfigLadder(t *testing.T) {
 // PenaltyTimestamp are cleared to zero (B1 left them untouched, which could keep
 // a dead lockout on record indefinitely).
 func TestEarlyQuitChargeGate_ClearsPenaltyAtLevelZero(t *testing.T) {
-	logger := loggerForTest(t)
-	db := NewDB(t)
-	cfg := NewConfig(logger)
-
-	storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
-	if err != nil {
-		t.Fatalf("failed to create storage index: %v", err)
-	}
-	nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
-		nil, &chargeTestLeaderboardCache{}, nil, nil,
-		&testSessionRegistry{}, nil, nil, nil,
-		&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
-		storageIndex, nil)
+	nk, db := newChargeModule(t)
 
 	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 
@@ -415,7 +371,6 @@ func TestEarlyQuitChargeGate_ClearsPenaltyAtLevelZero(t *testing.T) {
 	// 2nd quit maps to level 0, so the stale lockout must be cleared. ---
 	staleTS := time.Now().Add(time.Hour).Unix()
 	player := reconnectTestPlayer("b2-level0-clear", evr.TeamBlue)
-	InsertUser(t, db, player.UserID)
 
 	if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
 		Collection:      StorageCollectionEarlyQuit,

--- a/server/evr_earlyquit_pipeline_test.go
+++ b/server/evr_earlyquit_pipeline_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
-	"go.uber.org/zap"
 )
 
 // TestEarlyQuitDetectionPipeline validates that early quits are properly
@@ -26,16 +25,13 @@ import (
 //
 // and asserts on the stored EarlyQuit|statistics counter.
 //
-// Requires a real Postgres (TEST_DB_URL) — the gate's StorableRead/StorableWrite
-// run through RuntimeGoNakamaModule, which uses pgx connections directly.
+// Runs against the in-memory evrTestNakamaModule: no database, no services.
 func TestEarlyQuitDetectionPipeline(t *testing.T) {
-	logger := loggerForTest(t)
-	db, nk := newChargeModule(t, logger)
+	nk, db := newChargeModule(t)
 	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 
 	t.Run("Player leaving mid-game increments early quit counter", func(t *testing.T) {
 		player := reconnectTestPlayer("b6-pipe-midgame", evr.TeamBlue)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeArenaPublic, player)
@@ -53,7 +49,6 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 		// the old "60 second grace" case, which asserted a rule production
 		// does not implement.
 		player := reconnectTestPlayer("b6-pipe-early", evr.TeamBlue)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeArenaPublic, player)
@@ -67,7 +62,6 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 
 	t.Run("Player leaving after match ends does not increment early quit", func(t *testing.T) {
 		player := reconnectTestPlayer("b6-pipe-after", evr.TeamBlue)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeArenaPublic, player)
@@ -81,7 +75,6 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 
 	t.Run("Spectator leaving does not increment early quit", func(t *testing.T) {
 		player := reconnectTestPlayer("b6-pipe-spec", evr.TeamSpectator)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeArenaPublic, player)
@@ -94,7 +87,6 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 
 	t.Run("Moderator leaving does not increment early quit", func(t *testing.T) {
 		player := reconnectTestPlayer("b6-pipe-mod", evr.TeamModerator)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeArenaPublic, player)
@@ -107,7 +99,6 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 
 	t.Run("Social lobby leaving does not increment early quit", func(t *testing.T) {
 		player := reconnectTestPlayer("b6-pipe-social", evr.TeamBlue)
-		InsertUser(t, db, player.UserID)
 		preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 		state := chargeState(evr.ModeSocialPublic, player)
@@ -155,8 +146,7 @@ func TestEarlyQuitDetectionPipeline(t *testing.T) {
 // re-implementation — it could never fail. There is deliberately no
 // match-started-ago field: production has no duration threshold.
 func TestEarlyQuitConditions(t *testing.T) {
-	logger := loggerForTest(t)
-	db, nk := newChargeModule(t, logger)
+	nk, db := newChargeModule(t)
 	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
 
 	tests := []struct {
@@ -263,7 +253,6 @@ func TestEarlyQuitConditions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			player := reconnectTestPlayer(tt.seed, tt.roleAlignment)
-			InsertUser(t, db, player.UserID)
 			preseedEarlyQuitConfig(t, ctx, nk, player.GetUserId())
 
 			state := chargeState(tt.mode, player)
@@ -285,25 +274,25 @@ func TestEarlyQuitConditions(t *testing.T) {
 	}
 }
 
-// newChargeModule returns a real RuntimeGoNakamaModule over the test DB. The
-// leaderboard cache is the same stub the charge-gate tests use: leaderboard
-// ops degrade to non-fatal warnings, which is what MatchLeave expects.
-func newChargeModule(t *testing.T, logger *zap.Logger) (*sql.DB, *RuntimeGoNakamaModule) {
+// newChargeModule returns the in-memory NakamaModule the charge-gate tests drive
+// MatchLeave with, plus the nil *sql.DB that MatchLeave is handed alongside it.
+//
+// No database and no services. The module carries a real (in-memory)
+// LocalSessionRegistry so the charge gate's session-refresh branch and its
+// deferred-penalty goroutines run against a genuine registry rather than being
+// skipped. The registry is empty, so the refresh finds no live session — the
+// same shape as a player whose session has already gone.
+//
+// The *sql.DB is nil on purpose: MatchLeave only touches db on the Discord
+// tier-change DM path, which is gated behind
+// ServiceSettings().Matchmaking.EnableEarlyQuitPenalty. These tests leave that
+// false, so a nil db is never dereferenced. A regression that reaches it would
+// panic loudly rather than pass quietly.
+func newChargeModule(t *testing.T) (*evrTestNakamaModule, *sql.DB) {
 	t.Helper()
-	db := NewDB(t)
-	t.Cleanup(func() { _ = db.Close() })
-	cfg := NewConfig(logger)
-
-	storageIndex, err := NewLocalStorageIndex(logger, db, &StorageConfig{}, &testMetrics{})
-	if err != nil {
-		t.Fatalf("failed to create storage index: %v", err)
-	}
-	nk := NewRuntimeGoNakamaModule(logger, db, nil, cfg,
-		nil, &chargeTestLeaderboardCache{}, nil, nil,
-		&testSessionRegistry{}, nil, nil, nil,
-		&testTracker{}, &testMetrics{}, nil, &testMessageRouter{},
-		storageIndex, nil)
-	return db, nk
+	nk := newEvrTestNakamaModule()
+	nk.sessions = NewLocalSessionRegistry(&testMetrics{})
+	return nk, nil
 }
 
 // chargeState builds a match label in the given mode with one player present

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -171,7 +171,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 	}
 
 	// Load the user's matchmaking config
-	userSettings, err := LoadMatchmakingSettings(ctx, p.nk, userID)
+	userSettings, err := LoadMatchmakingSettings(ctx, nk, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load user matchmaking settings: %w", err)
 	}
@@ -184,7 +184,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 			zap.String("reason", userSettings.MatchLockReason))
 	}
 
-	joinDirective, err := LoadJoinDirective(ctx, p.nk, userID)
+	joinDirective, err := LoadJoinDirective(ctx, nk, userID)
 	if err != nil && status.Code(err) != codes.NotFound {
 		return nil, fmt.Errorf("failed to load join directive: %w", err)
 	}
@@ -206,7 +206,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 	if joinDirective != nil && joinDirective.HostDiscordID != "" {
 		hostUserIDStr := p.discordCache.DiscordIDToUserID(joinDirective.HostDiscordID)
 		if hostUserID := uuid.FromStringOrNil(hostUserIDStr); !hostUserID.IsNil() {
-			presences, _ := p.nk.StreamUserList(StreamModeService, hostUserID.String(), "", StreamLabelMatchService, false, true)
+			presences, _ := nk.StreamUserList(StreamModeService, hostUserID.String(), "", StreamLabelMatchService, false, true)
 			for _, presence := range presences {
 				matchID := MatchIDFromStringOrNil(presence.GetStatus())
 				if !matchID.IsNil() {
@@ -242,7 +242,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 			go func() {
 				ctxCleanup, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
-				if err := DeleteJoinDirective(ctxCleanup, p.nk, userID); err != nil {
+				if err := DeleteJoinDirective(ctxCleanup, nk, userID); err != nil {
 					logger.Warn("Failed to delete join directive", zap.Error(err))
 				} else {
 					logger.Debug("Deleted join directive")
@@ -348,7 +348,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 		if userSettings.StaticRatingMu != nil && userSettings.StaticRatingSigma != nil {
 			matchmakingRating = types.Rating{Mu: *userSettings.StaticRatingMu, Sigma: *userSettings.StaticRatingSigma}
 		} else {
-			matchmakingRating, err = MatchmakingRatingLoad(ctx, p.nk, userID, groupIDStr, mmMode)
+			matchmakingRating, err = MatchmakingRatingLoad(ctx, nk, userID, groupIDStr, mmMode)
 			if err != nil {
 				logger.Warn("Failed to load matchmaking rating", zap.String("group_id", groupIDStr), zap.String("mode", mmMode.String()), zap.Error(err))
 				matchmakingRating = NewDefaultRating()
@@ -359,7 +359,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 	// Load the player's total games played for new-player detection.
 	gamesPlayed := 0
 	if groupID != uuid.Nil {
-		gamesPlayed, err = GamesPlayedLoad(ctx, p.nk, userID, groupIDStr, evr.ModeArenaPublic)
+		gamesPlayed, err = GamesPlayedLoad(ctx, nk, userID, groupIDStr, evr.ModeArenaPublic)
 		if err != nil {
 			logger.Warn("Failed to load games played",
 				zap.String("user_id", userID),
@@ -392,7 +392,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 	hasSuspensionHistory := false
 	if globalSettings.ToxicSeparationEnabled() && globalSettings.NewPlayerMaxGames > 0 && !isModerator {
 		journal := NewGuildEnforcementJournal(userID)
-		if err := StorableRead(ctx, p.nk, userID, journal, true); err != nil {
+		if err := StorableRead(ctx, nk, userID, journal, true); err != nil {
 			logger.Warn("Failed to load enforcement journal for toxic separation", zap.Error(err))
 		} else {
 			for _, records := range journal.RecordsByGroupID {

--- a/server/evr_lobby_parameters_test.go
+++ b/server/evr_lobby_parameters_test.go
@@ -2,10 +2,10 @@ package server
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/atomic"
@@ -183,10 +183,10 @@ func TestResolveDirectiveRole_StaleDirectiveScenarios(t *testing.T) {
 // operator keeps the moderator role.
 //
 // Exercises the real resolution path: NewLobbyParametersFromRequest with a
-// real LobbyFindSessionRequest over the test DB.
+// real LobbyFindSessionRequest, against the in-memory module — no database.
 func TestLobbyParameters_ModeratorRoleAuthorization(t *testing.T) {
 	logger := loggerForTest(t)
-	db, nk := newChargeModule(t, logger)
+	nk, _ := newChargeModule(t)
 
 	// Deterministic defaults: NewPlayerMaxGames=0 disables the toxic
 	// separation journal read; EnableSBMM=false skips rating loads.
@@ -195,7 +195,7 @@ func TestLobbyParameters_ModeratorRoleAuthorization(t *testing.T) {
 	ServiceSettingsUpdate(&ServiceSettingsData{})
 
 	t.Run("non-moderator client claiming TeamModerator is downgraded to TeamUnassigned", func(t *testing.T) {
-		session := newLobbyParamsTestSession(t, logger, db, nk, false)
+		session := newLobbyParamsTestSession(t, logger, nk, false)
 		lobbyParams, err := NewLobbyParametersFromRequest(session.ctx, logger, nk, session, moderatorClaimRequest())
 		if err != nil {
 			t.Fatalf("NewLobbyParametersFromRequest failed: %v", err)
@@ -205,7 +205,7 @@ func TestLobbyParameters_ModeratorRoleAuthorization(t *testing.T) {
 	})
 
 	t.Run("global operator claiming TeamModerator keeps it", func(t *testing.T) {
-		session := newLobbyParamsTestSession(t, logger, db, nk, true)
+		session := newLobbyParamsTestSession(t, logger, nk, true)
 		lobbyParams, err := NewLobbyParametersFromRequest(session.ctx, logger, nk, session, moderatorClaimRequest())
 		if err != nil {
 			t.Fatalf("NewLobbyParametersFromRequest failed: %v", err)
@@ -231,20 +231,23 @@ func moderatorClaimRequest() *evr.LobbyFindSessionRequest {
 	}
 }
 
-// newLobbyParamsTestSession builds a sessionWS with real pipeline dependencies
-// (DB-backed nk) and SessionParameters stored in ctx. isGlobalOperator controls
-// the moderator privilege the session holds.
-func newLobbyParamsTestSession(t *testing.T, logger *zap.Logger, db *sql.DB, nk *RuntimeGoNakamaModule, isGlobalOperator bool) *sessionWS {
+// newLobbyParamsTestSession builds a sessionWS with SessionParameters stored in
+// ctx. isGlobalOperator controls the moderator privilege the session holds.
+//
+// EvrPipeline.nk is left nil on purpose. NewLobbyParametersFromRequest takes the
+// module as a parameter and (since this change set) uses that parameter for
+// every storage read rather than reaching back through session.evrPipeline.nk.
+// A nil pipeline module is therefore the assertion that it does not regress: if
+// some future edit reintroduces a p.nk read on this path, this test panics
+// rather than quietly going back to needing a database.
+func newLobbyParamsTestSession(t *testing.T, logger *zap.Logger, nk runtime.NakamaModule, isGlobalOperator bool) *sessionWS {
 	t.Helper()
 	userID := uuid.Must(uuid.NewV4())
-	InsertUser(t, db, userID)
 
 	ep := &EvrPipeline{
 		node:   "test-node",
 		logger: logger,
-		db:     db,
 		config: NewConfig(logger),
-		nk:     nk,
 	}
 
 	params := &SessionParameters{

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -48,6 +48,41 @@ const (
 	PreMatchToPlayingTimeout   = 60 * time.Second
 )
 
+// evrSessionRegistryProvider and evrPartyRegistryProvider are the two narrow
+// capabilities the EVR match handler needs beyond runtime.NakamaModule.
+//
+// They are declared here, at the consumer, and kept to the single method each
+// call site actually uses. *RuntimeGoNakamaModule satisfies both. They replace
+// `nk.(*RuntimeGoNakamaModule)` assertions, which no test double could satisfy:
+// every double fell through to the failure branch, so the guarded code was never
+// exercised by any test and the tests that "covered" it proved nothing.
+type evrSessionRegistryProvider interface {
+	SessionRegistry() SessionRegistry
+}
+
+type evrPartyRegistryProvider interface {
+	PartyRegistry() PartyRegistry
+}
+
+// evrSessionRegistry returns nk's session registry, or nil when nk does not
+// provide one. Call sites must handle nil: it means "cannot look sessions up",
+// not "abandon the surrounding work".
+func evrSessionRegistry(nk runtime.NakamaModule) SessionRegistry {
+	if p, ok := nk.(evrSessionRegistryProvider); ok {
+		return p.SessionRegistry()
+	}
+	return nil
+}
+
+// evrPartyRegistry returns nk's party registry, or nil when nk does not provide
+// one.
+func evrPartyRegistry(nk runtime.NakamaModule) PartyRegistry {
+	if p, ok := nk.(evrPartyRegistryProvider); ok {
+		return p.PartyRegistry()
+	}
+	return nil
+}
+
 var (
 	LobbySizeByMode = map[evr.Symbol]int{
 		evr.ModeArenaPublic:   MatchLobbyMaxSize,
@@ -871,8 +906,8 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			// Only apply match-leave transitions if the player is still InMatch.
 			// Stale leave events (player already advanced to Matchmaking,
 			// SocialReady, etc.) should be ignored — the player has moved on.
-			if _nkLocal, ok := nk.(*RuntimeGoNakamaModule); ok {
-				if s := _nkLocal.sessionRegistry.Get(uuid.FromStringOrNil(p.GetSessionId())); s != nil {
+			if sessions := evrSessionRegistry(nk); sessions != nil {
+				if s := sessions.Get(uuid.FromStringOrNil(p.GetSessionId())); s != nil {
 					if ws, ok := s.(*sessionWS); ok {
 						if lc := getMatchLifecycle(ws); lc != nil && lc.State() == StateInMatch {
 							if hasReconnectReservation {
@@ -894,8 +929,8 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 			// reservations remain valid because the leader is still present).
 			if mp.PartyID != uuid.Nil {
 				isLeader := false
-				if _nk, ok := nk.(*RuntimeGoNakamaModule); ok {
-					if ph, ok := _nk.partyRegistry.Get(mp.PartyID); ok {
+				if parties := evrPartyRegistry(nk); parties != nil {
+					if ph, ok := parties.Get(mp.PartyID); ok {
 						ph.RLock()
 						if ph.leader != nil {
 							isLeader = ph.leader.UserPresence.SessionId == mp.GetSessionId()
@@ -980,11 +1015,11 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 						recordEarlyQuitForPlayer(ctx, logger, nk, state, mp, leaveReason)
 
 						eqconfig := NewEarlyQuitPlayerState()
-						_nk, ok := nk.(*RuntimeGoNakamaModule)
-						if !ok {
-							logger.Warn("nk is not *RuntimeGoNakamaModule, skipping early quit penalty")
-							continue
-						}
+						// Used to refresh the quitter's live session cache and by
+						// the deferred-penalty goroutines. nil means no registry is
+						// available; the penalty itself is still charged and
+						// persisted, only the session-side follow-ups are skipped.
+						sessions := evrSessionRegistry(nk)
 						if err := StorableRead(ctx, nk, mp.GetUserId(), eqconfig, true); err != nil {
 							logger.WithField("error", err).Warn("Failed to load early quitter config")
 						} else {
@@ -1031,9 +1066,11 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 							if err := StorableWrite(ctx, nk, mp.GetUserId(), eqconfig); err != nil {
 								logger.Warn("Failed to write early quitter config", zap.Error(err))
 							} else {
-								if s := _nk.sessionRegistry.Get(uuid.FromStringOrNil(mp.GetSessionId())); s != nil {
-									if params, ok := LoadParams(s.Context()); ok {
-										params.earlyQuitConfig.Store(eqconfig)
+								if sessions != nil {
+									if s := sessions.Get(uuid.FromStringOrNil(mp.GetSessionId())); s != nil {
+										if params, ok := LoadParams(s.Context()); ok {
+											params.earlyQuitConfig.Store(eqconfig)
+										}
 									}
 								}
 
@@ -1077,19 +1114,23 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 
 								// Launch goroutine for deferred penalty resolution.
 								// Use background context to ensure goroutine isn't cancelled when match ends.
-								if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
+								// Both callees dereference the registry unconditionally,
+								// so skip the deferral when none is available.
+								if sessions == nil {
+									logger.Warn("No session registry available; skipping deferred early quit penalty resolution")
+								} else if leaveReason == LeaveReasonVoluntary || leaveReason == LeaveReasonUnknown || leaveReason == "" {
 									// Voluntary leave: penalty applied immediately. If player logs out
 									// within 5 minutes, forgive the penalty (crash during quit flow).
 									go func(userID, sessionID string) {
 										bgCtx := context.Background()
-										CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, 5*time.Minute)
+										CheckAndStrikeEarlyQuitIfLoggedOut(bgCtx, logger, nk, db, sessions, userID, sessionID, 5*time.Minute)
 									}(mp.GetUserId(), mp.GetSessionId())
 								} else {
 									// Disconnect: penalty deferred. If player is still online after
 									// 5 minutes, they force-closed intentionally — apply the penalty.
 									go func(userID, sessionID string, matchID MatchID) {
 										bgCtx := context.Background()
-										CheckAndApplyEarlyQuitIfStillOnline(bgCtx, logger, nk, db, _nk.sessionRegistry, userID, sessionID, matchID, 5*time.Minute)
+										CheckAndApplyEarlyQuitIfStillOnline(bgCtx, logger, nk, db, sessions, userID, sessionID, matchID, 5*time.Minute)
 									}(mp.GetUserId(), mp.GetSessionId(), state.ID)
 								}
 							}
@@ -1451,12 +1492,10 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				logger.WithField("error", err).Error("failed to send match summary")
 			}
 
-			// Increment completed matches for players who stayed until the end
-			_nk, ok := nk.(*RuntimeGoNakamaModule)
-			if !ok {
-				logger.Warn("nk is not *RuntimeGoNakamaModule, skipping post-match processing")
-				return state
-			}
+			// Increment completed matches for players who stayed until the end.
+			// A nil registry only costs the live-session cache refresh below; the
+			// completion counters are still credited and persisted.
+			sessions := evrSessionRegistry(nk)
 			serviceSettings := ServiceSettings()
 			if serviceSettings == nil {
 				serviceSettings = &ServiceSettingsData{}
@@ -1496,9 +1535,11 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				if err := StorableWrite(ctx, nk, presence.GetUserId(), eqconfig); err != nil {
 					logger.Warn("Failed to write early quitter config after completed match", zap.Error(err))
 				} else {
-					if s := _nk.sessionRegistry.Get(uuid.FromStringOrNil(presence.GetSessionId())); s != nil {
-						if params, ok := LoadParams(s.Context()); ok {
-							params.earlyQuitConfig.Store(eqconfig)
+					if sessions != nil {
+						if s := sessions.Get(uuid.FromStringOrNil(presence.GetSessionId())); s != nil {
+							if params, ok := LoadParams(s.Context()); ok {
+								params.earlyQuitConfig.Store(eqconfig)
+							}
 						}
 					}
 
@@ -1519,11 +1560,13 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				// Update ambassador state after match completion.
 				if serviceSettings.Matchmaking.AmbassadorProgramEnabled() {
 					wasAmbassador := false
-					if s := _nk.sessionRegistry.Get(uuid.FromStringOrNil(presence.GetSessionId())); s != nil {
-						if params, ok := LoadParams(s.Context()); ok {
-							wasAmbassador = params.isAmbassadorMatch.Load()
-							// Reset for next match.
-							params.isAmbassadorMatch.Store(false)
+					if sessions != nil {
+						if s := sessions.Get(uuid.FromStringOrNil(presence.GetSessionId())); s != nil {
+							if params, ok := LoadParams(s.Context()); ok {
+								wasAmbassador = params.isAmbassadorMatch.Load()
+								// Reset for next match.
+								params.isAmbassadorMatch.Store(false)
+							}
 						}
 					}
 

--- a/server/evr_testsupport_test.go
+++ b/server/evr_testsupport_test.go
@@ -36,18 +36,29 @@ func requireCharacterizationFixture(t *testing.T, path string) {
 // are inert stubs, which is faithful enough because the code under test treats
 // all of them as best-effort (failures are logged, not propagated).
 //
-// Fidelity caveat: production passes a *RuntimeGoNakamaModule, and several
-// branches in MatchLeave are guarded by `nk.(*RuntimeGoNakamaModule)` type
-// assertions (session-lifecycle transitions, party-registry reservation
-// clearing). Those branches are NOT exercised when this double is used. Tests
-// asserting on those behaviours need the real module and a database.
+// The MatchLeave branches that used to be gated behind a
+// `nk.(*RuntimeGoNakamaModule)` assertion (session-lifecycle transitions,
+// party-registry reservation clearing, the early-quit charge gate) now reach
+// for the registries through the narrow evrSessionRegistryProvider /
+// evrPartyRegistryProvider interfaces, which this double implements. Leave
+// `sessions` / `parties` nil to model "registry unavailable"; set them (a real
+// LocalSessionRegistry works fine in-memory) to exercise those branches.
 type evrTestNakamaModule struct {
 	*occTestNakamaModule
+
+	sessions SessionRegistry
+	parties  PartyRegistry
 }
 
 func newEvrTestNakamaModule() *evrTestNakamaModule {
 	return &evrTestNakamaModule{occTestNakamaModule: newOCCTestNakamaModule()}
 }
+
+// SessionRegistry / PartyRegistry satisfy the narrow provider interfaces the EVR
+// match handler asserts for. Returning nil is a valid answer and the production
+// call sites treat it as "no registry available".
+func (m *evrTestNakamaModule) SessionRegistry() SessionRegistry { return m.sessions }
+func (m *evrTestNakamaModule) PartyRegistry() PartyRegistry     { return m.parties }
 
 func (m *evrTestNakamaModule) StorageList(ctx context.Context, callerID, userID, collection string, limit int, cursor string) ([]*api.StorageObject, string, error) {
 	m.mu.Lock()
@@ -117,6 +128,13 @@ func (m *evrTestNakamaModule) LeaderboardRecordsList(ctx context.Context, id str
 
 func (m *evrTestNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
 	return nil, nil
+}
+
+// FriendsList reports a player with no friends and therefore no ghosted/blocked
+// players. NewLobbyParametersFromRequest calls it to build the blocked-ID list;
+// an empty list is the ordinary case and keeps the ghost-filter addon empty.
+func (m *evrTestNakamaModule) FriendsList(ctx context.Context, userID string, limit int, state *int, cursor string) ([]*api.Friend, string, error) {
+	return nil, "", nil
 }
 
 func (m *evrTestNakamaModule) UsersGetId(ctx context.Context, userIDs []string, facebookIDs []string) ([]*api.User, error) {

--- a/server/runtime_go_nakama.go
+++ b/server/runtime_go_nakama.go
@@ -4482,3 +4482,16 @@ func (n *RuntimeGoNakamaModule) PartyList(ctx context.Context, limit int, open *
 func (n *RuntimeGoNakamaModule) SetPartyRegistry(pr PartyRegistry) {
 	n.partyRegistry = pr
 }
+
+// SessionRegistry and PartyRegistry expose the registries this module was built
+// with. They exist so callers that need a registry can ask a narrow interface
+// for it (see evrSessionRegistryProvider / evrPartyRegistryProvider in
+// evr_match.go) instead of type-asserting runtime.NakamaModule down to this
+// concrete type — an assertion no test double can ever satisfy.
+func (n *RuntimeGoNakamaModule) SessionRegistry() SessionRegistry {
+	return n.sessionRegistry
+}
+
+func (n *RuntimeGoNakamaModule) PartyRegistry() PartyRegistry {
+	return n.partyRegistry
+}


### PR DESCRIPTION
Stacks on #521 (`test/db-free-suite-and-build-tooling`). Diff reads cleanly against that base.

> **Directive:** *"none of the tests of evr_ should require db at all. if a function needs the db to be tested, it needs to be extracted."*

**Status: satisfied for `server/evr_*_test.go`.**

```
$ grep -n "NewDB(t)" server/evr_*_test.go
(no matches)
```

`server/evr/**` never required one — it is pure protocol code.

---

## Results

| | before (`79aa386d7`) | after (`7d79f3006`) |
|---|---|---|
| pass | 2901 | **2929** |
| skip | 138 | **129** |
| fail | 0 | 0 |
| data races | 0 | 0 |

Nine tests moved skip → pass. The other 19 new passes are subtests of
`TestEarlyQuitDetectionPipeline` (7), `TestEarlyQuitConditions` (10) and
`TestLobbyParameters_ModeratorRoleAuthorization` (2) that never ran at all while their
parents were skipped. 9 + 19 = 28. **No test moved pass → skip.**

<details><summary>The nine tests</summary>

```
TestEarlyQuitChargeGate_SetsPenaltyState
TestEarlyQuitChargeGate_UsesStoredConfigLadder
TestEarlyQuitChargeGate_ClearsPenaltyAtLevelZero
TestEarlyQuitChargeGate_GuildEnforcementFlag/guild-flag-nil
TestEarlyQuitChargeGate_GuildEnforcementFlag/guild-flag-false
TestEarlyQuitChargeGate_GuildEnforcementFlag/guild-flag-true
TestEarlyQuitDetectionPipeline
TestEarlyQuitConditions
TestLobbyParameters_ModeratorRoleAuthorization
```
</details>

---

## ⚠️ @metis-sprock — behaviour-affecting change, please review

This PR **deletes two `nk.(*RuntimeGoNakamaModule)` type assertions whose failure branches
skipped real work.** In production those branches are unreachable, so the change is
behaviour-preserving *in practice* — but that is a claim about reachability, so here is the
proof rather than the assertion. All citations are at `7d79f3006`.

**Chain of custody for the `nk` that reaches the assertion:**

1. `server/runtime_go.go:2896` — `nk := NewRuntimeGoNakamaModule(...)`, statically `*RuntimeGoNakamaModule`.
2. `server/runtime_go.go:2928` — that same `nk` is passed to `NewRuntimeGoMatchCore(..., nk, match)`.
3. `server/runtime_go_match_core.go:61` stores it; `:172` (`MatchLeave`) and `:185` (`MatchLoop`) pass `r.nk` unchanged to the EVR handlers.
4. It is the only production construction site: `NewRuntimeGoMatchCore(` has exactly three callers, and the other two are `server/evr_lobby_find_test.go:47` and `server/match_common_test.go:66`.

**The wrapper was checked, and it does not reach this path.** `matchSignalBlockedNakamaModule`
(`server/evr_match.go:1712-1720`) is assigned to a **local** `nk` inside `MatchSignal`
(`:1731`). Within `MatchSignal` the wrapped value flows only to `nk.SessionDisconnect` and to
`m.MatchShutdown`. `MatchShutdown` uses `nk` only for `MetricsCounterAdd`,
`MetricsTimerRecord`, `AccumulateLeaderboardStat` and `StoreMatchLabel` — it never calls
`evrSessionRegistry`/`evrPartyRegistry`, `MatchLeave` or `MatchLoop`. `MatchShutdown` does
cause `MatchLeave` to fire, but *indirectly*: it tells the game server to kick players
(`sendEntrantReject`), and the resulting leave arrives as a **fresh match-core invocation**
carrying `r.nk` — the unwrapped concrete module.

Note the wrapper embeds `runtime.NakamaModule` as an interface, so it would **not** promote
`SessionRegistry()` either. Had it reached this path, both the old code and the new code would
take their respective fallback branch; the new one degrades rather than abandoning the work.

**No path was found where `!ok` is reachable in production.**

---

## Behaviour-change scenarios

### 1. Early-quit charge gate: `!ok` skipped the penalty *and* leaked a phantom player

**What was tried:** A player quits an in-progress public arena match.
**What they expected:** The quit is counted, a lockout is applied per the ladder, and the player disappears from the lobby.
**What happened BEFORE this PR:** With a `runtime.NakamaModule` that is not `*RuntimeGoNakamaModule`, `evr_match.go` (old `:983-987`) logged a warning and ran `continue`. That `continue` skipped the rest of the loop body — including the presence-map cleanup (`delete(state.presenceMap, ...)`, `presenceByEvrID`, `joinTimestamps`, `joinTimeMilliseconds`) at the bottom. The player stayed counted in `Size`/`PlayerCount` **for the life of the match**, and no penalty was charged.
**Estimated frequency:** **Unreachable in production — zero occurrences.** See the chain-of-custody proof above. It was reachable *only* from tests, where it silently neutered them.
**What happens AFTER this PR:** The registry is fetched through a narrow interface. The penalty is charged and persisted regardless; only the live-session cache refresh and the deferred-penalty goroutines are skipped when no registry exists. Presence-map cleanup always runs.
**Log signature BEFORE:** `"nk is not *RuntimeGoNakamaModule, skipping early quit penalty"` (WARN, old `evr_match.go:985`).
**Log signature AFTER:** That message is deleted. A different, narrower message can appear only if a registry is genuinely absent: `"No session registry available; skipping deferred early quit penalty resolution"` (WARN, `evr_match.go:1120`).
**How to verify in production logs:**
```bash
grep -c 'nk is not \*RuntimeGoNakamaModule' /home/echovrce/deployment/logs/nakama.log   # expect 0 historically
grep -c 'No session registry available'      /home/echovrce/deployment/logs/nakama.log   # expect 0 after deploy
```
A non-zero count on the first grep would **disprove** the unreachability claim above — worth running before merge.
**Citation:** `server/runtime_go.go:2896,2928`; `server/runtime_go_match_core.go:61,172,185`; `server/evr_match.go:1712-1731`. Test proof that the branch really was neutering tests: `TestEarlyQuitChargeGate_SetsPenaltyState` failed with `expected charge gate to increment to 3 early quits, got 2` before the extraction and passes after.

### 2. `MatchLoop` post-match processing: `!ok` abandoned every remaining player

**What was tried:** A public arena match reaches match-over with players still present.
**What they expected:** Each player is credited a completed match, tier is recalculated, ambassador state is updated.
**What happened BEFORE this PR:** On `!ok`, old `evr_match.go:1455-1459` ran `return state`, exiting the whole handler before the per-player loop. Nobody was credited.
**Estimated frequency:** **Unreachable in production — zero occurrences.** Same proof.
**What happens AFTER this PR:** Completion counters are credited and persisted regardless; a nil registry costs only the live-session cache refresh and the ambassador-state read of `params.isAmbassadorMatch`.
**Log signature BEFORE:** `"nk is not *RuntimeGoNakamaModule, skipping post-match processing"` (WARN, old `evr_match.go:1457`).
**Log signature AFTER:** none — the message is deleted and there is no replacement on this path.
**How to verify in production logs:**
```bash
grep -c 'skipping post-match processing' /home/echovrce/deployment/logs/nakama.log   # expect 0 historically
```
**Citation:** `server/evr_match.go` diff in commit `134c5b320`.

### 3. `logger.(*RuntimeGoLogger)` cast removed — no new log lines in production

**What was tried:** The early-quit ladder is resolved while the `EarlyQuit|config` storage row is unreadable.
**What they expected:** A warning naming the storage failure.
**What happened BEFORE this PR:** `resolveAndApplyPenaltyLockout` cast `logger` to `*RuntimeGoLogger` to reach the wrapped `*zap.Logger`, passing `nil` when the cast failed, which silences the warnings.
**Estimated frequency:** **The cast never failed in production, so nothing was ever suppressed there.** `RuntimeGoMatchCore` sets `runtimeLogger: NewRuntimeGoLogger(logger)` (`runtime_go_match_core.go:91`) and passes that value to `MatchLeave` (`:172`) and `MatchLoop` (`:185`); the third caller, `CheckAndApplyEarlyQuitIfStillOnline` (`evr_earlyquit.go:511`), receives the same logger from `MatchLeave`. All three are `*RuntimeGoLogger`. The silent drop only ever affected **test doubles**.
**What happens AFTER this PR:** `LoadEarlyQuitServiceConfig` takes `runtime.Logger` directly; no cast.
**Log signature BEFORE:** `"Failed to load early quit config from storage, using defaults"` and `"Failed to write early quit config to storage"` (WARN), field `error` via `zap.Error(err)`.
**Log signature AFTER:** **Identical message strings, identical WARN level, identical emission frequency, identical `error` field key** (`WithField("error", …)` → `zap.Any("error", …)`, `runtime_go_logger.go:78-93`). The one difference: `RuntimeGoLogger.Warn` appends a `source=file:line` field (`runtime_go_logger.go:38-48`) that the raw zap path did not.
**How to verify in production logs:**
```bash
grep -c 'Failed to load early quit config from storage' /home/echovrce/deployment/logs/nakama.log
# rate before vs after deploy should be UNCHANGED; only a new "source" field appears
```
**Citation:** `server/runtime_go_match_core.go:91,172,185`; `server/runtime_go_logger.go:38-48,64-69,78-93`; `server/evr_earlyquit.go:511`.

> ⚠️ **Correcting a hypothesis raised in review:** it was suggested that removing this cast might make log lines *start appearing* in production that never appeared before. **That is wrong.** The cast succeeded in production, so the lines were already being emitted. Do not expect a log-volume change here.

### 4. `NewLobbyParametersFromRequest` uses its own `nk` parameter

**What was tried:** A client sends `LobbyFindSessionRequest`.
**What they expected:** Matchmaking parameters are built.
**What happened BEFORE this PR:** The function accepted `nk runtime.NakamaModule` and ignored it, reaching through `session.evrPipeline.nk` for all seven storage reads.
**Estimated frequency:** N/A — no behaviour difference. The sole production caller (`evr_pipeline_matchmaker.go:45`) passes `p.nk`, the very value the body reached for. Same object, same calls, same order.
**What happens AFTER this PR:** The seven reads use the `nk` parameter.
**Log signature BEFORE / AFTER:** none — no log statement was added, removed or altered.
**How to verify in production logs:** nothing to verify; no log surface changed.
**Citation:** `server/evr_pipeline_matchmaker.go:45`; diff in commit `ee3085cb7` (pure `p.nk` → `nk` rename, 7 lines).

### Production log-statement audit

Every production log statement in a touched path was reviewed. **Two messages deleted**
(scenarios 1 and 2), **one added** (`"No session registry available; skipping deferred early
quit penalty resolution"`, WARN, `evr_match.go:1120`, only on a nil registry — unreachable in
production), **two gained a `source` field with no change to string, level or frequency**
(scenario 3). No other production log message had its string, level or emission frequency
changed. Checked by reading every `logger.`/`Warn(`/`Error(`/`Info(` line in
`git diff origin/test/db-free-suite-and-build-tooling..HEAD -- server/evr_match.go
server/evr_earlyquit.go server/evr_early_quit_message_trigger.go
server/evr_lobby_parameters.go server/runtime_go_nakama.go`.

---

## Extraction design

**1. Narrow registry interfaces, declared at the consumer** (`server/evr_match.go:51-85`)

```go
type evrSessionRegistryProvider interface { SessionRegistry() SessionRegistry }
type evrPartyRegistryProvider   interface { PartyRegistry() PartyRegistry }
```

`SessionRegistry` and `PartyRegistry` were *already* interfaces
(`session_registry.go:65`, `party_registry.go:29`); only the reach-through was concrete. So
the fix is two accessors on `*RuntimeGoNakamaModule` (`runtime_go_nakama.go`) plus one-method
interfaces at the consumer — not a mirror of the ~200-method module. Nil is a valid answer and
call sites degrade rather than abandoning work.

**2. Parameter-type widening** for `LoadEarlyQuitServiceConfig` (`*zap.Logger` → `runtime.Logger`).
The cast existed only to satisfy the parameter type, so the parameter type is what changed.

**3. Use the parameter you already accept** in `NewLobbyParametersFromRequest`.

`EvrPipeline.nk` (`evr_pipeline.go:70`) is **deliberately left concrete.** Widening it would
touch ~70 sites using concrete fields (`p.nk.metrics`, `p.nk.tracker`, `p.nk.partyRegistry`, …)
across `evr_lobby_*.go` and `evr_pipeline_*.go` — far outside a testability refactor, and not
needed to unblock the test.

---

## These tests are not vacuous

Every target test was run **red first**, then re-checked by perturbing **production** code
(stronger than perturbing an expectation — it proves the test drives production):

| perturbation | result |
|---|---|
| disable `eqconfig.IncrementEarlyQuit()` | charge-gate + pipeline red: `expected charge gate to increment to 3 early quits, got 2` |
| force resolved ladder to `nil` | penalty-level assertions red, **increment assertions stay green** (independently exercised) |
| delete the SEC-5 moderator downgrade | lobby-params red: `expected: -1, actual: 4` |
| `earlyQuitEnforcementEnabled` → always `true` | `guild-flag-nil` and `guild-flag-false` red |

All perturbations reverted; `grep -rn PERTURBATION server/` is empty.

---

## Pre-existing bugs — NOT fixed here

No **new** bug was exposed: all nine newly-running tests pass. Two pre-existing defects are
re-stated because this PR touches their neighbourhood.

### `withGuildEnforcement` still validates an impossible path (pre-existing, from #517 `f2901629b`)

`TestEarlyQuitChargeGate_GuildEnforcementFlag` plants `ctxSessionParametersKey{}` on the
context passed to `MatchLeave`. The Nakama match runtime never produces that key — it is set on
the *session* context by the EVR pipeline. So in production `LoadParams` fails and
`earlyQuitEnforcementEnabled` takes its fail-open `return true` branch
(`evr_earlyquit.go:282-286`): **every guild is treated as opted in and
`EnforceEarlyQuitPenalty` never suppresses anything.** Deliberately not fixed — needs its own PR.
The warning comment is retained and updated. What the test *now* proves that it could not
before: the subtests actually execute (perturbation 4 above turns them red).

### The `!ok` presence-map leak was real but unreachable

Documented in scenario 1 for the record. It is fixed as a side effect of deleting the branch,
not as a drive-by.

---

## Still skipping (129) — none blocked on a database

Remaining EVR-adjacent skips are **unwritten placeholder stubs** (`t.Skip("Requires mock DB and
NakamaModule - will test in integration")` in `evr_auth_context_test.go`, `"Requires
runtime.MatchmakerEntry mock"` in `evr_earlyquit_integration_test.go`) — bodies with no
assertions, so un-skipping them would exercise nothing. The rest are #521's documented
pre-existing failures (`TestLobbyCapacity_*`, `TestPoll_LeaderLeftMatch_ReturnsFalse`,
`TestGroupEntries*`) and the gitignored characterization fixtures. All out of scope.

---

## Verification (zero services running)

```
GOWORK=off go build ./server/...          exit 0
GOWORK=off go vet   ./server/...          exit 0
GOWORK=off go test  ./server/... -count=1 ok — 2929 pass, 129 skip, 0 fail
GOWORK=off go test -race ./server/...     ok — 0 data races (server 143.640s)
gofmt -l <files I authored>               clean
```

`gofmt -l server/` flags `evr_earlyquit.go` and `evr_lobby_parameters.go`, but **both already
failed gofmt on the base branch** (verified by extracting the base blobs and running `gofmt -l`
on them) in regions I did not touch — struct-tag alignment at `evr_earlyquit.go:53-58` and a
stray blank line at `evr_lobby_parameters.go:884`. Left alone; there is a `style/gofmt-compliance`
branch for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
