### PR TITLE
chore(test): cap per-test-binary memory in a cgroup for correct attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,39 @@ This applies regardless of context — even if the task seems to require deploym
 - Full suite including DB-backed tests: `just test-db` (requires a reachable database at `TEST_DB_URL`)
 - Docker image build (local only, no push): `just build` — FORBIDDEN without explicit approval, see above
 
+## Tests — per-test-binary memory cap
+
+A runaway test once reached 11.6 GB. The kernel OOM killer picks victims
+machine-wide by heuristic, so it did not kill the test — it killed two unrelated
+developer sessions. `scripts/go-test-limit.sh` fixes the *attribution*: it runs
+each test binary in its own bounded cgroup so the offending test is the only
+process eligible to die, and it dies naming itself.
+
+`just test`, `just test-verbose` and `just test-db` apply it automatically.
+
+To get the same protection on a raw `go test` (which is how the 11.6 GB run was
+started), add this to `.claude/settings.local.json` — it is gitignored, which is
+required here because the path must be absolute and `settings.json` `env` values
+are **not** interpolated:
+
+```json
+{
+  "env": {
+    "GOFLAGS": "-exec=/home/andrew/src/nakama/scripts/go-test-limit.sh",
+    "GO_TEST_MEMORY_LIMIT": "4G"
+  }
+}
+```
+
+One absolute path covers every worktree — the wrapper only wraps whatever binary
+it is handed, so it does not care which checkout it lives in.
+
+- Default cap is 4G per test binary. Raise for one run: `GO_TEST_MEMORY_LIMIT=8G go test ...`
+- Disable: `GO_TEST_MEMORY_LIMIT=off`
+- Degrades to running unwrapped where cgroups are unavailable (CI containers, non-systemd), so it can never fail a run that would otherwise pass.
+- Do NOT rely on `GOMEMLIMIT` for this. It is a soft limit: against a genuinely
+  live heap Go keeps allocating and GC-thrashes to the timeout instead of failing.
+
 ## Project
 
 This is a fork of [heroiclabs/nakama](https://github.com/heroiclabs/nakama) with EchoVR-specific extensions. The EVR runtime module lives in `server/evr_*.go`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,17 @@ are **not** interpolated:
 ```json
 {
   "env": {
-    "GOFLAGS": "-exec=/home/andrew/src/nakama/scripts/go-test-limit.sh",
+    "GOFLAGS": "-exec=/ABSOLUTE/PATH/TO/nakama/scripts/go-test-limit.sh",
     "GO_TEST_MEMORY_LIMIT": "4G"
   }
 }
 ```
+
+**Substitute your own path.** Replace `/ABSOLUTE/PATH/TO/nakama` with the
+absolute path to your checkout — `git rev-parse --show-toplevel` prints it. A
+relative path will not work (`go test` runs the wrapper with cwd set to the
+package directory), and neither will `${CLAUDE_PROJECT_DIR}`, which is passed
+through literally for the reason above.
 
 One absolute path covers every worktree — the wrapper only wraps whatever binary
 it is handed, so it does not care which checkout it lives in.

--- a/justfile
+++ b/justfile
@@ -13,6 +13,16 @@ DEBUG_FLAGS := "-trimpath -gcflags \"-trimpath " + PWD + "\" -gcflags=\"all=-N -
 # CockroachDB/Postgres: just TEST_DB_URL=postgresql://... test-db
 TEST_DB_URL := env_var_or_default("TEST_DB_URL", "postgresql://root@127.0.0.1:26257/nakama?sslmode=disable")
 
+# Per-test-binary memory cap. See scripts/go-test-limit.sh for the rationale:
+# a runaway test must die itself rather than letting the machine-wide OOM killer
+# pick an unrelated victim. Raise for one run with:
+#   just GO_TEST_MEMORY_LIMIT=8G test        (or GO_TEST_MEMORY_LIMIT=off to disable)
+#
+# The path must be ABSOLUTE: `go test -exec` runs the wrapper with the working
+# directory set to the package under test, so a relative path fails to resolve.
+GO_TEST_MEMORY_LIMIT := env_var_or_default("GO_TEST_MEMORY_LIMIT", "4G")
+TEST_LIMIT_FLAG := "-exec=" + justfile_directory() + "/scripts/go-test-limit.sh"
+
 # Build nakama (debug). Default target.
 all: nakama
 
@@ -68,11 +78,13 @@ bench-check: bench-compare
 
 # Run the DB-free server test suite
 test:
-    go test ./server/... -count=1
+    GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
+        go test ./server/... -count=1
 
 # Run the DB-free suite with verbose output.
 test-verbose:
-    go test -v ./server/... -count=1
+    GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
+        go test -v ./server/... -count=1
 
 # Requires a reachable CockroachDB/Postgres at TEST_DB_URL. TEST_DB_REQUIRED
 # makes an unreachable database a hard failure instead of a silent skip, so this
@@ -80,7 +92,9 @@ test-verbose:
 
 # Run the FULL suite, including the DB-backed tests
 test-db:
-    TEST_DB_URL="{{ TEST_DB_URL }}" TEST_DB_REQUIRED=1 go test ./server/... -count=1
+    TEST_DB_URL="{{ TEST_DB_URL }}" TEST_DB_REQUIRED=1 \
+        GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
+        go test ./server/... -count=1
 
 # Formatting.
 # Scope is repo-wide: every *tracked* Go file except generated sources.

--- a/scripts/go-test-limit.sh
+++ b/scripts/go-test-limit.sh
@@ -54,6 +54,17 @@ probe_cache="${TMPDIR:-/tmp}/.go-test-limit-probe-$(id -u)"
 readonly probe_cache
 if [ -f "${probe_cache}" ] && [ -z "${GO_TEST_MEMORY_LIMIT_REPROBE:-}" ]; then
 	cap_ok="$(cat "${probe_cache}" 2>/dev/null || echo no)"
+	# The cache is keyed only by uid, so it can outlive the environment that
+	# wrote it: a container sharing this TMPDIR and uid would inherit the host's
+	# "yes" and then die on `systemd-run: command not found` (exit 127), failing
+	# a run that would otherwise pass. Re-check presence before trusting a cached
+	# "yes". `command -v` is a shell builtin — no fork, no D-Bus — so the point of
+	# the cache (not paying for the real probe every package) is unaffected.
+	# Deliberately not rewritten to "no": the verdict is still correct for the
+	# environment that wrote it, and this re-check is free on every run.
+	if [ "${cap_ok}" = "yes" ] && ! command -v systemd-run >/dev/null 2>&1; then
+		cap_ok=no
+	fi
 else
 	if probe_cgroup_cap; then cap_ok=yes; else cap_ok=no; fi
 	printf '%s' "${cap_ok}" >"${probe_cache}" 2>/dev/null || true

--- a/scripts/go-test-limit.sh
+++ b/scripts/go-test-limit.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# go-test-limit.sh — run a Go test binary inside a bounded cgroup.
+#
+# Wired in via GOFLAGS=-exec=..., so it applies to EVERY `go test` invocation
+# regardless of caller: `just test`, a raw `GOWORK=off go test ./server/...`,
+# or an agent's ad-hoc command. `go test -exec` wraps the TEST BINARY, so each
+# package gets its own cgroup and its own limit.
+#
+# WHY THIS EXISTS
+#
+# A runaway test used 11.6 GB and kept climbing. The kernel OOM killer picks
+# victims machine-wide by badness heuristic, so it did not kill the test — it
+# killed two unrelated developer sessions. The failure signal landed on the
+# wrong process and it took two crashes plus a manual `ps` to find the culprit.
+#
+# The point of this cap is NOT resource hygiene. It is deterministic, correctly
+# attributed failure: the offending test binary is the only process eligible to
+# die, and it dies with a message naming itself.
+#
+# MemorySwapMax=0 is load-bearing. With swap available the cgroup pushes pages
+# to swap and thrashes for minutes, degrading the whole machine, before anything
+# dies. Disabling swap for the scope makes the limit bite promptly.
+#
+# Tunables:
+#   GO_TEST_MEMORY_LIMIT=8G     raise/lower the per-test-binary cap
+#   GO_TEST_MEMORY_LIMIT=off    disable entirely (also: unset GOFLAGS)
+
+set -uo pipefail
+
+readonly LIMIT="${GO_TEST_MEMORY_LIMIT:-4G}"
+
+if [ "$#" -eq 0 ]; then
+	echo "go-test-limit.sh: no command given" >&2
+	exit 2
+fi
+
+# Escape hatch: run unwrapped.
+if [ "${LIMIT}" = "off" ] || [ "${LIMIT}" = "0" ]; then
+	exec "$@"
+fi
+
+# Detect, do not assume. systemd-run may be missing (containers, macOS), or
+# present but unusable (no user D-Bus session, cgroup v1, memory controller not
+# delegated to the user slice). Probe once and cache the verdict for the run so
+# a multi-package `go test ./...` pays for it a single time.
+probe_cgroup_cap() {
+	command -v systemd-run >/dev/null 2>&1 || return 1
+	systemd-run --user --scope -q \
+		-p MemoryMax="${LIMIT}" -p MemorySwapMax=0 \
+		-- true >/dev/null 2>&1
+}
+
+probe_cache="${TMPDIR:-/tmp}/.go-test-limit-probe-$(id -u)"
+readonly probe_cache
+if [ -f "${probe_cache}" ] && [ -z "${GO_TEST_MEMORY_LIMIT_REPROBE:-}" ]; then
+	cap_ok="$(cat "${probe_cache}" 2>/dev/null || echo no)"
+else
+	if probe_cgroup_cap; then cap_ok=yes; else cap_ok=no; fi
+	printf '%s' "${cap_ok}" >"${probe_cache}" 2>/dev/null || true
+fi
+
+# Graceful degradation: no usable cgroup support means run the tests anyway,
+# unwrapped. A missing cap must never fail a test run that would otherwise pass.
+if [ "${cap_ok}" != "yes" ]; then
+	exec "$@"
+fi
+
+# Backgrounded + `wait` so that when the cgroup OOM killer SIGKILLs the scope,
+# bash does not print its own "Killed  systemd-run --user --scope ..." line.
+# That message leaks the wrapper's internals into test output and buries the
+# attributed diagnostic below.
+systemd-run --user --scope -q \
+	-p MemoryMax="${LIMIT}" -p MemorySwapMax=0 \
+	-- "$@" &
+wait $! 2>/dev/null
+rc=$?
+
+# 137 = 128 + SIGKILL. Under MemoryMax with swap disabled, that is the cgroup
+# OOM killer reclaiming this scope — and only this scope.
+if [ "${rc}" -eq 137 ]; then
+	cat >&2 <<EOF
+
+*** go-test-limit: $(basename "${1}") exceeded the ${LIMIT} memory cap and was killed.
+*** Only this test binary was eligible to die; no other process was affected.
+*** This usually means unbounded growth in the test or the code under test.
+*** To raise it for one run: GO_TEST_MEMORY_LIMIT=8G go test ...
+*** To disable the cap:      GO_TEST_MEMORY_LIMIT=off go test ...
+
+EOF
+fi
+
+exit "${rc}"


### PR DESCRIPTION
## Summary

A runaway test in `server/` reached **11.6 GB RSS and was still climbing after 7 minutes**. The kernel OOM killer selects victims machine-wide by badness heuristic, so it did not kill the test — it killed two unrelated developer sessions. The failure signal landed on the wrong process, and finding the culprit took two crashes plus a manual `ps`.

**The value of this cap is not resource hygiene — it is deterministic, correctly attributed failure.** The offending test binary becomes the only process eligible to die, and it dies naming itself.

This PR is the guardrail only. The test that triggered it was a separate, already-fixed defect (see "Root cause" below).

## Mechanism

`scripts/go-test-limit.sh` runs a test binary inside a bounded cgroup:

```
systemd-run --user --scope -q -p MemoryMax=<N> -p MemorySwapMax=0 -- "$@"
```

Wired in via `GOFLAGS=-exec=...`, so it applies to **every** `go test` invocation regardless of caller — `just test`, a raw `GOWORK=off go test ./server/...`, or an agent's ad-hoc command. A justfile-only guardrail would not have caught this: the invocations that killed the sessions were raw `go test`, never `just test`.

Because `-exec` wraps the **test binary**, each package gets its own cgroup and its own limit — the granularity you want.

`MemorySwapMax=0` is load-bearing. With 15 GiB of swap the cgroup pushes pages out and thrashes for minutes, degrading the whole machine, before anything dies.

## Acceptance test — attribution, on the real `server.test` binary

A temporary test allocating 3 GiB was added to `server/`, run under a 2G cap, then removed:

```
*** go-test-limit: server.test exceeded the 2G memory cap and was killed.
*** Only this test binary was eligible to die; no other process was affected.
*** This usually means unbounded growth in the test or the code under test.
*** To raise it for one run: GO_TEST_MEMORY_LIMIT=8G go test ...
*** To disable the cap:      GO_TEST_MEMORY_LIMIT=off go test ...

FAIL	github.com/heroiclabs/nakama/v3/server	1.632s
exit=1
```

- Killed in **1.632s**, naming `server.test` and the failing package.
- Two bystander processes confirmed **alive** afterwards.
- The identical test with `GO_TEST_MEMORY_LIMIT=off` **passes in 2.021s** — so the cap is what fired, not the test.
- `free -h` went 16Gi used -> 13Gi used across the run; no machine-wide pressure event.

## Verified behaviours

| Property | Result |
|---|---|
| `-exec` composes through `GOFLAGS` for `go test` | Yes — wrapper observed running (`WRAPPER-INVOKED argv0=.../ok.test`) |
| `go build` / `go vet` / `go list` tolerate the flag | Yes — all exit 0, flag ignored |
| Relative `-exec` path | **Fails** — `fork/exec ./wrap.sh: no such file or directory`. `go test` runs the wrapper with cwd set to the package dir, so the path **must be absolute** |
| Non-executable wrapper (0644) | **Fails the run** — `fork/exec ...: permission denied`. Committed as `100755`; note `core.fileMode=false` in this repo, so the mode had to be set with `git update-index --chmod=+x` |
| Degradation with no `systemd-run` | Runs unwrapped, tests pass, exit 0 — a missing cap can never fail a run that would otherwise pass |
| stdout/stderr passthrough | Intact under `-v` |
| shellcheck | Clean (exit 0) |
| `go build ./server/...` / `go vet ./server/...` | Both exit 0 |
| Go files touched | None |

## Where it is wired

- **`just test`, `just test-verbose`, `just test-db`** — automatic, using `justfile_directory()` for a portable absolute path. Existing `GOFLAGS` is preserved, not clobbered.
- **Raw `go test`** — documented snippet for `.claude/settings.local.json`, which is where an absolute path belongs because settings.json `env` values are **not** interpolated (`${CLAUDE_PROJECT_DIR}` would be passed through literally) and `.claude/settings.local.json` is gitignored. One absolute path covers every worktree, since the wrapper only wraps whatever binary it is handed.

`GOMEMLIMIT` is deliberately **not** used. It is a soft limit: against a genuinely live heap Go keeps allocating and GC-thrashes to the timeout instead of failing. It would not have prevented this incident.

## Root cause of the 11.6 GB run — a TEST defect, not a production defect

Diagnosed while investigating; **already fixed independently** by the branch that owned it (`fix/concurrency-locking`, commit `cd26981ff`), so no test change is included here.

The fixture's simulated Discord gateway goroutine minted a **distinct guild ID every iteration** in an unbounded loop, and `discordgo.State.GuildAdd` retains every guild permanently (`discordgo@v0.29.0/state.go:89`). The reader's per-pass cost is `O(len(State.Guilds))`, so it fell further behind as the producer ran — a positive feedback loop with no fixed point.

Measured scaling of the original loop (bounded wall-clock windows, kernel `VmHWM`):

```
mode=unbounded secs= 2 reader_passes=267     state.Guilds=502239    peak_RSS_MB=706.9
mode=unbounded secs= 4 reader_passes=277     state.Guilds=635592    peak_RSS_MB=854.9
mode=unbounded secs= 8 reader_passes=308     state.Guilds=2140891   peak_RSS_MB=2752.6
mode=unbounded secs=16 reader_passes=362     state.Guilds=4358332   peak_RSS_MB=5922.1
--- after the fix (bounded guild pool) ---
mode=bounded   secs=16 reader_passes=9975241 state.Guilds=8         peak_RSS_MB=28.9
```

Memory scaled with **wall-clock time, not with any fixture constant** — there was no size to shrink. The tell is `reader_passes`: 267 -> 362 across 8x more time, i.e. the reader was asymptotically stalled and would essentially never finish its 3000 passes. That is why it was "still climbing after 7 minutes".

Production is not implicated: `snapshotStateGuilds` returns the live slice and allocates nothing, and real Discord state is bounded by guilds actually joined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
