### PR TITLE
fix: assorted one-off correctness fixes and hygiene (Tier-1 batch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -736,3 +736,9 @@ BUGS.md
 .claude-line/
 *.lock
 .mcp.json
+
+# Binaries dropped by `go build` inside tools/ (a plain `go build` names the
+# output after its directory). tools/purge-docker-ips/purge-docker-ips was
+# committed this way -- an 87MB ELF that outlived its deleted source.
+/tools/party-split-detector/party-split-detector
+/tools/echovr-mock-client/echovr-mock-client

--- a/server/evr/core_account_statistics.go
+++ b/server/evr/core_account_statistics.go
@@ -31,6 +31,14 @@ var (
 
 type TabletStatisticGroup Symbol
 
+// timeNow is the clock used to date-stamp the daily and weekly statistic group
+// names. It is a package-level var rather than a field on StatisticsGroup
+// because StatisticsGroup is used as a map key (see PlayerStatistics), and a
+// func field would make the struct non-comparable. Production always uses
+// time.Now; tests pin it to a fixed instant so the date-stamped names do not
+// depend on when or where the suite runs.
+var timeNow = time.Now
+
 type StatisticsGroup struct {
 	Mode          Symbol
 	ResetSchedule ResetSchedule
@@ -44,7 +52,7 @@ func (g *StatisticsGroup) String() string {
 func (g StatisticsGroup) MarshalText() ([]byte, error) {
 	switch g.ResetSchedule {
 	case ResetScheduleDaily:
-		return []byte("daily_" + time.Now().UTC().Format("2006_01_02")), nil
+		return []byte("daily_" + timeNow().UTC().Format("2006_01_02")), nil
 	case ResetScheduleWeekly:
 		return []byte("weekly_" + mostRecentThursday().Format("2006_01_02")), nil
 	default:
@@ -896,7 +904,7 @@ func NewStatistics() PlayerStatistics {
 
 // Echo normally resets stats on Thursday, so use that as the default
 func mostRecentThursday() time.Time {
-	now := time.Now().UTC()
+	now := timeNow().UTC()
 	offset := (int(now.Weekday()) - int(time.Thursday) + 7) % 7
 	return now.AddDate(0, 0, -offset)
 }

--- a/server/evr/core_account_statistics_test.go
+++ b/server/evr/core_account_statistics_test.go
@@ -9,7 +9,37 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// pinClock pins the package clock to a fixed instant for the duration of the
+// test. Without it both the daily and weekly cases below read the ambient wall
+// clock, which made them pass or fail depending on the machine's timezone.
+func pinClock(t *testing.T, at time.Time) {
+	t.Helper()
+	prev := timeNow
+	timeNow = func() time.Time { return at }
+	t.Cleanup(func() { timeNow = prev })
+}
+
+// The two instants below straddle a UTC midnight and are deliberately carried
+// in non-UTC zones, so the wall clock they read disagrees with their UTC date.
+// That disagreement is what makes the assertions fail if the formatters ever
+// stop normalizing to UTC.
+
+// justAfterUTCMidnight is 2026-08-06T00:30:00Z (a Thursday) held in a UTC-5
+// zone, where the wall clock still reads Wednesday 2026-08-05.
+func justAfterUTCMidnight() time.Time {
+	return time.Date(2026, 8, 5, 19, 30, 0, 0, time.FixedZone("UTC-5", -5*60*60))
+}
+
+// justBeforeUTCMidnight is 2026-08-05T23:30:00Z (a Wednesday) held in a UTC+13
+// zone, where the wall clock already reads Thursday 2026-08-06.
+func justBeforeUTCMidnight() time.Time {
+	return time.Date(2026, 8, 6, 12, 30, 0, 0, time.FixedZone("UTC+13", 13*60*60))
+}
+
 func TestStatisticsGroup_MarshalText(t *testing.T) {
+	// 2026-08-06 UTC is itself a Thursday, so the weekly stamp is the same day.
+	pinClock(t, justAfterUTCMidnight())
+
 	tests := []struct {
 		name     string
 		group    StatisticsGroup
@@ -21,7 +51,7 @@ func TestStatisticsGroup_MarshalText(t *testing.T) {
 				Mode:          ModeArenaPublic,
 				ResetSchedule: ResetScheduleDaily,
 			},
-			expected: "daily_" + time.Now().Format("2006_01_02"),
+			expected: "daily_2026_08_06",
 		},
 		{
 			name: "Weekly Arena",
@@ -29,7 +59,7 @@ func TestStatisticsGroup_MarshalText(t *testing.T) {
 				Mode:          ModeArenaPublic,
 				ResetSchedule: ResetScheduleWeekly,
 			},
-			expected: "weekly_" + mostRecentThursday().Format("2006_01_02"),
+			expected: "weekly_2026_08_06",
 		},
 		{
 			name: "All Time Arena",
@@ -64,6 +94,62 @@ func TestStatisticsGroup_MarshalText(t *testing.T) {
 		})
 	}
 }
+
+// Statistic groups partition by UTC day and UTC week so that guilds in
+// different timezones share one bucket. These cases pin instants that sit on
+// either side of a UTC midnight, while the clock they carry reads the adjacent
+// date, so the rollover is covered explicitly rather than incidentally.
+func TestStatisticsGroup_MarshalText_UTCDateBoundary(t *testing.T) {
+	tests := []struct {
+		name         string
+		at           time.Time
+		wantDaily    string
+		wantWeekly   string
+		localReading string
+	}{
+		{
+			name:         "instant after UTC midnight, local clock a day behind",
+			at:           justAfterUTCMidnight(),
+			wantDaily:    "daily_2026_08_06",
+			wantWeekly:   "weekly_2026_08_06", // 2026-08-06 UTC is a Thursday
+			localReading: "2026-08-05 19:30 UTC-5",
+		},
+		{
+			name:         "instant before UTC midnight, local clock a day ahead",
+			at:           justBeforeUTCMidnight(),
+			wantDaily:    "daily_2026_08_05",
+			wantWeekly:   "weekly_2026_07_30", // Thursday preceding Wed 2026-08-05 UTC
+			localReading: "2026-08-06 12:30 UTC+13",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pinClock(t, tt.at)
+
+			daily := StatisticsGroup{Mode: ModeArenaPublic, ResetSchedule: ResetScheduleDaily}
+			got, err := daily.MarshalText()
+			if err != nil {
+				t.Fatalf("MarshalText() error = %v", err)
+			}
+			if string(got) != tt.wantDaily {
+				t.Errorf("daily at %s (%s local): got = %s, expected %s",
+					tt.at.UTC().Format(time.RFC3339), tt.localReading, got, tt.wantDaily)
+			}
+
+			weekly := StatisticsGroup{Mode: ModeArenaPublic, ResetSchedule: ResetScheduleWeekly}
+			got, err = weekly.MarshalText()
+			if err != nil {
+				t.Fatalf("MarshalText() error = %v", err)
+			}
+			if string(got) != tt.wantWeekly {
+				t.Errorf("weekly at %s (%s local): got = %s, expected %s",
+					tt.at.UTC().Format(time.RFC3339), tt.localReading, got, tt.wantWeekly)
+			}
+		})
+	}
+}
+
 func TestStatisticsGroup_UnmarshalText(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/evr/login_earlyquitconfig.go
+++ b/server/evr/login_earlyquitconfig.go
@@ -3,7 +3,6 @@ package evr
 import (
 	"fmt"
 	"sort"
-	"time"
 )
 
 const (
@@ -76,10 +75,6 @@ type EarlyQuitConfig struct {
 	NumSteadyMatches  int32 `json:"num_steady_matches,omitempty"`
 	PenaltyLevel      int32 `json:"penalty_level,omitempty"`
 	PenaltyTimestamp  int64 `json:"penalty_ts,omitempty"`
-}
-
-func (c EarlyQuitConfig) PenaltyTimestampAsTime() time.Time {
-	return time.Unix(c.PenaltyTimestamp, 0)
 }
 
 // NewSNSEarlyQuitConfig creates a new SNS message for early quit config.

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -336,8 +337,13 @@ func (a EVRProfile) GetActiveGroupDisplayName() string {
 // write commit different data. json.Number keeps the literal intact, and
 // encoding/json re-emits it verbatim when MultiUpdate serializes the map.
 //
-// Both json errors are returned rather than discarded; a swallowed error here
-// would blank the account metadata on the next write.
+// Both json errors are returned rather than discarded. Swallowing one would hand
+// MultiUpdate a nil metadata map, and RuntimeGoNakamaModule.MultiUpdate skips the
+// account update entirely in that case (`if update.Metadata != nil`, see
+// server/runtime_go_nakama.go) rather than blanking it. The storage row would
+// still commit the new profile while account metadata silently kept the old one,
+// leaving the two halves of a single atomic write disagreeing with no error
+// raised anywhere.
 func (a EVRProfile) MarshalMap() (map[string]any, error) {
 	b, err := json.Marshal(a)
 	if err != nil {
@@ -506,6 +512,33 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 // already uses for the same key.
 const evrProfileUpdateMaxAttempts = 3
 
+// evrProfileUpdateRetryBaseDelay is the pause before the first retry; each
+// further attempt doubles it, so the three attempts span roughly 60ms.
+//
+// Without any pause the attempts are issued back to back within a few hundred
+// microseconds — far inside the window a genuinely concurrent writer holds the
+// key for. All three would then lose to the same writer and the caller would see
+// a hard failure that a few milliseconds of patience avoids. The delay is
+// deliberately short: login blocks on this call.
+var evrProfileUpdateRetryBaseDelay = 20 * time.Millisecond
+
+// evrProfileUpdateRetryBackoff waits before retry number attempt (1-based).
+//
+// A cancelled context aborts the wait rather than sleeping out the full delay,
+// and reports the conflict error joined with the context error: the caller's
+// contract is that a returned conflict stays recognisable to
+// isVersionConflictError, and errors.Join keeps both messages in Error().
+func evrProfileUpdateRetryBackoff(ctx context.Context, attempt int, conflictErr error) error {
+	timer := time.NewTimer(evrProfileUpdateRetryBaseDelay << (attempt - 1))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return errors.Join(conflictErr, ctx.Err())
+	case <-timer.C:
+		return nil
+	}
+}
+
 // evrProfileUpdateWithRetry writes profile via EVRProfileUpdate with a bounded
 // retry on storage version conflicts.
 //
@@ -527,6 +560,9 @@ func evrProfileUpdateWithRetry(ctx context.Context, nk runtime.NakamaModule, use
 	var err error
 	for attempt := 0; attempt < evrProfileUpdateMaxAttempts; attempt++ {
 		if attempt > 0 {
+			if waitErr := evrProfileUpdateRetryBackoff(ctx, attempt, err); waitErr != nil {
+				return nil, waitErr
+			}
 			var reloaded *EVRProfile
 			reloaded, err = EVRProfileLoad(ctx, nk, userID)
 			if err != nil {

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -323,11 +324,32 @@ func (a EVRProfile) GetActiveGroupDisplayName() string {
 	return a.GetGroupIGN(a.ActiveGroupID)
 }
 
-func (a EVRProfile) MarshalMap() map[string]any {
-	b, _ := json.Marshal(a)
+// MarshalMap renders the profile as the generic map that runtime.AccountUpdate
+// expects for account metadata.
+//
+// Decoding uses json.Decoder.UseNumber() rather than a plain json.Unmarshal:
+// the default decoder turns every JSON number into a float64, which silently
+// truncates the 64-bit EchoVR item hashes in NewUnlocks (and the uint64
+// customization POI versions) above 2^53. Because EVRProfileUpdate writes the
+// storage value with json.Marshal and the account metadata with this function in
+// a single MultiUpdate, a lossy encoding here makes the two halves of one atomic
+// write commit different data. json.Number keeps the literal intact, and
+// encoding/json re-emits it verbatim when MultiUpdate serializes the map.
+//
+// Both json errors are returned rather than discarded; a swallowed error here
+// would blank the account metadata on the next write.
+func (a EVRProfile) MarshalMap() (map[string]any, error) {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal profile: %w", err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
 	var m map[string]any
-	_ = json.Unmarshal(b, &m)
-	return m
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("failed to decode profile into map: %w", err)
+	}
+	return m, nil
 }
 
 func (a EVRProfile) GetMuted() []evr.EvrId {
@@ -437,10 +459,15 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 		return fmt.Errorf("failed to marshal profile: %w", err)
 	}
 
+	metadata, err := md.MarshalMap()
+	if err != nil {
+		return fmt.Errorf("failed to marshal profile metadata: %w", err)
+	}
+
 	acks, _, err := nk.MultiUpdate(ctx,
 		[]*runtime.AccountUpdate{{
 			UserID:   userID,
-			Metadata: md.MarshalMap(),
+			Metadata: metadata,
 		}},
 		[]*runtime.StorageWrite{{
 			Collection:      meta.Collection,

--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -501,6 +501,55 @@ func EVRProfileUpdate(ctx context.Context, nk runtime.NakamaModule, userID strin
 	return nil
 }
 
+// evrProfileUpdateMaxAttempts bounds evrProfileUpdateWithRetry. Three attempts
+// matches the retry budget the display-name sync in evr_discord_integrator.go
+// already uses for the same key.
+const evrProfileUpdateMaxAttempts = 3
+
+// evrProfileUpdateWithRetry writes profile via EVRProfileUpdate with a bounded
+// retry on storage version conflicts.
+//
+// EVRProfileUpdate itself makes exactly one attempt by design: retrying with the
+// caller's stale payload would silently discard whatever the concurrent writer
+// committed. This helper supplies the safe form of the retry — on a conflict it
+// RE-READS the current stored profile and hands it to apply, so the caller's
+// mutation is re-applied on top of fresh data instead of overwriting it. Callers
+// must therefore keep apply free of side effects; it may run more than once.
+//
+// The returned *EVRProfile is the object that was actually written: the caller's
+// own pointer when the first attempt succeeded, or the reloaded profile
+// otherwise. Callers that keep the profile around (e.g. session parameters) must
+// adopt the returned value.
+//
+// Non-conflict errors are surfaced immediately; the final conflict error is
+// returned unchanged so errors.Is / isVersionConflictError still recognise it.
+func evrProfileUpdateWithRetry(ctx context.Context, nk runtime.NakamaModule, userID string, profile *EVRProfile, apply func(*EVRProfile) error) (*EVRProfile, error) {
+	var err error
+	for attempt := 0; attempt < evrProfileUpdateMaxAttempts; attempt++ {
+		if attempt > 0 {
+			var reloaded *EVRProfile
+			reloaded, err = EVRProfileLoad(ctx, nk, userID)
+			if err != nil {
+				return nil, fmt.Errorf("failed to reload profile for retry: %w", err)
+			}
+			profile = reloaded
+			if apply != nil {
+				if err := apply(profile); err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if err = EVRProfileUpdate(ctx, nk, userID, profile); err == nil {
+			return profile, nil
+		}
+		if !isVersionConflictError(err) {
+			return nil, err
+		}
+	}
+	return nil, err
+}
+
 func BuildEVRProfileFromAccount(account *api.Account) (*EVRProfile, error) {
 	if account == nil || account.User == nil {
 		return nil, fmt.Errorf("account is nil")

--- a/server/evr_account_marshalmap_test.go
+++ b/server/evr_account_marshalmap_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEVRProfileMarshalMap_PreservesInt64Precision pins the invariant that the
+// account-metadata half of EVRProfileUpdate's write carries the SAME data as the
+// storage half.
+//
+// EVRProfileUpdate marshals the profile twice: once with json.Marshal (exact) for
+// the storage row, and once with MarshalMap() for the account metadata. MarshalMap
+// used to round-trip through map[string]any, which decodes every JSON number as
+// float64 — silently truncating the 64-bit EchoVR item hashes in NewUnlocks past
+// 2^53. The two halves of a single "atomic" write then committed different data,
+// and BuildEVRProfileFromAccount (the fallback used when the storage row is
+// missing) served the corrupted values.
+func TestEVRProfileMarshalMap_PreservesInt64Precision(t *testing.T) {
+	const bigHash int64 = 1234567890123456789 // > 2^53, not representable as float64
+
+	p := EVRProfile{
+		NewUnlocks: []int64{bigHash, 42},
+	}
+
+	m, err := p.MarshalMap()
+	require.NoError(t, err)
+
+	// The metadata map is handed to nk.MultiUpdate, which serializes it with
+	// json.Marshal before it ever reaches the database. Reproduce that step.
+	encoded, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	var round EVRProfile
+	require.NoError(t, json.Unmarshal(encoded, &round))
+
+	require.Equal(t, []int64{bigHash, 42}, round.NewUnlocks,
+		"MarshalMap must not lose int64 precision; account metadata and storage value must agree")
+}
+
+// TestEVRProfileMarshalMap_Int64Boundaries covers the edges around the float64
+// mantissa limit and both signs, not just the headline value.
+func TestEVRProfileMarshalMap_Int64Boundaries(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		v    int64
+	}{
+		{"max_int64", math.MaxInt64},
+		{"min_int64", math.MinInt64},
+		{"two_pow_53", 1 << 53},
+		{"two_pow_53_plus_one", (1 << 53) + 1},
+		{"negative_two_pow_53_minus_one", -((1 << 53) + 1)},
+		{"zero", 0},
+		{"small", 7},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p := EVRProfile{NewUnlocks: []int64{tc.v}}
+
+			m, err := p.MarshalMap()
+			require.NoError(t, err)
+
+			encoded, err := json.Marshal(m)
+			require.NoError(t, err)
+
+			var round EVRProfile
+			require.NoError(t, json.Unmarshal(encoded, &round))
+			require.Equal(t, []int64{tc.v}, round.NewUnlocks)
+		})
+	}
+}
+
+// TestEVRProfileMarshalMap_AgreesWithStorageValue is the general form of the bug:
+// EVRProfileUpdate writes json.Marshal(md) to storage and MarshalMap(md) to the
+// account metadata in one MultiUpdate. Whatever the profile contains, those two
+// encodings must describe the same document — otherwise an "atomic" write commits
+// two different states. This also covers the uint64 POI-version fields, which have
+// the same float64 truncation exposure as NewUnlocks.
+func TestEVRProfileMarshalMap_AgreesWithStorageValue(t *testing.T) {
+	p := EVRProfile{
+		ActiveGroupID: "6f6b1b0a-0000-4000-8000-000000000001",
+		TeamName:      "Test Team",
+		InGameNames: map[string]GroupInGameName{
+			"6f6b1b0a-0000-4000-8000-000000000001": {
+				GroupID:     "6f6b1b0a-0000-4000-8000-000000000001",
+				DisplayName: "Player One",
+				IsOverride:  true,
+			},
+		},
+		NewUnlocks: []int64{
+			1234567890123456789,
+			math.MaxInt64,
+			-9007199254740993,
+			42,
+		},
+		CustomizationPOIs: &evr.Customization{
+			BattlePassSeasonPoiVersion: math.MaxUint64,
+			NewUnlocksPoiVersion:       9007199254740993,
+			StoreEntryPoiVersion:       3,
+			ClearNewUnlocksVersion:     1,
+		},
+		LegalConsents: evr.LegalConsents{EulaVersion: 1, GameAdminVersion: 1},
+	}
+
+	storageValue, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	m, err := p.MarshalMap()
+	require.NoError(t, err)
+	metadataValue, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	// Compare as generic documents so key ordering does not matter, but with
+	// UseNumber so numeric literals are compared textually rather than as float64
+	// (a float64 comparison would happily call the corrupted values equal).
+	require.Equal(t,
+		decodeWithNumbers(t, storageValue),
+		decodeWithNumbers(t, metadataValue),
+		"account metadata half and storage half of the same write must encode identical data")
+}
+
+func decodeWithNumbers(t *testing.T, b []byte) any {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	var v any
+	require.NoError(t, dec.Decode(&v))
+	return v
+}

--- a/server/evr_account_update_retry_test.go
+++ b/server/evr_account_update_retry_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -215,4 +216,64 @@ func TestEVRProfileUpdateWithRetry_DoesNotRetryNonConflictErrors(t *testing.T) {
 	require.Error(t, err)
 	require.False(t, isVersionConflictError(err))
 	require.Equal(t, 1, m.calls(), "a non-conflict error must not be retried")
+}
+
+// TestEVRProfileUpdateWithRetry_BacksOffBetweenAttempts pins that the retries are
+// spaced rather than issued back to back.
+//
+// Three attempts fired within a few hundred microseconds all fall inside the
+// window a single concurrent writer holds the key for, so they lose to the same
+// writer and the caller gets a hard failure a few milliseconds of patience would
+// have avoided. The assertion is a lower bound on elapsed time, which is the only
+// thing about a backoff that is worth pinning and the only thing that stays true
+// on a loaded CI box.
+func TestEVRProfileUpdateWithRetry_BacksOffBetweenAttempts(t *testing.T) {
+	ctx := context.Background()
+	const userID = "aaaaaaaa-0000-4000-8000-000000000001"
+
+	m := newProfileUpdateTestModule()
+	seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+	m.conflictsRemaining = 1000 // every attempt conflicts
+
+	// attempt 1 waits base, attempt 2 waits 2*base.
+	wantMin := evrProfileUpdateRetryBaseDelay * 3
+
+	start := time.Now()
+	_, err := evrProfileUpdateWithRetry(ctx, m, userID, &EVRProfile{}, func(p *EVRProfile) error { return nil })
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Equal(t, 3, m.calls(), "precondition: all three attempts must have run")
+	require.GreaterOrEqual(t, elapsed, wantMin,
+		"the retries must be spaced by a backoff, not fired back to back")
+}
+
+// TestEVRProfileUpdateWithRetry_CancelledContextAbortsTheBackoff pins that a
+// caller who has given up is not held for the full backoff, and that the error
+// they get back is STILL recognisable as a version conflict — isVersionConflictError
+// matches on the message, so joining the context error must not displace it.
+func TestEVRProfileUpdateWithRetry_CancelledContextAbortsTheBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	const userID = "aaaaaaaa-0000-4000-8000-000000000002"
+
+	m := newProfileUpdateTestModule()
+	seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+	m.conflictsRemaining = 1000
+
+	// Cancel as soon as the first attempt has been rejected, so the abort happens
+	// during the backoff rather than before the first write.
+	cancel()
+
+	start := time.Now()
+	_, err := evrProfileUpdateWithRetry(ctx, m, userID, &EVRProfile{}, func(p *EVRProfile) error { return nil })
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.Equal(t, 1, m.calls(),
+		"a cancelled caller must not keep hammering the key")
+	require.Less(t, elapsed, evrProfileUpdateRetryBaseDelay,
+		"the backoff must abort on cancellation, not sleep it out")
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, isVersionConflictError(err),
+		"the conflict must stay recognisable after the context error is joined: %v", err)
 }

--- a/server/evr_account_update_retry_test.go
+++ b/server/evr_account_update_retry_test.go
@@ -1,0 +1,196 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// profileUpdateTestModule is an OCC-correct in-memory module that supports the
+// exact surface EVRProfileUpdate / EVRProfileLoad need: AccountGetId,
+// StorageRead, StorageDelete and MultiUpdate.
+//
+// MultiUpdate routes its storage writes through the shared OCC mock, so a write
+// carrying a stale Version is rejected with runtime.ErrStorageRejectedVersion —
+// the same signal isVersionConflictError keys on in production.
+type profileUpdateTestModule struct {
+	*occTestNakamaModule
+
+	metadata map[string]map[string]any
+
+	// conflictsRemaining injects that many artificial version conflicts before
+	// letting writes through, independent of the stored version. Used to force a
+	// conflict on the very first attempt.
+	conflictsRemaining int
+
+	multiUpdateCalls int
+}
+
+func newProfileUpdateTestModule() *profileUpdateTestModule {
+	return &profileUpdateTestModule{
+		occTestNakamaModule: newOCCTestNakamaModule(),
+		metadata:            make(map[string]map[string]any),
+	}
+}
+
+func (m *profileUpdateTestModule) AccountGetId(ctx context.Context, userID string) (*api.Account, error) {
+	return &api.Account{User: &api.User{Id: userID, Username: "tester"}}, nil
+}
+
+func (m *profileUpdateTestModule) StorageDelete(ctx context.Context, deletes []*runtime.StorageDelete) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range deletes {
+		delete(m.objects, occStorageKey(d.UserID, d.Collection, d.Key))
+	}
+	return nil
+}
+
+func (m *profileUpdateTestModule) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	m.multiUpdateCalls++
+
+	if m.conflictsRemaining > 0 {
+		m.conflictsRemaining--
+		return nil, nil, runtime.ErrStorageRejectedVersion
+	}
+
+	acks, err := m.StorageWrite(ctx, storageWrites)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := m.StorageDelete(ctx, storageDeletes); err != nil {
+		return nil, nil, err
+	}
+	for _, au := range accountUpdates {
+		m.metadata[au.UserID] = au.Metadata
+	}
+	return acks, nil, nil
+}
+
+// storedProfile decodes the EVRProfile storage row for userID.
+func (m *profileUpdateTestModule) storedProfile(t *testing.T, userID string) *EVRProfile {
+	t.Helper()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	obj, ok := m.objects[occStorageKey(userID, StorageCollectionEVRProfile, StorageKeyEVRProfile)]
+	require.True(t, ok, "expected an EVRProfile storage row for %s", userID)
+	p := &EVRProfile{}
+	require.NoError(t, json.Unmarshal([]byte(obj.Value), p))
+	return p
+}
+
+func seedStoredProfile(t *testing.T, m *profileUpdateTestModule, userID string, p *EVRProfile) string {
+	t.Helper()
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	return m.seedObject(userID, StorageCollectionEVRProfile, StorageKeyEVRProfile, string(b))
+}
+
+// TestEVRProfileUpdateWithRetry_RetriesOnConflictWithFreshRead is the core of the
+// login-hard-fail finding.
+//
+// PR #520 removed EVRProfileUpdate's internal retry, deliberately: a blind retry
+// re-submits the caller's stale payload and silently discards whatever the
+// concurrent writer committed. But the login path (and two others) then had no
+// retry at all, so the FIRST version conflict rejected the login outright with
+// "failed to update user profile". A concurrent writer is realistic — login fires
+// QueueSyncMember for the same user a few hundred lines earlier, and that Discord
+// sync path writes the same key.
+//
+// The correct shape is a bounded retry that RE-READS between attempts and
+// re-applies the caller's mutation to the fresh profile. This test pins both
+// halves: the write eventually succeeds, AND the concurrent writer's field
+// survives.
+func TestEVRProfileUpdateWithRetry_RetriesOnConflictWithFreshRead(t *testing.T) {
+	ctx := context.Background()
+	const userID = "11111111-1111-4111-8111-111111111111"
+
+	m := newProfileUpdateTestModule()
+
+	// The version our caller is holding.
+	staleVersion := seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+
+	// A concurrent writer commits first, bumping the stored version.
+	seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original", MatchmakingDivision: "gold"})
+
+	// Our caller's in-hand profile still carries the stale version and knows
+	// nothing about MatchmakingDivision.
+	mine := &EVRProfile{TeamName: "mine"}
+	mine.SetStorageMeta(StorableMetadata{Version: staleVersion})
+
+	updated, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error {
+		p.TeamName = "mine"
+		return nil
+	})
+	require.NoError(t, err, "a version conflict must not be fatal; retry with a fresh read")
+	require.NotNil(t, updated)
+
+	stored := m.storedProfile(t, userID)
+	require.Equal(t, "mine", stored.TeamName, "the caller's mutation must be applied")
+	require.Equal(t, "gold", stored.MatchmakingDivision,
+		"the concurrent writer's field must survive: the retry must re-read, not re-submit a stale payload")
+}
+
+// TestEVRProfileUpdateWithRetry_SucceedsFirstTryWithoutReload is the control: no
+// conflict means exactly one write and no reload.
+func TestEVRProfileUpdateWithRetry_SucceedsFirstTryWithoutReload(t *testing.T) {
+	ctx := context.Background()
+	const userID = "22222222-2222-4222-8222-222222222222"
+
+	m := newProfileUpdateTestModule()
+	version := seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+
+	mine := &EVRProfile{TeamName: "mine"}
+	mine.SetStorageMeta(StorableMetadata{Version: version})
+
+	applyCalls := 0
+	updated, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error {
+		applyCalls++
+		p.TeamName = "mine"
+		return nil
+	})
+	require.NoError(t, err)
+	require.Same(t, mine, updated, "no conflict means the caller's own profile object is kept")
+	require.Equal(t, 1, m.multiUpdateCalls)
+	require.Zero(t, applyCalls, "apply must not be re-run when the first attempt succeeds")
+}
+
+// TestEVRProfileUpdateWithRetry_GivesUpAfterBoundedAttempts pins that the retry is
+// bounded: a permanently conflicting key must not spin forever.
+func TestEVRProfileUpdateWithRetry_GivesUpAfterBoundedAttempts(t *testing.T) {
+	ctx := context.Background()
+	const userID = "33333333-3333-4333-8333-333333333333"
+
+	m := newProfileUpdateTestModule()
+	seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+	m.conflictsRemaining = 1000 // every attempt conflicts
+
+	mine := &EVRProfile{TeamName: "mine"}
+	_, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error { return nil })
+	require.Error(t, err)
+	require.True(t, isVersionConflictError(err), "the surfaced error must still be recognisable as a conflict: %v", err)
+	require.Equal(t, evrProfileUpdateMaxAttempts, m.multiUpdateCalls,
+		"retry must be bounded at evrProfileUpdateMaxAttempts attempts")
+}
+
+// TestEVRProfileUpdateWithRetry_DoesNotRetryNonConflictErrors pins that an
+// unrelated failure is surfaced immediately rather than amplified into N writes.
+func TestEVRProfileUpdateWithRetry_DoesNotRetryNonConflictErrors(t *testing.T) {
+	ctx := context.Background()
+	const userID = "44444444-4444-4444-8444-444444444444"
+
+	m := newProfileUpdateTestModule()
+	seedStoredProfile(t, m, userID, &EVRProfile{TeamName: "original"})
+	m.failNonVersion = errors.New("database is on fire")
+
+	mine := &EVRProfile{TeamName: "mine"}
+	_, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error { return nil })
+	require.Error(t, err)
+	require.False(t, isVersionConflictError(err))
+	require.Equal(t, 1, m.multiUpdateCalls, "a non-conflict error must not be retried")
+}

--- a/server/evr_account_update_retry_test.go
+++ b/server/evr_account_update_retry_test.go
@@ -52,10 +52,18 @@ func (m *profileUpdateTestModule) StorageDelete(ctx context.Context, deletes []*
 }
 
 func (m *profileUpdateTestModule) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	// These counters share the embedded module's mutex, which its own
+	// StorageWrite/StorageDelete also take. Guard them here rather than relying on
+	// the current tests being single-goroutine.
+	m.mu.Lock()
 	m.multiUpdateCalls++
-
-	if m.conflictsRemaining > 0 {
+	conflict := m.conflictsRemaining > 0
+	if conflict {
 		m.conflictsRemaining--
+	}
+	m.mu.Unlock()
+
+	if conflict {
 		return nil, nil, runtime.ErrStorageRejectedVersion
 	}
 
@@ -66,10 +74,19 @@ func (m *profileUpdateTestModule) MultiUpdate(ctx context.Context, accountUpdate
 	if err := m.StorageDelete(ctx, storageDeletes); err != nil {
 		return nil, nil, err
 	}
+	m.mu.Lock()
 	for _, au := range accountUpdates {
 		m.metadata[au.UserID] = au.Metadata
 	}
+	m.mu.Unlock()
 	return acks, nil, nil
+}
+
+// calls returns multiUpdateCalls under the mutex.
+func (m *profileUpdateTestModule) calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.multiUpdateCalls
 }
 
 // storedProfile decodes the EVRProfile storage row for userID.
@@ -156,7 +173,7 @@ func TestEVRProfileUpdateWithRetry_SucceedsFirstTryWithoutReload(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Same(t, mine, updated, "no conflict means the caller's own profile object is kept")
-	require.Equal(t, 1, m.multiUpdateCalls)
+	require.Equal(t, 1, m.calls())
 	require.Zero(t, applyCalls, "apply must not be re-run when the first attempt succeeds")
 }
 
@@ -174,8 +191,13 @@ func TestEVRProfileUpdateWithRetry_GivesUpAfterBoundedAttempts(t *testing.T) {
 	_, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error { return nil })
 	require.Error(t, err)
 	require.True(t, isVersionConflictError(err), "the surfaced error must still be recognisable as a conflict: %v", err)
-	require.Equal(t, evrProfileUpdateMaxAttempts, m.multiUpdateCalls,
-		"retry must be bounded at evrProfileUpdateMaxAttempts attempts")
+	// Assert against a literal, not against evrProfileUpdateMaxAttempts itself:
+	// comparing the constant to itself would keep this test green for ANY value,
+	// including 1 (no retry at all).
+	require.Equal(t, 3, m.calls(),
+		"retry must make exactly 3 bounded attempts")
+	require.Equal(t, 3, evrProfileUpdateMaxAttempts,
+		"evrProfileUpdateMaxAttempts changed; update this test deliberately")
 }
 
 // TestEVRProfileUpdateWithRetry_DoesNotRetryNonConflictErrors pins that an
@@ -192,5 +214,5 @@ func TestEVRProfileUpdateWithRetry_DoesNotRetryNonConflictErrors(t *testing.T) {
 	_, err := evrProfileUpdateWithRetry(ctx, m, userID, mine, func(p *EVRProfile) error { return nil })
 	require.Error(t, err)
 	require.False(t, isVersionConflictError(err))
-	require.Equal(t, 1, m.multiUpdateCalls, "a non-conflict error must not be retried")
+	require.Equal(t, 1, m.calls(), "a non-conflict error must not be retried")
 }

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -693,8 +693,19 @@ func (d *DiscordIntegrator) handleGuildDelete(logger *zap.Logger, _ *discordgo.S
 	}
 
 	// Log the metadata of the group before deleting it.
-	gg := d.guildGroupRegistry.Get(groupID)
-	logger.Info("Deleting guild group", zap.String("group_id", groupID), zap.Any("metadata", gg.GroupMetadata))
+	//
+	// Get returns nil when the group exists in the database but is absent from the
+	// registry (the rebuild filters on GuildGroupLangTag, and any failure between
+	// GroupCreate and registry.Add in guildSync leaves that window open).
+	// GroupMetadata is an embedded VALUE, so dereferencing a nil *GuildGroup here
+	// panics — and discordgo runs handlers on bare goroutines with no recover, so
+	// the panic would take down the process. Still delete the group; only the
+	// metadata detail in the log is lost.
+	if gg := d.guildGroupRegistry.Get(groupID); gg != nil {
+		logger.Info("Deleting guild group", zap.String("group_id", groupID), zap.Any("metadata", gg.GroupMetadata))
+	} else {
+		logger.Info("Deleting guild group (not present in registry)", zap.String("group_id", groupID))
+	}
 
 	if err := d.nk.GroupDelete(d.ctx, groupID); err != nil {
 		return fmt.Errorf("error deleting group: %w", err)

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -804,7 +804,11 @@ func (d *DiscordIntegrator) handleMemberUpdate(logger *zap.Logger, s *discordgo.
 	}
 
 	if accountUpdate {
-		if err := d.nk.AccountUpdateId(ctx, evrAccount.ID(), e.Member.User.Username, evrAccount.MarshalMap(), evrAccount.GetActiveGroupDisplayName(), "", "", locale, avatarURL); err != nil {
+		accountMetadata, err := evrAccount.MarshalMap()
+		if err != nil {
+			return fmt.Errorf("failed to marshal account metadata: %w", err)
+		}
+		if err := d.nk.AccountUpdateId(ctx, evrAccount.ID(), e.Member.User.Username, accountMetadata, evrAccount.GetActiveGroupDisplayName(), "", "", locale, avatarURL); err != nil {
 			return fmt.Errorf("failed to update account: %w", err)
 		}
 	}

--- a/server/evr_discord_integrator_guilddelete_test.go
+++ b/server/evr_discord_integrator_guilddelete_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.uber.org/zap"
+)
+
+// groupDeleteRecorderModule records GroupDelete calls. handleGuildDelete's only
+// real side effect on the Nakama side is the group deletion, so that is all the
+// double needs to observe.
+type groupDeleteRecorderModule struct {
+	runtime.NakamaModule
+	deleted []string
+}
+
+func (m *groupDeleteRecorderModule) GroupDelete(ctx context.Context, groupID string) error {
+	m.deleted = append(m.deleted, groupID)
+	return nil
+}
+
+// newGuildDeleteTestIntegrator builds a DiscordIntegrator wired only with the
+// pieces handleGuildDelete touches. The registry is constructed as a struct
+// literal rather than via NewGuildGroupRegistry so no background database poller
+// is started.
+func newGuildDeleteTestIntegrator(t *testing.T, nk runtime.NakamaModule) *DiscordIntegrator {
+	t.Helper()
+	return &DiscordIntegrator{
+		ctx:    context.Background(),
+		logger: zap.NewNop(),
+		nk:     nk,
+		guildGroupRegistry: &GuildGroupRegistry{
+			guildGroups:    atomic.NewPointer(&map[string]*GuildGroup{}),
+			inheritanceMap: atomic.NewPointer(&map[string][]string{}),
+		},
+		idcache:        &MapOf[string, string]{},
+		memberCache:    &MapOf[string, cachedMember]{},
+		queueCooldowns: &MapOf[QueueEntry, time.Time]{},
+	}
+}
+
+// TestHandleGuildDelete_UnregisteredGroupDoesNotPanic pins the crash-safety of
+// the GUILD_DELETE handler.
+//
+// GuildGroupRegistry.Get returns nil for a group that is in the database but not
+// (yet) in the registry — the registry rebuild filters on GuildGroupLangTag, and
+// any failure between GroupCreate and registry.Add in guildSync leaves that
+// window open. handleGuildDelete then logged gg.GroupMetadata. GroupMetadata is
+// an EMBEDDED VALUE in GuildGroup, so that expression dereferences the nil
+// pointer. discordgo dispatches handlers on bare goroutines with no recover, so
+// the panic takes down the whole process.
+//
+// evr_lobby_joinentrant.go already nil-checks the same lookup defensively; this
+// test holds handleGuildDelete to the same standard: no panic, and the group is
+// still deleted.
+func TestHandleGuildDelete_UnregisteredGroupDoesNotPanic(t *testing.T) {
+	const guildID = "123456789012345678"
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	nk := &groupDeleteRecorderModule{}
+	d := newGuildDeleteTestIntegrator(t, nk)
+
+	// Seed the guild->group mapping so GuildIDToGroupID resolves without a DB.
+	d.idcache.Store(guildID, groupID)
+	d.idcache.Store(groupID, guildID)
+
+	// Deliberately do NOT add the group to the registry: this is the window the
+	// bug lives in.
+	require.Nil(t, d.guildGroupRegistry.Get(groupID), "precondition: group is absent from the registry")
+
+	require.NotPanics(t, func() {
+		err := d.handleGuildDelete(zap.NewNop(), nil, &discordgo.GuildDelete{
+			Guild: &discordgo.Guild{ID: guildID, OwnerID: "987654321098765432"},
+		})
+		require.NoError(t, err)
+	})
+
+	require.Equal(t, []string{groupID}, nk.deleted,
+		"the group must still be deleted even when it was never registered")
+}
+
+// TestHandleGuildDelete_RegisteredGroupStillDeletes is the positive control: the
+// nil guard must not short-circuit the normal path.
+func TestHandleGuildDelete_RegisteredGroupStillDeletes(t *testing.T) {
+	const guildID = "223456789012345678"
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	nk := &groupDeleteRecorderModule{}
+	d := newGuildDeleteTestIntegrator(t, nk)
+
+	d.idcache.Store(guildID, groupID)
+	d.idcache.Store(groupID, guildID)
+
+	gg := &GuildGroup{
+		GroupMetadata: GroupMetadata{GuildID: guildID},
+		Group:         &api.Group{Id: groupID, Name: "Test Guild"},
+	}
+	d.guildGroupRegistry.Add(gg)
+	require.NotNil(t, d.guildGroupRegistry.Get(groupID))
+
+	require.NotPanics(t, func() {
+		err := d.handleGuildDelete(zap.NewNop(), nil, &discordgo.GuildDelete{
+			Guild: &discordgo.Guild{ID: guildID, OwnerID: "987654321098765432"},
+		})
+		require.NoError(t, err)
+	})
+
+	require.Equal(t, []string{groupID}, nk.deleted)
+}
+
+// TestHandleGuildDelete_UnknownGuildIsNoOp covers the third branch: a guild with
+// no group mapping at all must return early without deleting anything.
+func TestHandleGuildDelete_UnknownGuildIsNoOp(t *testing.T) {
+	nk := &groupDeleteRecorderModule{}
+	d := newGuildDeleteTestIntegrator(t, nk)
+	d.idcache.Store("323456789012345678", "") // resolves to "" => unknown guild
+
+	require.NotPanics(t, func() {
+		err := d.handleGuildDelete(zap.NewNop(), nil, &discordgo.GuildDelete{
+			Guild: &discordgo.Guild{ID: "323456789012345678", OwnerID: "987654321098765432"},
+		})
+		require.NoError(t, err)
+	})
+
+	require.Empty(t, nk.deleted)
+}
+
+// TestEarlyQuitEnforcementEnabled_NilGuildGroupEntry pins the same nil-*GuildGroup
+// class of bug on the other site the review flagged.
+//
+// GetEnforceEarlyQuitPenalty opens with `if g == nil` — but its receiver is
+// *GroupMetadata, and GroupMetadata is embedded by VALUE in GuildGroup. The call
+// `gg.GetEnforceEarlyQuitPenalty()` is shorthand for
+// `(&gg.GroupMetadata).GetEnforceEarlyQuitPenalty()`, so the receiver address is
+// computed from gg BEFORE the method body runs. A nil gg therefore panics and the
+// guard never fires: it is decorative at this call site.
+//
+// GuildUserGroupsList currently filters nil registry lookups out of the map, so
+// the panic is not reachable through that path today. The guard is cheap, matches
+// the defensive nil check evr_lobby_joinentrant.go already applies to the same
+// map, and stops a future populator from turning a map entry into a crash.
+func TestEarlyQuitEnforcementEnabled_NilGuildGroupEntry(t *testing.T) {
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	params := &SessionParameters{
+		guildGroups: map[string]*GuildGroup{groupID: nil},
+	}
+	ctx := context.WithValue(context.Background(), ctxSessionParametersKey{}, atomic.NewPointer(params))
+
+	var enabled bool
+	require.NotPanics(t, func() {
+		enabled = earlyQuitEnforcementEnabled(ctx, groupID)
+	})
+	require.True(t, enabled,
+		"an unusable guild-group entry must fall through to the lenient default, like an absent one")
+}

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -179,11 +179,6 @@ func GetLockoutDuration(penaltyLevel int) time.Duration {
 	return duration
 }
 
-// GetLockoutDurationSeconds returns the lockout duration in seconds for a given penalty level.
-func GetLockoutDurationSeconds(penaltyLevel int) int32 {
-	return int32(GetLockoutDuration(penaltyLevel).Seconds())
-}
-
 func NewEarlyQuitPlayerState() *EarlyQuitPlayerState {
 	return &EarlyQuitPlayerState{
 		MatchmakingTier: MatchmakingTier1,
@@ -311,19 +306,6 @@ func (s *EarlyQuitPlayerState) GetEarlyQuitCount() int32 {
 	s.Lock()
 	defer s.Unlock()
 	return s.NumEarlyQuits
-}
-
-// GetEffectivePenaltyLevel returns the penalty level for a specific guild,
-// checking guild overrides first, falling back to global.
-func (s *EarlyQuitPlayerState) GetEffectivePenaltyLevel(groupID string) int32 {
-	s.Lock()
-	defer s.Unlock()
-	if s.GuildOverrides != nil {
-		if override, ok := s.GuildOverrides[groupID]; ok && override.PenaltyLevel != nil {
-			return *override.PenaltyLevel
-		}
-	}
-	return s.PenaltyLevel
 }
 
 // IsExempt returns true if the player is exempt from early quit tracking in the given guild.

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -284,8 +284,12 @@ func earlyQuitEnforcementEnabled(ctx context.Context, groupID string) bool {
 	if !ok {
 		return true
 	}
+	// A nil entry is treated exactly like an absent one. The nil guard inside
+	// GetEnforceEarlyQuitPenalty cannot catch it: GroupMetadata is embedded by
+	// VALUE in GuildGroup, so gg.GetEnforceEarlyQuitPenalty() takes the address
+	// &gg.GroupMetadata before the method body runs and a nil gg panics first.
 	gg, ok := params.guildGroups[groupID]
-	if !ok {
+	if !ok || gg == nil {
 		return true
 	}
 	return gg.GetEnforceEarlyQuitPenalty()

--- a/server/evr_earlyquit_completion_loglevel_test.go
+++ b/server/evr_earlyquit_completion_loglevel_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+// completionTrackFailModule reads normally but fails every write. The
+// early-quit config row is pre-seeded so it still LOADS (that read must succeed
+// or incrementCompletedMatches bails before reaching the code under test);
+// TrackMatchCompletion's history write then fails, which is exactly the shape of
+// the failure the finding is about — the player never gets credited for the
+// match they stayed through.
+//
+// Failing the config write too keeps the test off the session-registry branch,
+// which needs a live registry this test has no reason to build.
+type completionTrackFailModule struct {
+	*occTestNakamaModule
+}
+
+func newCompletionTrackFailModule() *completionTrackFailModule {
+	return &completionTrackFailModule{occTestNakamaModule: newOCCTestNakamaModule()}
+}
+
+func (m *completionTrackFailModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	return nil, errors.New("simulated storage write failure")
+}
+
+func (m *completionTrackFailModule) StorageDelete(ctx context.Context, deletes []*runtime.StorageDelete) error {
+	return nil
+}
+
+// TestIncrementCompletedMatches_TrackFailureLogsAboveDebug pins the log level of
+// the TrackMatchCompletion failure in the post-match stats path.
+//
+// This is the failure that costs the player match credit: without the history
+// write, IncrementCompletedMatches is never called and the completion is lost.
+// It was logged at Debug while the ADJACENT, less consequential eqconfig write
+// failure logged at Warn — so at production log levels the expensive failure was
+// invisible and the cheap one was not.
+func TestIncrementCompletedMatches_TrackFailureLogsAboveDebug(t *testing.T) {
+	ctx := context.Background()
+	logger := newCaptureLogger()
+	nk := newCompletionTrackFailModule()
+
+	const userID = "55555555-5555-4555-8555-555555555555"
+	nk.seedObject(userID, StorageCollectionEarlyQuit, StorageKeyEarlyQuit, `{}`)
+
+	s := &EventRemoteLogSet{}
+	matchID := MatchID{}
+
+	err := s.incrementCompletedMatches(ctx, logger, nk, nil, nil,
+		userID, "66666666-6666-4666-8666-666666666666", matchID)
+	require.NoError(t, err, "the completion-tracking failure is non-fatal; only its visibility is at issue")
+
+	// Precondition: the config row loaded, so the block under test really ran.
+	_, loadFailed := logger.find("warn", "Failed to load early quitter config")
+	require.False(t, loadFailed, "precondition: the early quit config row must load")
+
+	const msg = "Failed to track match completion in history"
+	_, atDebug := logger.find("debug", msg)
+	_, atWarn := logger.find("warn", msg)
+
+	require.False(t, atDebug,
+		"the failure that costs the player match credit must not be hidden at Debug")
+	require.True(t, atWarn,
+		"it must be at least Warn, matching the adjacent eqconfig write failure")
+}

--- a/server/evr_group_metadata.go
+++ b/server/evr_group_metadata.go
@@ -99,6 +99,12 @@ func (g *GroupMetadata) GetKickPlayerAllowPrivates() bool {
 
 // GetEnforceEarlyQuitPenalty returns whether the guild has opted in to
 // server-side early quit enforcement. Defaults to false when unset.
+//
+// The `g == nil` guard only protects a genuinely nil *GroupMetadata. It does NOT
+// protect a nil *GuildGroup: GroupMetadata is embedded by value, so
+// gg.GetEnforceEarlyQuitPenalty() evaluates &gg.GroupMetadata before entering
+// this body and panics on a nil gg. Callers holding a *GuildGroup must nil-check
+// it themselves (see earlyQuitEnforcementEnabled).
 func (g *GroupMetadata) GetEnforceEarlyQuitPenalty() bool {
 	if g == nil || g.EnforceEarlyQuitPenalty == nil {
 		return false

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1515,8 +1515,11 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				// Track completion in detailed history first; only credit the
 				// counter when this is the first time the match is reported
 				// (the post-match stats upload also reports it).
+				// Warn, not Debug: this is the failure that costs the player
+				// match credit, so it must be at least as visible as the
+				// adjacent eqconfig write failure below.
 				if first, err := TrackMatchCompletion(ctx, logger, nk, presence.GetUserId(), state.ID, time.Now().UTC()); err != nil {
-					logger.WithField("error", err).Debug("Failed to track match completion in history")
+					logger.WithField("error", err).Warn("Failed to track match completion in history")
 				} else if first {
 					eqconfig.IncrementCompletedMatches()
 				}

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 	"go.uber.org/zap"
 )
@@ -112,6 +113,56 @@ func setLoadoutSlot(l *evr.CosmeticLoadout, slotName, equippedName string) bool 
 	return true
 }
 
+// knownLoadoutSlot reports whether slotName is a slot this server recognises.
+//
+// The handler uses it while PARSING, so an unrecognised slot is rejected and
+// logged exactly once per request rather than re-discovered on every write
+// attempt of a retry.
+func knownLoadoutSlot(slotName string) bool {
+	var probe evr.CosmeticLoadout
+	return setLoadoutSlot(&probe, slotName, "")
+}
+
+// persistGameServerLoadout applies equips to profile and writes it, retrying on a
+// storage version conflict.
+//
+// The retry is the entire reason this is a function rather than a few lines inline
+// in the handler. evrProfileUpdateWithRetry RE-READS the profile after a conflict
+// and hands that fresh object to the callback, so the callback must derive
+// everything except equips from the profile it is HANDED. A callback that instead
+// closed over the caller's pre-conflict profile would stamp that stale 22-slot
+// loadout back over whatever the concurrent writer committed — precisely the
+// clobber the retry exists to prevent, and a silent one: no error, no log.
+//
+// That mistake is a one-character edit away (dropping the parameter, or renaming
+// it so the outer variable is no longer shadowed) and the type checker cannot see
+// it. Keeping the callback here, next to a test that drives a real version
+// conflict through this function, is what makes the mistake fail loudly.
+//
+// It returns the loadout actually stored: after a retry that is the one composed
+// onto the FRESH base, so the caller's success log matches storage rather than the
+// attempt that lost.
+func persistGameServerLoadout(ctx context.Context, nk runtime.NakamaModule, userID string, profile *EVRProfile, equips []gameServerLoadoutEquip, jerseyNumber int) (evr.CosmeticLoadout, error) {
+	var written evr.CosmeticLoadout
+
+	apply := func(profile *EVRProfile) error {
+		w, err := applyGameServerLoadout(profile, equips, jerseyNumber)
+		if err != nil {
+			return err
+		}
+		written = w
+		return nil
+	}
+
+	if err := apply(profile); err != nil {
+		return evr.CosmeticLoadout{}, err
+	}
+	if _, err := evrProfileUpdateWithRetry(ctx, nk, userID, profile, apply); err != nil {
+		return evr.CosmeticLoadout{}, fmt.Errorf("failed to store EVR profile: %w", err)
+	}
+	return written, nil
+}
+
 // sanitizeGameServerLoadout strips any cosmetic the player does not own from a loadout
 // parsed from a GameServerSaveLoadoutRequest, mirroring EquipAndSanitize's protection
 // for the RemoteLogSet equip path (COSMETIC-1). It is a separate entry point because
@@ -176,10 +227,6 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 	// exactly the clobber evrProfileUpdateWithRetry exists to prevent.
 	equips := make([]gameServerLoadoutEquip, 0, len(payload.LoadoutInstances))
 
-	// slotProbe exists only so an unrecognised slot name is detected — and logged
-	// — once here during parsing, rather than once per write attempt.
-	var slotProbe evr.CosmeticLoadout
-
 	// Process each loadout instance
 	for _, instance := range payload.LoadoutInstances {
 		for slotHex, equippedHex := range instance.Items {
@@ -204,7 +251,7 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 				zap.String("equipped_hash", equippedHex),
 				zap.String("equipped_name", equippedName))
 
-			if !setLoadoutSlot(&slotProbe, slotName, equippedName) {
+			if !knownLoadoutSlot(slotName) {
 				logger.Debug("Unknown slot type", zap.String("slot", slotName))
 				continue
 			}
@@ -220,38 +267,20 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 	// those servers at all. Without this check, a NativeSupport-hosted character
 	// customization equip would persist an unowned cosmetic (e.g. a VRML finalist tag)
 	// exactly like the original remotelogset bug.
-	// applyLoadout is factored out so a retry after a version conflict can
-	// re-apply it against a freshly read profile. BOTH the base loadout and the
-	// ownership check are taken from that profile, so a retry only ever changes
-	// the slots this request actually named; every other slot keeps the value the
-	// concurrent writer committed.
-	//
-	// writtenLoadout is the loadout the most recent attempt actually produced, used
-	// for the success log below. On a retry it reflects the fresh base, so the log
-	// matches what was persisted.
-	var writtenLoadout evr.CosmeticLoadout
-
-	applyLoadout := func(profile *EVRProfile) error {
-		written, err := applyGameServerLoadout(profile, equips, payload.Number)
-		if err != nil {
-			return err
-		}
-		writtenLoadout = written
-		return nil
-	}
-
-	if err := applyLoadout(profile); err != nil {
+	// persistGameServerLoadout applies the equips and saves the profile, retrying
+	// on a version conflict with a fresh read: a concurrent writer on the same key
+	// (the Discord sync path and the login path both write it) must not cost the
+	// player this equip. The retry composes the equips onto the RE-READ profile, so
+	// only the slots this request named change; see its doc comment.
+	writtenLoadout, err := persistGameServerLoadout(ctx, p.nk, userID, profile, equips, payload.Number)
+	if err != nil {
 		return err
 	}
+
+	// Logged only after the write commits. Emitting it before meant a failed write
+	// still reported a jersey number that never persisted.
 	if payload.Number >= 0 {
 		logger.Info("Updated jersey number", zap.Int("number", payload.Number))
-	}
-
-	// Save the updated profile. A concurrent writer on the same key (the Discord
-	// sync path and the login path both write it) must not lose this equip, so
-	// retry on a version conflict with a fresh read rather than failing outright.
-	if _, err := evrProfileUpdateWithRetry(ctx, p.nk, userID, profile, applyLoadout); err != nil {
-		return fmt.Errorf("failed to store EVR profile: %w", err)
 	}
 
 	logger.Info("Successfully saved loadout update",

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -164,20 +164,34 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 	// those servers at all. Without this check, a NativeSupport-hosted character
 	// customization equip would persist an unowned cosmetic (e.g. a VRML finalist tag)
 	// exactly like the original remotelogset bug.
-	sanitized, err := sanitizeGameServerLoadout(loadout, profile)
-	if err != nil {
-		return fmt.Errorf("failed to compute owned cosmetics: %w", err)
-	}
-	profile.LoadoutCosmetics.Loadout = sanitized
+	// applyLoadout is factored out so a retry after a version conflict can
+	// re-apply it against a freshly read profile. Ownership is recomputed each
+	// time, since the fresh profile is the authority on what the player owns.
+	applyLoadout := func(profile *EVRProfile) error {
+		sanitized, err := sanitizeGameServerLoadout(loadout, profile)
+		if err != nil {
+			return fmt.Errorf("failed to compute owned cosmetics: %w", err)
+		}
+		profile.LoadoutCosmetics.Loadout = sanitized
 
-	// Update jersey number if present
+		// Update jersey number if present
+		if payload.Number >= 0 {
+			profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
+		}
+		return nil
+	}
+
+	if err := applyLoadout(profile); err != nil {
+		return err
+	}
 	if payload.Number >= 0 {
-		profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
 		logger.Info("Updated jersey number", zap.Int("number", payload.Number))
 	}
 
-	// Save the updated profile
-	if err := EVRProfileUpdate(ctx, p.nk, userID, profile); err != nil {
+	// Save the updated profile. A concurrent writer on the same key (the Discord
+	// sync path and the login path both write it) must not lose this equip, so
+	// retry on a version conflict with a fresh read rather than failing outright.
+	if _, err := evrProfileUpdateWithRetry(ctx, p.nk, userID, profile, applyLoadout); err != nil {
 		return fmt.Errorf("failed to store EVR profile: %w", err)
 	}
 

--- a/server/evr_pipeline_gameserver_loadout.go
+++ b/server/evr_pipeline_gameserver_loadout.go
@@ -22,6 +22,96 @@ type GameServerLoadoutInstance struct {
 	Items        map[string]string `json:"items"` // slot_hash -> equipped_hash (both as hex strings)
 }
 
+// gameServerLoadoutEquip is one slot assignment named by a
+// GameServerSaveLoadoutRequest, already decoded from its symbol hashes.
+type gameServerLoadoutEquip struct{ slot, equipped string }
+
+// applyGameServerLoadout composes equips onto the CURRENT loadout of profile,
+// strips any cosmetic the player does not own, and stores the result on profile.
+// A jerseyNumber below zero leaves the stored jersey number untouched. It returns
+// the loadout it stored.
+//
+// Every input other than equips is read from profile, which is what makes this
+// safe to call more than once: on a retry after a version conflict, profile is a
+// freshly read object, so only the slots this request actually named change and
+// a concurrent writer's other slots survive. Deriving the base loadout from a
+// profile captured BEFORE the conflict would instead stamp a stale full loadout
+// back over that writer's work.
+func applyGameServerLoadout(profile *EVRProfile, equips []gameServerLoadoutEquip, jerseyNumber int) (evr.CosmeticLoadout, error) {
+	loadout := profile.LoadoutCosmetics.Loadout
+	for _, e := range equips {
+		setLoadoutSlot(&loadout, e.slot, e.equipped)
+	}
+
+	sanitized, err := sanitizeGameServerLoadout(loadout, profile)
+	if err != nil {
+		return evr.CosmeticLoadout{}, fmt.Errorf("failed to compute owned cosmetics: %w", err)
+	}
+	profile.LoadoutCosmetics.Loadout = sanitized
+
+	// Update jersey number if present
+	if jerseyNumber >= 0 {
+		profile.LoadoutCosmetics.JerseyNumber = int64(jerseyNumber)
+	}
+	return sanitized, nil
+}
+
+// setLoadoutSlot assigns equippedName to the named slot of l, and reports whether
+// slotName is a slot this server recognises. Splitting the slot-name switch out of
+// the request handler is what lets the equips be replayed onto a freshly read
+// profile when a write hits a version conflict.
+func setLoadoutSlot(l *evr.CosmeticLoadout, slotName, equippedName string) bool {
+	switch slotName {
+	case "banner":
+		l.Banner = equippedName
+	case "booster":
+		l.Booster = equippedName
+	case "bracer":
+		l.Bracer = equippedName
+	case "chassis":
+		l.Chassis = equippedName
+	case "decal":
+		l.Decal = equippedName
+	case "decal_body":
+		l.DecalBody = equippedName
+	case "decalborder":
+		l.DecalBorder = equippedName
+	case "decalback":
+		l.DecalBack = equippedName
+	case "emissive":
+		l.Emissive = equippedName
+	case "emote":
+		l.Emote = equippedName
+	case "goal_fx":
+		l.GoalFX = equippedName
+	case "medal":
+		l.Medal = equippedName
+	case "pattern":
+		l.Pattern = equippedName
+	case "pattern_body":
+		l.PatternBody = equippedName
+	case "pip":
+		l.PIP = equippedName
+	case "secondemote":
+		l.SecondEmote = equippedName
+	case "tag":
+		l.Tag = equippedName
+	case "tint":
+		l.Tint = equippedName
+	case "tint_alignment_a":
+		l.TintAlignmentA = equippedName
+	case "tint_alignment_b":
+		l.TintAlignmentB = equippedName
+	case "tint_body":
+		l.TintBody = equippedName
+	case "title":
+		l.Title = equippedName
+	default:
+		return false
+	}
+	return true
+}
+
 // sanitizeGameServerLoadout strips any cosmetic the player does not own from a loadout
 // parsed from a GameServerSaveLoadoutRequest, mirroring EquipAndSanitize's protection
 // for the RemoteLogSet equip path (COSMETIC-1). It is a separate entry point because
@@ -77,8 +167,18 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 		return fmt.Errorf("failed to load EVR profile: %w", err)
 	}
 
-	// Convert the hash-based items to CosmeticLoadout fields
-	loadout := profile.LoadoutCosmetics.Loadout
+	// Convert the hash-based items to (slot, equipped) name pairs.
+	//
+	// Parsing is deliberately independent of the profile. A retry after a version
+	// conflict must compose these equips onto the loadout of the FRESHLY read
+	// profile; capturing a base loadout here instead would stamp this request's
+	// pre-conflict copy back over whatever the concurrent writer committed —
+	// exactly the clobber evrProfileUpdateWithRetry exists to prevent.
+	equips := make([]gameServerLoadoutEquip, 0, len(payload.LoadoutInstances))
+
+	// slotProbe exists only so an unrecognised slot name is detected — and logged
+	// — once here during parsing, rather than once per write attempt.
+	var slotProbe evr.CosmeticLoadout
 
 	// Process each loadout instance
 	for _, instance := range payload.LoadoutInstances {
@@ -104,55 +204,11 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 				zap.String("equipped_hash", equippedHex),
 				zap.String("equipped_name", equippedName))
 
-			// Map slot names to CosmeticLoadout fields
-			switch slotName {
-			case "banner":
-				loadout.Banner = equippedName
-			case "booster":
-				loadout.Booster = equippedName
-			case "bracer":
-				loadout.Bracer = equippedName
-			case "chassis":
-				loadout.Chassis = equippedName
-			case "decal":
-				loadout.Decal = equippedName
-			case "decal_body":
-				loadout.DecalBody = equippedName
-			case "decalborder":
-				loadout.DecalBorder = equippedName
-			case "decalback":
-				loadout.DecalBack = equippedName
-			case "emissive":
-				loadout.Emissive = equippedName
-			case "emote":
-				loadout.Emote = equippedName
-			case "goal_fx":
-				loadout.GoalFX = equippedName
-			case "medal":
-				loadout.Medal = equippedName
-			case "pattern":
-				loadout.Pattern = equippedName
-			case "pattern_body":
-				loadout.PatternBody = equippedName
-			case "pip":
-				loadout.PIP = equippedName
-			case "secondemote":
-				loadout.SecondEmote = equippedName
-			case "tag":
-				loadout.Tag = equippedName
-			case "tint":
-				loadout.Tint = equippedName
-			case "tint_alignment_a":
-				loadout.TintAlignmentA = equippedName
-			case "tint_alignment_b":
-				loadout.TintAlignmentB = equippedName
-			case "tint_body":
-				loadout.TintBody = equippedName
-			case "title":
-				loadout.Title = equippedName
-			default:
+			if !setLoadoutSlot(&slotProbe, slotName, equippedName) {
 				logger.Debug("Unknown slot type", zap.String("slot", slotName))
+				continue
 			}
+			equips = append(equips, gameServerLoadoutEquip{slot: slotName, equipped: equippedName})
 		}
 	}
 
@@ -165,19 +221,22 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 	// customization equip would persist an unowned cosmetic (e.g. a VRML finalist tag)
 	// exactly like the original remotelogset bug.
 	// applyLoadout is factored out so a retry after a version conflict can
-	// re-apply it against a freshly read profile. Ownership is recomputed each
-	// time, since the fresh profile is the authority on what the player owns.
-	applyLoadout := func(profile *EVRProfile) error {
-		sanitized, err := sanitizeGameServerLoadout(loadout, profile)
-		if err != nil {
-			return fmt.Errorf("failed to compute owned cosmetics: %w", err)
-		}
-		profile.LoadoutCosmetics.Loadout = sanitized
+	// re-apply it against a freshly read profile. BOTH the base loadout and the
+	// ownership check are taken from that profile, so a retry only ever changes
+	// the slots this request actually named; every other slot keeps the value the
+	// concurrent writer committed.
+	//
+	// writtenLoadout is the loadout the most recent attempt actually produced, used
+	// for the success log below. On a retry it reflects the fresh base, so the log
+	// matches what was persisted.
+	var writtenLoadout evr.CosmeticLoadout
 
-		// Update jersey number if present
-		if payload.Number >= 0 {
-			profile.LoadoutCosmetics.JerseyNumber = int64(payload.Number)
+	applyLoadout := func(profile *EVRProfile) error {
+		written, err := applyGameServerLoadout(profile, equips, payload.Number)
+		if err != nil {
+			return err
 		}
+		writtenLoadout = written
 		return nil
 	}
 
@@ -198,7 +257,7 @@ func (p *EvrPipeline) gameServerSaveLoadoutRequest(ctx context.Context, logger *
 	logger.Info("Successfully saved loadout update",
 		zap.String("user_id", userID),
 		zap.String("evr_id", request.EvrID.String()),
-		zap.Any("loadout", loadout))
+		zap.Any("loadout", writtenLoadout))
 
 	return nil
 }

--- a/server/evr_pipeline_gameserver_loadout_retry_test.go
+++ b/server/evr_pipeline_gameserver_loadout_retry_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/require"
+)
+
+// gameServerSaveLoadoutRequest writes the profile through
+// evrProfileUpdateWithRetry, so its apply closure can run a second time against a
+// profile re-read after a version conflict. applyGameServerLoadout is that
+// closure's body.
+//
+// The clobber these tests guard against: if the BASE loadout is captured from the
+// profile read before the conflict, a retry writes every slot of that stale copy
+// back, undoing whatever the concurrent writer committed — precisely what
+// evrProfileUpdateWithRetry exists to prevent. Only the slots the request
+// actually named may change.
+
+const retryTestOwnedTag = "rwd_tag_s1_vrml_s1_finalist"
+
+func newLoadoutRetryProfile(loadout evr.CosmeticLoadout) *EVRProfile {
+	return &EVRProfile{
+		account: &api.Account{
+			Wallet: `{"cosmetic:arena:` + retryTestOwnedTag + `":1}`,
+		},
+		LoadoutCosmetics: AccountCosmetics{Loadout: loadout},
+	}
+}
+
+// TestApplyGameServerLoadout_UsesBaseFromProfilePassedIn is the core of finding 3.
+//
+// The game server equips one slot (emote). While that write is in flight, another
+// writer equips the player's legitimately owned VRML tag and commits first. Our
+// write conflicts and is retried against the re-read profile. The tag must
+// survive: this request never mentioned the tag slot.
+func TestApplyGameServerLoadout_UsesBaseFromProfilePassedIn(t *testing.T) {
+	equips := []gameServerLoadoutEquip{
+		{slot: "emote", equipped: evr.DefaultCosmeticLoadout().Emote},
+	}
+
+	// The profile as re-read AFTER the conflict: the concurrent writer's tag is on it.
+	freshLoadout := evr.DefaultCosmeticLoadout()
+	freshLoadout.Tag = retryTestOwnedTag
+	fresh := newLoadoutRetryProfile(freshLoadout)
+
+	written, err := applyGameServerLoadout(fresh, equips, -1)
+	require.NoError(t, err)
+
+	require.Equal(t, retryTestOwnedTag, written.Tag,
+		"a retry must compose the request's equips onto the FRESH loadout; the "+
+			"concurrent writer's tag must not be overwritten")
+	require.Equal(t, retryTestOwnedTag, fresh.LoadoutCosmetics.Loadout.Tag)
+	require.Equal(t, evr.DefaultCosmeticLoadout().Emote, written.Emote,
+		"the slot the request did name must still be applied")
+
+	// Discriminator: the same equips against the PRE-conflict profile yield the
+	// default tag. That is exactly what would have been written back had the base
+	// loadout been captured before the conflict instead of taken from the argument.
+	stale := newLoadoutRetryProfile(evr.DefaultCosmeticLoadout())
+	staleWritten, err := applyGameServerLoadout(stale, equips, -1)
+	require.NoError(t, err)
+	require.Equal(t, evr.DefaultCosmeticLoadout().Tag, staleWritten.Tag)
+	require.NotEqual(t, written.Tag, staleWritten.Tag,
+		"the two profiles must produce different results, or this test proves nothing")
+}
+
+// TestApplyGameServerLoadout_StillStripsUnownedCosmetics pins that moving the base
+// loadout into the closure did not weaken the COSMETIC-1 ownership check.
+func TestApplyGameServerLoadout_StillStripsUnownedCosmetics(t *testing.T) {
+	// An empty wallet: the player owns no VRML tag.
+	profile := &EVRProfile{
+		account:          &api.Account{Wallet: "{}"},
+		LoadoutCosmetics: AccountCosmetics{Loadout: evr.DefaultCosmeticLoadout()},
+	}
+
+	equips := []gameServerLoadoutEquip{{slot: "tag", equipped: retryTestOwnedTag}}
+
+	written, err := applyGameServerLoadout(profile, equips, -1)
+	require.NoError(t, err)
+	require.Equal(t, evr.DefaultCosmeticLoadout().Tag, written.Tag,
+		"an unowned cosmetic must still be stripped (COSMETIC-1)")
+}
+
+// TestApplyGameServerLoadout_IsIdempotent pins evrProfileUpdateWithRetry's
+// contract that apply may run more than once.
+func TestApplyGameServerLoadout_IsIdempotent(t *testing.T) {
+	equips := []gameServerLoadoutEquip{
+		{slot: "tag", equipped: retryTestOwnedTag},
+	}
+	profile := newLoadoutRetryProfile(evr.DefaultCosmeticLoadout())
+
+	first, err := applyGameServerLoadout(profile, equips, 7)
+	require.NoError(t, err)
+	second, err := applyGameServerLoadout(profile, equips, 7)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+	require.Equal(t, int64(7), profile.LoadoutCosmetics.JerseyNumber)
+}
+
+// TestApplyGameServerLoadout_NegativeJerseyNumberLeavesItAlone pins the
+// payload.Number >= 0 guard that moved into the helper.
+func TestApplyGameServerLoadout_NegativeJerseyNumberLeavesItAlone(t *testing.T) {
+	profile := newLoadoutRetryProfile(evr.DefaultCosmeticLoadout())
+	profile.LoadoutCosmetics.JerseyNumber = 42
+
+	_, err := applyGameServerLoadout(profile, nil, -1)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), profile.LoadoutCosmetics.JerseyNumber)
+}
+
+// TestSetLoadoutSlot_ReportsUnknownSlots pins the return value the request handler
+// uses to log "Unknown slot type" exactly once per request rather than once per
+// write attempt.
+func TestSetLoadoutSlot_ReportsUnknownSlots(t *testing.T) {
+	var l evr.CosmeticLoadout
+
+	require.True(t, setLoadoutSlot(&l, "tag", "some_tag"))
+	require.Equal(t, "some_tag", l.Tag)
+
+	require.False(t, setLoadoutSlot(&l, "not_a_real_slot", "whatever"),
+		"an unrecognised slot must be reported, not silently ignored")
+}

--- a/server/evr_pipeline_gameserver_loadout_retry_test.go
+++ b/server/evr_pipeline_gameserver_loadout_retry_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/heroiclabs/nakama-common/api"
@@ -123,4 +124,167 @@ func TestSetLoadoutSlot_ReportsUnknownSlots(t *testing.T) {
 
 	require.False(t, setLoadoutSlot(&l, "not_a_real_slot", "whatever"),
 		"an unrecognised slot must be reported, not silently ignored")
+}
+
+// ---------------------------------------------------------------------------
+// Call-site coverage.
+//
+// The tests above exercise applyGameServerLoadout as a unit. They say nothing
+// about whether the handler WIRES it correctly, and that wiring is where the bug
+// actually lives: the retry callback has to use the profile it is HANDED. Drop
+// the parameter (`func(_ *EVRProfile)`) so the body closes over the caller's
+// pre-conflict profile instead, and every unit test above still passes, because
+// none of them ever runs a real version conflict through the real retry helper.
+//
+// TestPersistGameServerLoadout_* below drive persistGameServerLoadout end to end
+// against an OCC-correct module that rejects the first write. That is the only
+// thing in this package that can tell the two wirings apart.
+// ---------------------------------------------------------------------------
+
+// retryTestOwnedEmote is a second wallet-granted cosmetic. It differs from the
+// default emote on purpose: equipping the DEFAULT value would leave the assertion
+// true no matter which profile the callback composed onto, and prove nothing.
+const retryTestOwnedEmote = "rwd_emote_test_owned_a"
+
+// loadoutRetryModule is profileUpdateTestModule with a wallet on the account it
+// returns, so the profile RELOADED after a conflict still passes the COSMETIC-1
+// ownership check. Without it the reload yields an empty wallet and sanitizing
+// would strip both cosmetics, hiding the behaviour under test.
+type loadoutRetryModule struct {
+	*profileUpdateTestModule
+	wallet string
+}
+
+func (m *loadoutRetryModule) AccountGetId(ctx context.Context, userID string) (*api.Account, error) {
+	return &api.Account{User: &api.User{Id: userID, Username: "tester"}, Wallet: m.wallet}, nil
+}
+
+func newLoadoutRetryModule() *loadoutRetryModule {
+	return &loadoutRetryModule{
+		profileUpdateTestModule: newProfileUpdateTestModule(),
+		wallet: `{"cosmetic:arena:` + retryTestOwnedTag + `":1,` +
+			`"cosmetic:arena:` + retryTestOwnedEmote + `":1}`,
+	}
+}
+
+// TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile is the
+// call-site test for finding 3.
+//
+// Scenario: a player on a NativeSupport game server equips an emote at the
+// character customization screen. While that write is in flight another writer
+// commits the player's legitimately owned VRML finalist tag. Our write loses the
+// version race and is retried.
+//
+// Both halves must hold afterwards, and they fail under DIFFERENT miswirings:
+//
+//   - the tag must survive — a callback that composes onto a base loadout
+//     captured BEFORE the conflict stamps all 22 stale slots back over it;
+//   - the emote must be stored — a callback that ignores its parameter and
+//     mutates the caller's profile leaves the re-read object untouched, so the
+//     write succeeds having silently dropped the player's equip.
+//
+// Neither failure surfaces an error or a log line, which is why only an
+// end-to-end assertion against stored state can catch them.
+func TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile(t *testing.T) {
+	ctx := context.Background()
+	const userID = "77777777-7777-4777-8777-777777777777"
+
+	nk := newLoadoutRetryModule()
+
+	// Storage as it stood when the handler read the profile.
+	base := evr.DefaultCosmeticLoadout()
+	staleVersion := seedStoredProfile(t, nk.profileUpdateTestModule, userID,
+		&EVRProfile{LoadoutCosmetics: AccountCosmetics{Loadout: base}})
+
+	// The concurrent writer commits the tag first, bumping the stored version.
+	concurrent := evr.DefaultCosmeticLoadout()
+	concurrent.Tag = retryTestOwnedTag
+	seedStoredProfile(t, nk.profileUpdateTestModule, userID,
+		&EVRProfile{LoadoutCosmetics: AccountCosmetics{Loadout: concurrent}})
+
+	// What the handler is holding: the pre-conflict read, carrying the now-stale
+	// version and knowing nothing about the tag.
+	inHand := newLoadoutRetryProfile(base)
+	inHand.SetStorageMeta(StorableMetadata{Version: staleVersion})
+
+	equips := []gameServerLoadoutEquip{{slot: "emote", equipped: retryTestOwnedEmote}}
+
+	written, err := persistGameServerLoadout(ctx, nk, userID, inHand, equips, 8)
+	require.NoError(t, err, "a version conflict must not cost the player the equip")
+
+	// Precondition: the conflict really happened, so the retry path really ran.
+	// Without this the assertions below would also pass on a first-try success.
+	require.Equal(t, 2, nk.calls(),
+		"expected one rejected write and one successful retry; the conflict is the "+
+			"whole point of this test")
+
+	stored := nk.storedProfile(t, userID)
+
+	require.Equal(t, retryTestOwnedTag, stored.LoadoutCosmetics.Loadout.Tag,
+		"the concurrent writer's tag must survive: the retry must compose onto the "+
+			"RE-READ loadout, not stamp back the pre-conflict copy")
+	require.Equal(t, retryTestOwnedEmote, stored.LoadoutCosmetics.Loadout.Emote,
+		"the equip this request asked for must actually be stored: the retry "+
+			"callback must mutate the profile it is HANDED, not the caller's")
+	require.Equal(t, int64(8), stored.LoadoutCosmetics.JerseyNumber,
+		"the jersey number must be re-applied to the fresh profile too")
+
+	// The returned loadout is what the success log reports; it must describe what
+	// landed in storage, not the attempt that lost.
+	require.Equal(t, stored.LoadoutCosmetics.Loadout, written,
+		"the returned loadout must match what was persisted")
+}
+
+// TestPersistGameServerLoadout_NoConflictWritesEquipsOnce is the control: with no
+// concurrent writer, one write, and the equip lands. This is what makes the test
+// above a statement about the RETRY rather than about persistence in general.
+func TestPersistGameServerLoadout_NoConflictWritesEquipsOnce(t *testing.T) {
+	ctx := context.Background()
+	const userID = "88888888-8888-4888-8888-888888888888"
+
+	nk := newLoadoutRetryModule()
+	version := seedStoredProfile(t, nk.profileUpdateTestModule, userID,
+		&EVRProfile{LoadoutCosmetics: AccountCosmetics{Loadout: evr.DefaultCosmeticLoadout()}})
+
+	inHand := newLoadoutRetryProfile(evr.DefaultCosmeticLoadout())
+	inHand.SetStorageMeta(StorableMetadata{Version: version})
+
+	equips := []gameServerLoadoutEquip{{slot: "tag", equipped: retryTestOwnedTag}}
+
+	written, err := persistGameServerLoadout(ctx, nk, userID, inHand, equips, -1)
+	require.NoError(t, err)
+	require.Equal(t, 1, nk.calls(), "an uncontended write must not retry")
+
+	stored := nk.storedProfile(t, userID)
+	require.Equal(t, retryTestOwnedTag, stored.LoadoutCosmetics.Loadout.Tag)
+	require.Equal(t, retryTestOwnedTag, written.Tag)
+}
+
+// TestPersistGameServerLoadout_StripsUnownedCosmeticOnRetry pins that COSMETIC-1
+// still holds on the retry path, where the ownership check runs against the
+// RE-READ profile's wallet rather than the caller's.
+func TestPersistGameServerLoadout_StripsUnownedCosmeticOnRetry(t *testing.T) {
+	ctx := context.Background()
+	const userID = "99999999-9999-4999-8999-999999999999"
+
+	nk := newLoadoutRetryModule()
+	nk.wallet = "{}" // the player owns nothing beyond the defaults
+
+	staleVersion := seedStoredProfile(t, nk.profileUpdateTestModule, userID,
+		&EVRProfile{LoadoutCosmetics: AccountCosmetics{Loadout: evr.DefaultCosmeticLoadout()}})
+	seedStoredProfile(t, nk.profileUpdateTestModule, userID,
+		&EVRProfile{LoadoutCosmetics: AccountCosmetics{Loadout: evr.DefaultCosmeticLoadout()}})
+
+	inHand := newLoadoutRetryProfile(evr.DefaultCosmeticLoadout())
+	inHand.SetStorageMeta(StorableMetadata{Version: staleVersion})
+
+	equips := []gameServerLoadoutEquip{{slot: "tag", equipped: retryTestOwnedTag}}
+
+	_, err := persistGameServerLoadout(ctx, nk, userID, inHand, equips, -1)
+	require.NoError(t, err)
+	require.Equal(t, 2, nk.calls(), "precondition: the retry path must have run")
+
+	stored := nk.storedProfile(t, userID)
+	require.Equal(t, evr.DefaultCosmeticLoadout().Tag, stored.LoadoutCosmetics.Loadout.Tag,
+		"an unowned cosmetic must still be stripped on the retry path (COSMETIC-1)")
 }

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -650,11 +650,17 @@ type loginProfileReapply struct {
 	username             string
 	usernameOnlyGroupIDs []string
 
-	// displayNamesOwnedByOthers is the lowercased set of in-game names this login
-	// found registered to a different account. Any matching name on the fresh
-	// profile is pruned again, so a retry cannot resurrect a name the server had
-	// already rejected for this player.
-	displayNamesOwnedByOthers map[string]struct{}
+	// displayNamesOwnedByOthers lists the in-game names this login found
+	// registered to a different account. Any matching name on the fresh profile is
+	// pruned again, so a retry cannot resurrect a name the server had already
+	// rejected for this player.
+	//
+	// Matched with strings.EqualFold, exactly as the prune in initializeSession
+	// does. Case folding is NOT the same as lowercasing both sides — EqualFold
+	// applies simple Unicode folding, so pairs like 'ſ'/'s' compare equal to it and
+	// not to strings.ToLower. Keeping the same comparison here is what makes this a
+	// re-evaluation of the original rule rather than a slightly different one.
+	displayNamesOwnedByOthers []string
 }
 
 // apply re-applies the login mutations to profile. It is safe to call repeatedly
@@ -672,8 +678,11 @@ func (r loginProfileReapply) apply(profile *EVRProfile) error {
 		profile.SetGroupDisplayName(groupID, r.username)
 	}
 	for gID, gn := range profile.DisplayNamesByGroupID() {
-		if _, taken := r.displayNamesOwnedByOthers[strings.ToLower(gn)]; taken {
-			profile.DeleteGroupDisplayName(gID)
+		for _, taken := range r.displayNamesOwnedByOthers {
+			if strings.EqualFold(gn, taken) {
+				profile.DeleteGroupDisplayName(gID)
+				break
+			}
 		}
 	}
 	return nil
@@ -856,11 +865,13 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 		displayNames = append(displayNames, dn)
 	}
 
-	// displayNamesOwnedByOthers collects, lowercased, every in-game name this
-	// login found to belong to a different account. It is re-evaluated against the
-	// fresh profile on a storage retry (see the reapply closure below) so the
-	// prune below cannot be undone by adopting a reloaded profile.
-	displayNamesOwnedByOthers := make(map[string]struct{})
+	// displayNamesOwnedByOthers collects every in-game name this login found to
+	// belong to a different account. It is re-evaluated against the fresh profile
+	// on a storage retry (see the reapply closure below) so the prune below cannot
+	// be undone by adopting a reloaded profile. Names are stored verbatim; the
+	// retry matches them with strings.EqualFold, the same comparison the prune
+	// below uses.
+	displayNamesOwnedByOthers := make([]string, 0)
 
 	// The notification goroutine below must not close over params.profile: the
 	// retry path further down reassigns that field, which would be a data race
@@ -875,7 +886,7 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 		for _, dn := range params.profile.DisplayNamesByGroupID() {
 			if ownerIDs, ok := ownerMap[dn]; ok && !slices.Contains(ownerIDs, params.profile.ID()) {
 				// This display name is owned by someone else.
-				displayNamesOwnedByOthers[strings.ToLower(dn)] = struct{}{}
+				displayNamesOwnedByOthers = append(displayNamesOwnedByOthers, dn)
 				for gID, gn := range params.profile.DisplayNamesByGroupID() {
 					if strings.EqualFold(gn, dn) {
 						// This display name is owned by someone else.
@@ -1008,9 +1019,17 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 
 		// The mutations that set metadataUpdated are re-applied here to a freshly
 		// read profile on a retry: the resolved active group, and the
-		// broken-cosmetic repair. Login is racing its own QueueSyncMember call
-		// above, which writes the same key from the Discord sync path, so a version
-		// conflict is realistic and must not reject the login outright.
+		// broken-cosmetic repair.
+		//
+		// The competing writers are the Discord member-sync path and the
+		// guild-rename RPC, both of which write this same key and are driven by
+		// Discord commands, account linking, and this player's other reconnect
+		// attempts — none of which are sequenced against this session. A version
+		// conflict is therefore realistic and must not reject the login outright.
+		//
+		// Not the QueueSyncMember call earlier in this function: that one sits on
+		// the "user is not in any groups" branch and returns immediately after, so
+		// it never reaches this write.
 		//
 		// reapply runs ONLY on a retry, and only against a profile just read from
 		// storage. Everything it does is therefore expressed as a rule re-evaluated

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -927,12 +927,18 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 
 		userID := params.profile.ID()
 
-		// Everything this function mutates on the profile is captured here so a
-		// retry can re-apply it to a freshly read profile: the resolved active
-		// group, and the broken-cosmetic repair. Login is racing its own
-		// QueueSyncMember call above, which writes the same key from the Discord
-		// sync path, so a version conflict is realistic and must not reject the
-		// login outright.
+		// The two mutations that set metadataUpdated are captured here so a retry
+		// can re-apply them to a freshly read profile: the resolved active group,
+		// and the broken-cosmetic repair. Login is racing its own QueueSyncMember
+		// call above, which writes the same key from the Discord sync path, so a
+		// version conflict is realistic and must not reject the login outright.
+		//
+		// The in-game names recomputed earlier in this function are deliberately
+		// NOT re-applied on a retry. Re-applying them would mean writing this
+		// session's whole IGN map over the fresh read, which is precisely how the
+		// concurrent writer's work gets discarded — and the guild-rename RPC
+		// writes exactly that field. On the rare retry the fresh profile's IGNs
+		// win; login recomputes them on the next connect anyway.
 		desiredActiveGroupID := params.profile.GetActiveGroupID()
 		ignoreBrokenCosmetics := params.profile.IgnoreBrokenCosmetics
 		reapply := func(profile *EVRProfile) error {

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -925,11 +925,36 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 			params.profile.SetActiveGroupID(storedActiveGroupID)
 		}
 
+		userID := params.profile.ID()
+
+		// Everything this function mutates on the profile is captured here so a
+		// retry can re-apply it to a freshly read profile: the resolved active
+		// group, and the broken-cosmetic repair. Login is racing its own
+		// QueueSyncMember call above, which writes the same key from the Discord
+		// sync path, so a version conflict is realistic and must not reject the
+		// login outright.
+		desiredActiveGroupID := params.profile.GetActiveGroupID()
+		ignoreBrokenCosmetics := params.profile.IgnoreBrokenCosmetics
+		reapply := func(profile *EVRProfile) error {
+			profile.SetActiveGroupID(desiredActiveGroupID)
+			if !ignoreBrokenCosmetics {
+				profile.FixBrokenCosmetics()
+			}
+			return nil
+		}
+
 		// Use EVRProfileUpdate to persist changes AND invalidate the ServerProfile cache
-		if err := EVRProfileUpdate(ctx, p.nk, params.profile.ID(), params.profile); err != nil {
+		updated, err := evrProfileUpdateWithRetry(ctx, p.nk, userID, params.profile, reapply)
+		if err != nil {
 			metricsTags["error"] = "failed_update_profile"
+			// Restore the session fallback before bailing so params.profile is
+			// never left holding the stored value it was temporarily swapped to.
+			if groupIDAutoAssigned {
+				params.profile.SetActiveGroupID(sessionFallbackGID)
+			}
 			return fmt.Errorf("failed to update user profile: %w", err)
 		}
+		params.profile = updated
 
 		if groupIDAutoAssigned {
 			params.profile.SetActiveGroupID(sessionFallbackGID)

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -627,6 +627,58 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 	return nil
 }
 
+// loginProfileReapply holds the mutations login must re-assert when its profile
+// write loses a version race and has to be retried against a freshly read
+// profile.
+//
+// Every field is a RULE, not a captured value to replay: apply re-evaluates each
+// one against the profile it is handed. That distinction is the whole point — the
+// retry exists so a concurrent writer's committed work survives, and replaying
+// this session's pre-conflict snapshot would discard exactly that work.
+type loginProfileReapply struct {
+	// setActiveGroupID is true only when this session deliberately chose a new
+	// active group. When false the fresh profile's active group is left alone,
+	// since it may be a change the concurrent writer just made on purpose.
+	setActiveGroupID bool
+	activeGroupID    uuid.UUID
+
+	// fixBrokenCosmetics mirrors !profile.IgnoreBrokenCosmetics.
+	fixBrokenCosmetics bool
+
+	// username, plus the guilds whose UsernameOnly role forces the player's
+	// display name to it.
+	username             string
+	usernameOnlyGroupIDs []string
+
+	// displayNamesOwnedByOthers is the lowercased set of in-game names this login
+	// found registered to a different account. Any matching name on the fresh
+	// profile is pruned again, so a retry cannot resurrect a name the server had
+	// already rejected for this player.
+	displayNamesOwnedByOthers map[string]struct{}
+}
+
+// apply re-applies the login mutations to profile. It is safe to call repeatedly
+// and is deliberately NOT a wholesale write of this session's in-game name map:
+// the guild-rename RPC writes that same map, so overwriting it would clobber a
+// rename that landed while we were writing.
+func (r loginProfileReapply) apply(profile *EVRProfile) error {
+	if r.setActiveGroupID {
+		profile.SetActiveGroupID(r.activeGroupID)
+	}
+	if r.fixBrokenCosmetics {
+		profile.FixBrokenCosmetics()
+	}
+	for _, groupID := range r.usernameOnlyGroupIDs {
+		profile.SetGroupDisplayName(groupID, r.username)
+	}
+	for gID, gn := range profile.DisplayNamesByGroupID() {
+		if _, taken := r.displayNamesOwnedByOthers[strings.ToLower(gn)]; taken {
+			profile.DeleteGroupDisplayName(gID)
+		}
+	}
+	return nil
+}
+
 func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger, session *sessionWS, params *SessionParameters) error {
 	var err error
 	serviceSettings := ServiceSettings()
@@ -662,6 +714,11 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 	// use session-only fallback — don't overwrite their stored choice.
 	storedActiveGroupID := params.profile.GetActiveGroupID()
 	groupIDAutoAssigned := false
+	// activeGroupIDPersist records whether THIS session deliberately changed the
+	// stored active group. Only then may a storage retry re-assert it against a
+	// freshly read profile; otherwise the retry would revert an active-group
+	// change committed by the very writer we are retrying around.
+	activeGroupIDPersist := false
 	if _, ok := params.guildGroups[params.profile.ActiveGroupID]; !ok {
 
 		groupIDs := make([]string, 0, len(params.guildGroups))
@@ -685,6 +742,7 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 		if storedActiveGroupID == uuid.Nil {
 			// New player with no group set — persist the assignment
 			metadataUpdated = true
+			activeGroupIDPersist = true
 		} else {
 			// Existing player whose group is temporarily unresolvable — session only
 			groupIDAutoAssigned = true
@@ -711,8 +769,16 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 
 	// Update in-memory account metadata for guilds that the user has
 	// the force username role.
+	//
+	// usernameOnlyGroupIDs records which guilds this enforcement applies to so a
+	// storage retry further down can re-assert it against a freshly read profile
+	// (see the reapply closure below). Without that, a retry would drop the
+	// session back to whatever display name storage happens to hold, silently
+	// bypassing the guild's UsernameOnly role for the rest of the session.
+	usernameOnlyGroupIDs := make([]string, 0, len(params.guildGroups))
 	for groupID, gg := range params.guildGroups {
 		if gg.HasRole(session.userID.String(), gg.RoleMap.UsernameOnly) {
+			usernameOnlyGroupIDs = append(usernameOnlyGroupIDs, groupID)
 			params.profile.SetGroupDisplayName(groupID, params.profile.Username())
 		}
 	}
@@ -790,6 +856,18 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 		displayNames = append(displayNames, dn)
 	}
 
+	// displayNamesOwnedByOthers collects, lowercased, every in-game name this
+	// login found to belong to a different account. It is re-evaluated against the
+	// fresh profile on a storage retry (see the reapply closure below) so the
+	// prune below cannot be undone by adopting a reloaded profile.
+	displayNamesOwnedByOthers := make(map[string]struct{})
+
+	// The notification goroutine below must not close over params.profile: the
+	// retry path further down reassigns that field, which would be a data race
+	// against these reads. Snapshot the two values it needs up front.
+	notifyDiscordID := params.profile.DiscordID()
+	notifyUsername := params.profile.Username()
+
 	if ownerMap, err := DisplayNameOwnerSearch(ctx, p.nk, displayNames); err != nil {
 		logger.Warn("Failed to check display name owner", zap.Any("display_names", displayNames), zap.Error(err))
 	} else {
@@ -797,6 +875,7 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 		for _, dn := range params.profile.DisplayNamesByGroupID() {
 			if ownerIDs, ok := ownerMap[dn]; ok && !slices.Contains(ownerIDs, params.profile.ID()) {
 				// This display name is owned by someone else.
+				displayNamesOwnedByOthers[strings.ToLower(dn)] = struct{}{}
 				for gID, gn := range params.profile.DisplayNamesByGroupID() {
 					if strings.EqualFold(gn, dn) {
 						// This display name is owned by someone else.
@@ -805,7 +884,7 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 							// Notify the player that this display name is in use.
 							ownerDiscordID := p.discordCache.UserIDToDiscordID(ownerIDs[0])
 							go func(displayName string) {
-								if err := p.discordCache.SendDisplayNameInUseNotification(ctx, params.profile.DiscordID(), ownerDiscordID, displayName, params.profile.Username()); err != nil {
+								if err := p.discordCache.SendDisplayNameInUseNotification(ctx, notifyDiscordID, ownerDiscordID, displayName, notifyUsername); err != nil {
 									if IsDiscordErrorCode(err, discordgo.ErrCodeCannotSendMessagesToThisUser) {
 										logger.Warn("Failed to send display name in use notification", zap.Error(err))
 									}
@@ -927,30 +1006,38 @@ func (p *EvrPipeline) initializeSession(ctx context.Context, logger *zap.Logger,
 
 		userID := params.profile.ID()
 
-		// The two mutations that set metadataUpdated are captured here so a retry
-		// can re-apply them to a freshly read profile: the resolved active group,
-		// and the broken-cosmetic repair. Login is racing its own QueueSyncMember
-		// call above, which writes the same key from the Discord sync path, so a
-		// version conflict is realistic and must not reject the login outright.
+		// The mutations that set metadataUpdated are re-applied here to a freshly
+		// read profile on a retry: the resolved active group, and the
+		// broken-cosmetic repair. Login is racing its own QueueSyncMember call
+		// above, which writes the same key from the Discord sync path, so a version
+		// conflict is realistic and must not reject the login outright.
+		//
+		// reapply runs ONLY on a retry, and only against a profile just read from
+		// storage. Everything it does is therefore expressed as a rule re-evaluated
+		// against that fresh profile, never as a replay of this session's stale
+		// values — replaying stale values is exactly how the concurrent writer's
+		// work gets discarded.
 		//
 		// The in-game names recomputed earlier in this function are deliberately
-		// NOT re-applied on a retry. Re-applying them would mean writing this
-		// session's whole IGN map over the fresh read, which is precisely how the
-		// concurrent writer's work gets discarded — and the guild-rename RPC
-		// writes exactly that field. On the rare retry the fresh profile's IGNs
-		// win; login recomputes them on the next connect anyway.
-		desiredActiveGroupID := params.profile.GetActiveGroupID()
-		ignoreBrokenCosmetics := params.profile.IgnoreBrokenCosmetics
-		reapply := func(profile *EVRProfile) error {
-			profile.SetActiveGroupID(desiredActiveGroupID)
-			if !ignoreBrokenCosmetics {
-				profile.FixBrokenCosmetics()
-			}
-			return nil
+		// NOT re-applied wholesale: the guild-rename RPC writes that same map, and
+		// overwriting it would clobber a rename that landed while we were writing.
+		// On a retry the fresh profile's IGNs win; login recomputes them on the next
+		// connect anyway. The two IGN rules that are *enforcement* rather than
+		// preference are re-evaluated, because dropping them would leave the session
+		// running with a name the server had already rejected:
+		//   - guilds with the UsernameOnly role must show the username;
+		//   - a name found to belong to another account must not be used.
+		reapply := loginProfileReapply{
+			setActiveGroupID:          activeGroupIDPersist,
+			activeGroupID:             params.profile.GetActiveGroupID(),
+			fixBrokenCosmetics:        !params.profile.IgnoreBrokenCosmetics,
+			username:                  params.profile.Username(),
+			usernameOnlyGroupIDs:      usernameOnlyGroupIDs,
+			displayNamesOwnedByOthers: displayNamesOwnedByOthers,
 		}
 
 		// Use EVRProfileUpdate to persist changes AND invalidate the ServerProfile cache
-		updated, err := evrProfileUpdateWithRetry(ctx, p.nk, userID, params.profile, reapply)
+		updated, err := evrProfileUpdateWithRetry(ctx, p.nk, userID, params.profile, reapply.apply)
 		if err != nil {
 			metricsTags["error"] = "failed_update_profile"
 			// Restore the session fallback before bailing so params.profile is

--- a/server/evr_pipeline_login_reapply_test.go
+++ b/server/evr_pipeline_login_reapply_test.go
@@ -1,0 +1,251 @@
+package server
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover loginProfileReapply, the closure evrProfileUpdateWithRetry
+// runs when login's profile write loses a version race and has to be retried
+// against a freshly read profile.
+//
+// The whole reason EVRProfileUpdate has no internal retry is that a blind retry
+// re-submits the caller's stale payload and discards whatever the concurrent
+// writer committed. A reapply closure that replays this session's pre-conflict
+// snapshot reintroduces exactly that bug through the back door, so each rule it
+// applies has to be re-evaluated against the fresh profile. That is what these
+// tests pin.
+
+func newReapplyTestProfile(t *testing.T) *EVRProfile {
+	t.Helper()
+	return &EVRProfile{
+		account:     &api.Account{User: &api.User{Username: "tester"}, Wallet: "{}"},
+		InGameNames: make(map[string]GroupInGameName),
+	}
+}
+
+// TestLoginProfileReapply_DoesNotRevertConcurrentActiveGroupChange is finding 4.
+//
+// metadataUpdated can be true purely because FixBrokenCosmetics repaired a
+// cosmetic, while the player's active group was never touched by this login. If
+// the retry re-asserts the active group anyway, and the writer we are retrying
+// around is the one that changed it, login silently reverts the player's guild.
+func TestLoginProfileReapply_DoesNotRevertConcurrentActiveGroupChange(t *testing.T) {
+	const (
+		loginSawGroup   = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+		concurrentGroup = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+	)
+
+	// This session did not choose a new active group.
+	r := loginProfileReapply{
+		setActiveGroupID: false,
+		activeGroupID:    uuid.FromStringOrNil(loginSawGroup),
+	}
+
+	// The freshly read profile carries the concurrent writer's deliberate change.
+	fresh := newReapplyTestProfile(t)
+	fresh.ActiveGroupID = concurrentGroup
+
+	require.NoError(t, r.apply(fresh))
+	require.Equal(t, concurrentGroup, fresh.ActiveGroupID,
+		"a retry must not revert an active group the concurrent writer just set")
+}
+
+// TestLoginProfileReapply_PersistsDeliberateActiveGroupChange is the control for
+// the test above: when this login DID assign a group (a brand-new player with no
+// stored group), the retry must still persist it.
+func TestLoginProfileReapply_PersistsDeliberateActiveGroupChange(t *testing.T) {
+	const assignedGroup = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+
+	r := loginProfileReapply{
+		setActiveGroupID: true,
+		activeGroupID:    uuid.FromStringOrNil(assignedGroup),
+	}
+
+	fresh := newReapplyTestProfile(t)
+	fresh.ActiveGroupID = ""
+
+	require.NoError(t, r.apply(fresh))
+	require.Equal(t, assignedGroup, fresh.ActiveGroupID,
+		"a group this login deliberately assigned must survive the retry")
+}
+
+// TestLoginProfileReapply_ReassertsUsernameOnlyDisplayName is half of finding 2.
+//
+// A guild with the UsernameOnly role forces the player's display name to their
+// username. That is enforcement, not preference: if the retry adopts the fresh
+// profile without re-asserting it, the session runs the whole way through with a
+// display name the guild does not permit.
+func TestLoginProfileReapply_ReassertsUsernameOnlyDisplayName(t *testing.T) {
+	const usernameOnlyGroup = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+
+	r := loginProfileReapply{
+		username:             "tester",
+		usernameOnlyGroupIDs: []string{usernameOnlyGroup},
+	}
+
+	// Storage still holds the name the player had before login forced the username.
+	fresh := newReapplyTestProfile(t)
+	fresh.SetGroupDisplayName(usernameOnlyGroup, "SomeOtherName")
+
+	require.NoError(t, r.apply(fresh))
+
+	dn, found := fresh.GetGroupDisplayName(usernameOnlyGroup)
+	require.True(t, found)
+	require.Equal(t, "tester", dn,
+		"the UsernameOnly role must be re-enforced against the freshly read profile")
+}
+
+// TestLoginProfileReapply_PrunesDisplayNameOwnedByAnotherAccount is the other half
+// of finding 2.
+//
+// Login prunes any in-game name that DisplayNameOwnerSearch says belongs to a
+// different account. Storage still holds that name, so a retry that simply adopts
+// the fresh profile puts the duplicate name straight back — the exact condition
+// the prune exists to prevent.
+func TestLoginProfileReapply_PrunesDisplayNameOwnedByAnotherAccount(t *testing.T) {
+	const guild = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
+
+	r := loginProfileReapply{
+		// Stored lowercased, matching how initializeSession builds the set.
+		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+	}
+
+	fresh := newReapplyTestProfile(t)
+	fresh.SetGroupDisplayName(guild, "TakenName")
+
+	require.NoError(t, r.apply(fresh))
+
+	_, found := fresh.GetGroupDisplayName(guild)
+	require.False(t, found,
+		"a name owned by another account must be pruned again after the re-read")
+}
+
+// TestLoginProfileReapply_KeepsUnrelatedConcurrentRename is the guard against
+// over-correcting findings 2 and 4.
+//
+// The fix must re-assert enforcement rules WITHOUT writing this session's whole
+// in-game name map over the fresh read. GuildPlayerRenameRPC writes that same
+// map, so a wholesale overwrite would clobber a rename that landed mid-write.
+func TestLoginProfileReapply_KeepsUnrelatedConcurrentRename(t *testing.T) {
+	const (
+		usernameOnlyGuild = "ffffffff-ffff-4fff-8fff-ffffffffffff"
+		renamedGuild      = "11111111-2222-4333-8444-555555555555"
+	)
+
+	r := loginProfileReapply{
+		username:                  "tester",
+		usernameOnlyGroupIDs:      []string{usernameOnlyGuild},
+		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+	}
+
+	fresh := newReapplyTestProfile(t)
+	fresh.SetGroupDisplayName(usernameOnlyGuild, "Whatever")
+	// A rename committed by the concurrent writer we are retrying around.
+	fresh.SetGroupDisplayName(renamedGuild, "FreshRename")
+
+	require.NoError(t, r.apply(fresh))
+
+	dn, found := fresh.GetGroupDisplayName(renamedGuild)
+	require.True(t, found, "the concurrent rename must not be deleted")
+	require.Equal(t, "FreshRename", dn,
+		"reapply must not overwrite in-game names it has no enforcement rule for")
+}
+
+// TestLoginProfileReapply_IsIdempotent pins the contract
+// evrProfileUpdateWithRetry documents: apply may run more than once, so it must
+// be free of order-dependent side effects.
+func TestLoginProfileReapply_IsIdempotent(t *testing.T) {
+	const (
+		guild             = "66666666-7777-4888-8999-aaaaaaaaaaaa"
+		usernameOnlyGuild = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
+	)
+
+	r := loginProfileReapply{
+		setActiveGroupID:          true,
+		activeGroupID:             uuid.FromStringOrNil(guild),
+		fixBrokenCosmetics:        true,
+		username:                  "tester",
+		usernameOnlyGroupIDs:      []string{usernameOnlyGuild},
+		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+	}
+
+	fresh := newReapplyTestProfile(t)
+	fresh.SetGroupDisplayName(usernameOnlyGuild, "Whatever")
+	fresh.SetGroupDisplayName(guild, "TakenName")
+
+	require.NoError(t, r.apply(fresh))
+	first := fresh.DisplayNamesByGroupID()
+	firstGroup := fresh.ActiveGroupID
+	firstLoadout := fresh.LoadoutCosmetics.Loadout
+
+	require.NoError(t, r.apply(fresh))
+	require.Equal(t, first, fresh.DisplayNamesByGroupID())
+	require.Equal(t, firstGroup, fresh.ActiveGroupID)
+	require.Equal(t, firstLoadout, fresh.LoadoutCosmetics.Loadout)
+}
+
+// TestInitializeSession_NotificationGoroutineDoesNotReadParamsProfile guards the
+// data race this PR fixes.
+//
+// initializeSession spawns a goroutine to send the "display name in use" Discord
+// notification, and — since the retry work landed — also reassigns the
+// params.profile FIELD when the profile write succeeds. A goroutine that reads
+// params.profile therefore races that assignment. The window is real: the
+// goroutine performs a Discord API call while the main path continues through
+// several storage round-trips before reaching the write.
+//
+// No unit test can drive initializeSession (it needs a full session and pipeline),
+// and -race cannot catch what it never executes, so this asserts the property
+// structurally: nothing spawned by initializeSession may read params.profile.
+// Snapshot the values into locals before the go statement instead.
+func TestInitializeSession_NotificationGoroutineDoesNotReadParamsProfile(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "evr_pipeline_login.go", nil, 0)
+	require.NoError(t, err)
+
+	var fn *ast.FuncDecl
+	ast.Inspect(file, func(n ast.Node) bool {
+		if d, ok := n.(*ast.FuncDecl); ok && d.Name.Name == "initializeSession" {
+			fn = d
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, fn, "initializeSession not found; this guard test is stale")
+
+	goStmts := 0
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		gs, ok := n.(*ast.GoStmt)
+		if !ok {
+			return true
+		}
+		goStmts++
+		ast.Inspect(gs, func(m ast.Node) bool {
+			sel, ok := m.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			ident, ok := sel.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if ident.Name == "params" && sel.Sel.Name == "profile" {
+				t.Errorf("goroutine at %s reads params.profile, which initializeSession "+
+					"reassigns after a storage retry — that is a data race. Snapshot the "+
+					"values into locals before the go statement.", fset.Position(m.Pos()))
+			}
+			return true
+		})
+		return true
+	})
+
+	require.Positive(t, goStmts,
+		"expected at least one go statement in initializeSession; this guard test is stale")
+}

--- a/server/evr_pipeline_login_reapply_test.go
+++ b/server/evr_pipeline_login_reapply_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"strings"
 	"testing"
 
 	"github.com/gofrs/uuid/v5"
@@ -113,8 +114,10 @@ func TestLoginProfileReapply_PrunesDisplayNameOwnedByAnotherAccount(t *testing.T
 	const guild = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"
 
 	r := loginProfileReapply{
-		// Stored lowercased, matching how initializeSession builds the set.
-		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+		// Deliberately a different case from the stored name below: the prune in
+		// initializeSession matches with strings.EqualFold, and the retry must use
+		// the same comparison rather than an exact or lowercase-only match.
+		displayNamesOwnedByOthers: []string{"takenname"},
 	}
 
 	fresh := newReapplyTestProfile(t)
@@ -142,7 +145,7 @@ func TestLoginProfileReapply_KeepsUnrelatedConcurrentRename(t *testing.T) {
 	r := loginProfileReapply{
 		username:                  "tester",
 		usernameOnlyGroupIDs:      []string{usernameOnlyGuild},
-		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+		displayNamesOwnedByOthers: []string{"takenname"},
 	}
 
 	fresh := newReapplyTestProfile(t)
@@ -173,7 +176,7 @@ func TestLoginProfileReapply_IsIdempotent(t *testing.T) {
 		fixBrokenCosmetics:        true,
 		username:                  "tester",
 		usernameOnlyGroupIDs:      []string{usernameOnlyGuild},
-		displayNamesOwnedByOthers: map[string]struct{}{"takenname": {}},
+		displayNamesOwnedByOthers: []string{"takenname"},
 	}
 
 	fresh := newReapplyTestProfile(t)
@@ -248,4 +251,53 @@ func TestInitializeSession_NotificationGoroutineDoesNotReadParamsProfile(t *test
 
 	require.Positive(t, goStmts,
 		"expected at least one go statement in initializeSession; this guard test is stale")
+}
+
+// TestLoginProfileReapply_PrunesUsingTheSameFoldAsInitializeSession pins that the
+// retry's prune uses strings.EqualFold — the exact comparison initializeSession's
+// own prune uses — and not lowercase-set membership, which is a subtly different
+// rule.
+//
+// 'U+017F LATIN SMALL LETTER LONG S' is the discriminator: EqualFold folds it to
+// 's'; strings.ToLower leaves it alone. Under a lowercased set the retry would
+// therefore MISS a name the non-retry path deleted, leaving the player logged in
+// under a name the server had already ruled belongs to someone else.
+//
+// Reachability: the name is installed with SetGroupIGNData, which is what the
+// display-name-override path in initializeSession uses, and which does NOT
+// sanitize. That override comes straight from the "ign" query parameter on the
+// login WebSocket URL, parsed with a nil pattern (server/evr_session.go
+// parseUserQueryFunc), so a client controls these bytes exactly. Building the
+// state with SetGroupDisplayName instead would make this test vacuous: that
+// setter runs sanitizeDisplayName, whose anyascii transliteration rewrites the
+// long s to a plain 's' before either comparison ever sees it.
+func TestLoginProfileReapply_PrunesUsingTheSameFoldAsInitializeSession(t *testing.T) {
+	const (
+		guild     = "77777777-8888-4999-8aaa-bbbbbbbbbbbb"
+		longSName = "\u017fam" // "\u017fam" — folds to "sam", does not lowercase to it
+	)
+
+	// Guard the discriminator itself, so this test cannot quietly become a
+	// tautology if the constant is edited or the stdlib changes.
+	require.True(t, strings.EqualFold(longSName, "Sam"),
+		"precondition: EqualFold must fold these; otherwise this test proves nothing")
+	require.NotEqual(t, strings.ToLower(longSName), strings.ToLower("Sam"),
+		"precondition: ToLower must NOT collapse them, or there is nothing to discriminate")
+
+	r := loginProfileReapply{displayNamesOwnedByOthers: []string{"Sam"}}
+
+	fresh := newReapplyTestProfile(t)
+	// SetGroupIGNData, not SetGroupDisplayName: the override path stores the
+	// client-supplied name verbatim. See the reachability note above.
+	fresh.SetGroupIGNData(guild, GroupInGameName{GroupID: guild, DisplayName: longSName})
+
+	// Precondition: the name really did survive unsanitized into the profile.
+	require.Equal(t, longSName, fresh.DisplayNamesByGroupID()[guild],
+		"precondition: SetGroupIGNData must store the name verbatim")
+
+	require.NoError(t, r.apply(fresh))
+
+	_, found := fresh.GetGroupDisplayName(guild)
+	require.False(t, found,
+		"the retry must prune with EqualFold, matching initializeSession's prune")
 }

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -576,8 +576,11 @@ func (s *EventRemoteLogSet) incrementCompletedMatches(ctx context.Context, logge
 		// Track completion in detailed history first; only credit the counter
 		// when this is the first time the match is reported (the MatchLoop
 		// MatchOver dispatch also reports it).
+		// Warn, not Debug: this is the failure that costs the player match
+		// credit (no history write means no IncrementCompletedMatches), so it
+		// must be at least as visible as the adjacent eqconfig write failure.
 		if first, err := TrackMatchCompletion(ctx, logger, nk, userID, matchID, time.Now().UTC()); err != nil {
-			logger.WithField("error", err).Debug("Failed to track match completion in history")
+			logger.WithField("error", err).Warn("Failed to track match completion in history")
 		} else if first {
 			eqconfig.IncrementCompletedMatches()
 		}

--- a/server/evr_runtime_rpc_guild_rename.go
+++ b/server/evr_runtime_rpc_guild_rename.go
@@ -105,15 +105,20 @@ func GuildPlayerRenameRPC(ctx context.Context, logger runtime.Logger, db *sql.DB
 		return "", runtime.NewError("Player profile not found", StatusNotFound)
 	}
 
-	// Get the old display name for this guild
-	oldIGN := evrProfile.GetGroupIGNData(groupID)
-	oldName := oldIGN.DisplayName
-	if oldName == "" {
-		oldName = evrProfile.Username()
-	}
+	// oldName is the display name this rename replaced. It is captured INSIDE
+	// setIGN, from the profile setIGN is handed, rather than read once up front:
+	// on a retry after a version conflict the callback runs again against a
+	// freshly read profile, and the audit log and RPC response below must quote
+	// the name that was actually replaced, not the one this request happened to
+	// read before the concurrent writer committed.
+	var oldName string
 
 	// Set the new per-guild display name with override and lock flags
 	setIGN := func(profile *EVRProfile) error {
+		oldName = profile.GetGroupIGNData(groupID).DisplayName
+		if oldName == "" {
+			oldName = profile.Username()
+		}
 		profile.SetGroupIGNData(groupID, GroupInGameName{
 			GroupID:     groupID,
 			DisplayName: sanitizedName,
@@ -123,7 +128,9 @@ func GuildPlayerRenameRPC(ctx context.Context, logger runtime.Logger, db *sql.DB
 		return nil
 	}
 	// setIGN never fails; the error return exists only to satisfy
-	// evrProfileUpdateWithRetry's callback signature.
+	// evrProfileUpdateWithRetry's callback signature. Calling it here both applies
+	// the rename to the profile already in hand and records oldName for the
+	// uncontended path, where the callback is never invoked again.
 	_ = setIGN(evrProfile)
 
 	// Persist the profile (writes storage + invalidates ServerProfile cache).

--- a/server/evr_runtime_rpc_guild_rename.go
+++ b/server/evr_runtime_rpc_guild_rename.go
@@ -113,18 +113,29 @@ func GuildPlayerRenameRPC(ctx context.Context, logger runtime.Logger, db *sql.DB
 	}
 
 	// Set the new per-guild display name with override and lock flags
-	evrProfile.SetGroupIGNData(groupID, GroupInGameName{
-		GroupID:     groupID,
-		DisplayName: sanitizedName,
-		IsOverride:  true,
-		IsLocked:    request.IsLocked,
-	})
+	setIGN := func(profile *EVRProfile) error {
+		profile.SetGroupIGNData(groupID, GroupInGameName{
+			GroupID:     groupID,
+			DisplayName: sanitizedName,
+			IsOverride:  true,
+			IsLocked:    request.IsLocked,
+		})
+		return nil
+	}
+	// setIGN never fails; the error return exists only to satisfy
+	// evrProfileUpdateWithRetry's callback signature.
+	_ = setIGN(evrProfile)
 
-	// Persist the profile (writes storage + invalidates ServerProfile cache)
-	if err := EVRProfileUpdate(ctx, nk, targetUserID, evrProfile); err != nil {
+	// Persist the profile (writes storage + invalidates ServerProfile cache).
+	// Retry on a version conflict with a fresh read: the Discord sync and login
+	// paths write this same key, and a rename must not be rejected because one of
+	// them happened to commit first.
+	updated, err := evrProfileUpdateWithRetry(ctx, nk, targetUserID, evrProfile, setIGN)
+	if err != nil {
 		logger.Error("Failed to update EVR profile", zap.Error(err), zap.String("user_id", targetUserID))
 		return "", runtime.NewError("Failed to update player profile", StatusInternalError)
 	}
+	evrProfile = updated
 
 	// Record the change in display name history
 	if err := DisplayNameHistoryUpdate(ctx, nk, targetUserID, groupID, sanitizedName, evrProfile.Username(), false); err != nil {


### PR DESCRIPTION
Tier-1 batch: assorted one-off correctness fixes and hygiene. Base `d3e7e5549`, head `2ba891a29`.

Every claim below cites `file:line @ <sha>`, a test name, or quoted command output. Line numbers were re-checked at the SHA each claim names. §1–11 remain pinned at `a26c326c3` and are unaffected by the later commit; §12 cites `2ba891a29`.

## Summary

| # | scenario | class | gated behind | frequency |
|---|---|---|---|---|
| 1 | `MarshalMap` truncated int64 item hashes above 2^53 | FIX | none — every profile write | every write whose profile holds a hash > 2^53 |
| 2 | `GUILD_DELETE` for a group missing from the registry panicked the process | FIX | none | rare, but process-fatal |
| 3 | A storage version conflict rejected the login outright | FIX | none | unquantified — see §3 |
| 4 | Retry re-applied login rules against a **stale** profile | FIX | only on a version conflict | subset of §3 |
| 5 | Retry stamped a stale loadout / dropped the equip | FIX | only on a version conflict | subset of §3 |
| 6 | `TrackMatchCompletion` failure logged at Debug | FIX (log) | none | every failed history write |
| 7 | Retry prune used `ToLower` where the original used `EqualFold` | FIX | conflict **and** a non-ASCII `?ign=` name | unquantified, narrow |
| 8 | Three retry attempts fired with no delay | FIX | only on a version conflict | subset of §3 |
| 9 | Guild-rename audit log could name a stale old name | FIX | only on a version conflict | subset of §3 |
| 10 | "Updated jersey number" logged even when the write failed | NEUTRAL (log) | loadout write failure | rare |
| 11 | 87MB orphaned binary tracked in git; 3 dead functions | NEUTRAL | none | n/a |
| 12 | Daily stat-group test asserted against **local** time, implementation formats **UTC** | NEUTRAL (test-only) | none — no production change | test was red every evening in any negative-UTC-offset zone |

---

### 1. `EVRProfile.MarshalMap` truncated 64-bit values  [FIX]

**What was tried:** A player owns a cosmetic whose EchoVR item hash exceeds 2^53 (`NewUnlocks`), or has a `uint64` customization POI version. Anything triggering a profile write — logging in, equipping an item — runs `EVRProfileUpdate`.
**What they expected:** The storage row and the account metadata, written together in one `MultiUpdate`, hold the same numbers.
**What happened BEFORE this PR:** `MarshalMap` decoded with a plain `json.Unmarshal`, turning every JSON number into a `float64`. `EVRProfileUpdate` writes the storage value with `json.Marshal` (exact) and the metadata with `MarshalMap` (lossy), so the two halves of one atomic write committed **different data**.
**Estimated frequency:** Every write of a profile holding such a value. Not quantified against production data.
**What happens AFTER this PR:** Decoding uses `json.Decoder.UseNumber()` (`server/evr_account.go:353 @ a26c326c3`); `json.Number` keeps the literal intact and `encoding/json` re-emits it verbatim.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none.
**How to verify in production logs:** Not observable in logs; it is a silent data divergence. Compare a profile's storage row against its account metadata for the same user.
**Citation:** `TestEVRProfileMarshalMap_PreservesInt64Precision`, `TestEVRProfileMarshalMap_Int64Boundaries`, `TestEVRProfileMarshalMap_AgreesWithStorageValue`. Reverting the body to the pre-fix form makes them fail with `expected 1234567890123456789, actual 1234567890123456800`; `18446744073709551615 → 18446744073709552000`; `-9007199254740993 → -9007199254740992`.

### 2. `GUILD_DELETE` panicked the process  [FIX]

**What was tried:** A guild owner removes the bot from their Discord server (or deletes the server) while that group exists in the database but is absent from `guildGroupRegistry`.
**What they expected:** The group is deleted and the server keeps running.
**What happened BEFORE this PR:** `handleGuildDelete` read `gg.GroupMetadata` straight off `guildGroupRegistry.Get(groupID)`. `Get` returns nil in that window (the rebuild filters on `GuildGroupLangTag`; any failure between `GroupCreate` and `registry.Add` in `guildSync` opens it). `GroupMetadata` is an embedded **value**, so this is a nil-pointer dereference, not a nil-map read. discordgo dispatches handlers on bare goroutines with no `recover`, so **the panic took down the process**.
**Estimated frequency:** Unquantified — requires the registry gap to coincide with a guild-delete event. Consequence is process-fatal.
**What happens AFTER this PR:** The lookup is nil-checked (`server/evr_discord_integrator.go:705-707 @ a26c326c3`); the group is still deleted, only the metadata detail in the log is lost.
**Log signature BEFORE:** `Deleting guild group` (`evr_discord_integrator.go:705`), then a panic stack.
**Log signature AFTER:** unchanged in the normal case. **NEW line** on the nil path: `Deleting guild group (not present in registry)` at Info (`evr_discord_integrator.go:707`).
**How to verify in production logs:** `grep -c 'Deleting guild group (not present in registry)' /home/echovrce/deployment/logs/nakama.log` — a non-zero count is the previously-fatal path now handled. Operators should not read this as a fault.
**Citation:** `TestHandleGuildDelete_UnregisteredGroupDoesNotPanic`, `TestHandleGuildDelete_RegisteredGroupStillDeletes`, `TestHandleGuildDelete_UnknownGuildIsNoOp`. Removing the guard: `Panic value: runtime error: invalid memory address or nil pointer dereference`.

Same class of bug guarded in `earlyQuitEnforcementEnabled` (`server/evr_earlyquit.go:287 @ a26c326c3`): the `g == nil` guard inside `GroupMetadata.GetEnforceEarlyQuitPenalty` is decorative, because `gg.GetEnforceEarlyQuitPenalty()` evaluates `&gg.GroupMetadata` before the body runs. Removing `|| gg == nil` reproduces the same nil-deref panic (`TestEarlyQuitEnforcementEnabled_NilGuildGroupEntry`). The new `|| gg == nil` returns the same lenient default as the existing `!ok` branch, so guild scoping is unchanged.

### 3. A version conflict rejected the login outright  [FIX]

**What was tried:** A player logs in while a Discord member-sync or a guild-rename writes their profile.
**What they expected:** To log in.
**What happened BEFORE this PR:** PR #520 removed `EVRProfileUpdate`'s internal retry — correctly, since a blind retry re-submits the caller's stale payload and discards the concurrent writer's work. But the login path and two others were then left with **no retry at all**, so the first conflict failed the login with `failed to update user profile`.
**Estimated frequency:** Unquantified. The competing writers (`evr_discord_appbot.go:2163/2299/2414/3645`, `evr_discord_appbot_linking.go:119/286`, and the guild-rename RPC) are driven by Discord commands and reconnects that are not sequenced against the session.
**What happens AFTER this PR:** `evrProfileUpdateWithRetry` (`server/evr_account.go:559 @ a26c326c3`) makes up to 3 attempts, **re-reading between them** and re-applying the caller's mutation to the fresh profile. Wired at all three sites: `evr_pipeline_login.go:1059`, `evr_pipeline_gameserver_loadout.go:160`, `evr_runtime_rpc_guild_rename.go:140`.
**Log signature BEFORE:** `failed to update user profile` (login), returned as a session error.
**Log signature AFTER:** unchanged for a **final** failure after 3 attempts. No new log line per retry — see "Known follow-ups".
**How to verify in production logs:** `grep -c 'failed to update user profile' /home/echovrce/deployment/logs/nakama.log` — the count should fall.
**Citation:** `TestEVRProfileUpdateWithRetry_RetriesOnConflictWithFreshRead`. Setting `evrProfileUpdateMaxAttempts = 1` fails it with `a version conflict must not be fatal`. A retry **without** the re-read fails it with `expected "gold", actual ""` — the test discriminates a correct retry from a stale-payload retry.

### 4. The retry re-applied login rules against a stale profile  [FIX]

**What was tried:** A player switches guild in Discord (or is renamed) at the moment their client reconnects, and the login write loses the version race.
**What they expected:** Their guild switch / rename sticks; enforcement rules still apply.
**What happened BEFORE this PR:** `loginProfileReapply.apply` (`server/evr_pipeline_login.go:670 @ a26c326c3`) is the callback the retry runs against the freshly read profile. Three defects:
- it unconditionally re-asserted `ActiveGroupID`, **reverting the concurrent guild switch**;
- it dropped the UsernameOnly enforcement, leaving the session running under a name the guild forbids;
- it dropped the prune of names owned by another account, **resurrecting a name the server had already rejected**.

Separately, the notification goroutine read `params.profile.DiscordID()`/`.Username()` while the main path reassigned `params.profile` after a successful retry — a **data race**.
**Estimated frequency:** A subset of §3.
**What happens AFTER this PR:** Every field of `loginProfileReapply` is a **rule re-evaluated against the fresh profile**, never a replay of this session's snapshot. `setActiveGroupID` is only true when this session deliberately chose a new group. The goroutine reads snapshots taken before the `go` statement (`server/evr_pipeline_login.go:879`).
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none.
**How to verify in production logs:** Not observable. The guild switch reverting was silent.
**Citation:** `TestLoginProfileReapply_DoesNotRevertConcurrentActiveGroupChange`, `_PersistsDeliberateActiveGroupChange`, `_ReassertsUsernameOnlyDisplayName`, `_PrunesDisplayNameOwnedByAnotherAccount`, `_KeepsUnrelatedConcurrentRename` (the over-correction guard), `_IsIdempotent`, and `TestInitializeSession_NotificationGoroutineDoesNotReadParamsProfile` (an AST guard — no unit test can drive `initializeSession`). All five perturbations go red, including the over-correction guard.

### 5. The loadout retry stamped a stale loadout / dropped the equip  [FIX]

**What was tried:** A player on a NativeSupport game server equips an emote at the character customization screen while another writer commits their legitimately-owned VRML finalist tag.
**What they expected:** Both stick.
**What happened BEFORE this PR:** The retry callback derived the base loadout from the profile read **before** the conflict, so it wrote all 22 slots of that stale copy over the concurrent writer's work — the tag reverted, silently.
**Estimated frequency:** A subset of §3, restricted to NativeSupport game servers. This handler is the **sole** persistence path for them: the remotelogset equip handler explicitly skips itself for NativeSupport matches.
**What happens AFTER this PR:** `applyGameServerLoadout` derives **everything except the equips** from the profile it is handed, and `persistGameServerLoadout` (`server/evr_pipeline_gameserver_loadout.go:145 @ a26c326c3`) keeps that callback next to the retry call so a test can drive a real conflict through it. Only the slots the request named change. COSMETIC-1 ownership still applies, checked against the re-read profile's wallet.
**Log signature BEFORE:** none — silent. The success log reported the loadout of the attempt that lost.
**Log signature AFTER:** `Successfully saved loadout update` (`evr_pipeline_gameserver_loadout.go:286`) — same message and level, but its `loadout` field now reports what was **persisted** rather than what the losing attempt produced.
**How to verify in production logs:** `grep 'Successfully saved loadout update' /home/echovrce/deployment/logs/nakama.log` — the `loadout` field now matches storage.
**Citation:** `TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile` (+ `_NoConflictWritesEquipsOnce`, `_StripsUnownedCosmeticOnRetry`), plus the unit tests `TestApplyGameServerLoadout_*`. See "Test coverage" below for the two perturbations these catch.

### 6. `TrackMatchCompletion` failure hidden at Debug  [FIX — log level]

**What was tried:** A player stays through an entire match. The history write behind `TrackMatchCompletion` fails.
**What they expected:** Credit for the match, or at least a visible error.
**What happened BEFORE this PR:** Logged at **Debug**, so invisible at production log levels — while the *adjacent, less consequential* eqconfig write failure logged at Warn. Without the history write, `IncrementCompletedMatches` is never called and the completion is lost.
**Estimated frequency:** Every failed history write.
**What happens AFTER this PR:** Warn at both sites: `server/evr_runtime_event_remotelogset.go:583` and `server/evr_match.go:1522 @ a26c326c3`.
**Log signature BEFORE:** `Failed to track match completion in history` at **Debug**.
**Log signature AFTER:** `Failed to track match completion in history` at **Warn** — same message string, same fields, **higher level**.
**How to verify in production logs:** `grep -c 'Failed to track match completion in history' /home/echovrce/deployment/logs/nakama.log`. **This line will newly appear** in production logs. A non-zero count is not a new fault — it is a previously-hidden one becoming visible. If the count is high, players have been losing match credit all along.
**Citation:** `TestIncrementCompletedMatches_TrackFailureLogsAboveDebug`. Reverting Warn→Debug fails it with `the failure that costs the player match credit must not be hidden at Debug`.

### 7. The retry prune used `ToLower` where the original used `EqualFold`  [FIX]

**What was tried:** A player connects with a display-name override containing U+017F LATIN SMALL LETTER LONG S (`?ign=` on the login WebSocket URL), holds a plain-ASCII variant of the same name in another guild, and that name is registered to a different account. The login write then loses a version race.
**What they expected:** The same names pruned whether or not a retry happened.
**What happened BEFORE this PR:** `initializeSession`'s prune matches with `strings.EqualFold` (`server/evr_pipeline_login.go:891 @ a26c326c3`), but `loginProfileReapply.apply` re-implemented it as membership in a `strings.ToLower`-keyed set. `EqualFold` applies simple Unicode folding; `ToLower` does not collapse the same pairs. So the retry **missed** a name the non-retry path deleted.

Reachability, verified: the override is stored via `SetGroupIGNData`, which does **not** sanitize (`server/evr_account.go:255`), and it comes from `parseUserQueryFunc(&request, "ign", 20, nil)` (`server/session_ws.go:150`) — a nil pattern means no validation beyond truncation (`server/evr_session.go:166-177`). A client controls those bytes exactly.
**Estimated frequency:** Unquantified and narrow — requires a conflict **and** a non-ASCII override **and** a cross-account name collision.
**What happens AFTER this PR:** The names are stored verbatim and matched with `strings.EqualFold` (`server/evr_pipeline_login.go:682 @ a26c326c3`), so the retry re-evaluates the original rule.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none.
**How to verify in production logs:** Not observable.
**Citation:** `TestLoginProfileReapply_PrunesUsingTheSameFoldAsInitializeSession`. Under a `ToLower` implementation it fails with `the retry must prune with EqualFold, matching initializeSession's prune`. The test asserts its own discriminator as a precondition so it cannot decay into a tautology.

### 8. Three retry attempts fired with no delay  [FIX]

**What was tried:** A profile write contends with a writer that holds the key for a full storage round-trip.
**What they expected:** The retry to help.
**What happened BEFORE this PR:** The three attempts were issued back to back over a few hundred microseconds — well inside the window the competing writer holds — so all three lost to the same writer.
**Estimated frequency:** A subset of §3.
**What happens AFTER this PR:** Exponential backoff, 20ms then 40ms (`server/evr_account.go:523,531 @ a26c326c3`). Deliberately short: login blocks on this call. A cancelled context aborts the wait instead of sleeping it out, and the error joins the context error with the conflict error so `isVersionConflictError` — which matches on message text — still recognises it.
**Log signature BEFORE:** none.
**Log signature AFTER:** none.
**How to verify in production logs:** Not directly observable; see §3's grep.
**Citation:** `TestEVRProfileUpdateWithRetry_BacksOffBetweenAttempts`, `_CancelledContextAbortsTheBackoff`. The delay is visible in the existing tests' timings: `_RetriesOnConflictWithFreshRead (0.02s)`, `_GivesUpAfterBoundedAttempts (0.06s)`.

### 9. Guild-rename audit log could name a stale old name  [FIX]

**What was tried:** An operator renames a player via the `guild/player/rename` RPC while another writer commits a change to the same profile.
**What they expected:** The audit log's "from `%s`" names the value actually replaced.
**What happened BEFORE this PR:** `oldName` was read from the profile fetched **before** the write. On a retry the rename is re-applied to a freshly read profile, so the audit log and the RPC response's `OldName` could name a value the concurrent writer had already replaced.
**Estimated frequency:** A subset of §3, restricted to the rename RPC.
**What happens AFTER this PR:** `oldName` is captured inside `setIGN`, from the profile `setIGN` is handed (`server/evr_runtime_rpc_guild_rename.go:114,118 @ a26c326c3`).
**Log signature BEFORE:** the audit message's "from" value could be stale; message string unchanged.
**Log signature AFTER:** same message string and level; the **value** is now always the replaced name.
**How to verify in production logs:** `grep 'old_name' /home/echovrce/deployment/logs/nakama.log` — values now always reflect what was overwritten.
**Citation:** Covered by inspection plus `TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile`, which proves `evrProfileUpdateWithRetry` hands the callback a freshly-read profile. No behaviour change on the uncontended path: `setIGN` runs once on the profile in hand and computes `oldName` exactly as the removed code did.

### 10. "Updated jersey number" logged even when the write failed  [NEUTRAL — log]

**What was tried:** A game server saves a loadout including a jersey number; the profile write then fails.
**What they expected:** The log not to claim an update that did not persist.
**What happened BEFORE this PR:** The line was emitted **before** the write, so a failed write still reported a jersey number that never persisted.
**Estimated frequency:** Only when the loadout write fails.
**What happens AFTER this PR:** Emitted only after the write commits (`server/evr_pipeline_gameserver_loadout.go:283 @ a26c326c3`).
**Log signature BEFORE:** `Updated jersey number` at Info.
**Log signature AFTER:** `Updated jersey number` at Info — **identical message, level and fields**. Emitted **strictly less often**: never a new emission, only the removal of a false-positive.
**How to verify in production logs:** `grep -c 'Updated jersey number' /home/echovrce/deployment/logs/nakama.log` — the count may fall slightly. It cannot rise.
**Citation:** `server/evr_pipeline_gameserver_loadout.go:279-284 @ a26c326c3`.

### 11. Repo hygiene  [NEUTRAL]

`tools/purge-docker-ips/purge-docker-ips`, an 87MB ELF whose source was deleted, is untracked (`Bin 87952440 → 0 bytes`). `.gitignore` gains `/tools/party-split-detector/party-split-detector` and `/tools/echovr-mock-client/echovr-mock-client`; both are `package main` and both patterns verified effective via `git check-ignore` (`.gitignore:743`/`:744`). Three dead functions removed from `server/evr_earlyquit.go` and `server/evr/login_earlyquitconfig.go` — each had exactly one occurrence (its definition) at `d3e7e5549` and zero at head. No production behaviour.

### 12. Daily stat-group test asserted local time against a UTC implementation  [NEUTRAL]

Added at the repo owner's request ("toss it on the trivial fixes PR"). Pre-existing, last touched by `4e5a48d2e`, predating this branch's base; unrelated to §1–11. Earlier revisions of this PR body listed it under "out of scope"; it is now fixed, and that entry is removed.

**What was tried:** Any developer runs `go test ./server/evr/` from a machine whose local date differs from the UTC date — i.e. any negative-UTC-offset zone, in the hours after UTC rolls over.
**What they expected:** A test result that reflects the code, not the clock or the machine's `TZ`.
**What happened BEFORE this commit:** `MarshalText` formats `time.Now().UTC()` while the test built its expectation from `time.Now()` in **local** time (`server/evr/core_account_statistics_test.go:24 @ a26c326c3`). Both sides read the ambient clock, so the test asserted nothing about the code and everything about where it ran — green all day for a US-based developer, red every evening. CI runs UTC, so it never fired there. Reproduced at this branch's head before the fix:

```
$ TZ=America/Chicago GOWORK=off go test ./server/evr/ -run TestStatisticsGroup_MarshalText -count=1 -v
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena (0.00s)
```

**Estimated frequency:** Deterministic given zone and time of day — roughly 5 hours a day (CDT) of false red for a US-based developer, 0% on CI.
**What happens AFTER this commit:** The clock is injectable. `var timeNow = time.Now` (`server/evr/core_account_statistics.go:40 @ 2ba891a29`) is read by the daily formatter (`:55`) and by `mostRecentThursday` (`:907`); tests pin it to a fixed instant via `pinClock` (`server/evr/core_account_statistics_test.go:15 @ 2ba891a29`).

**Production behaviour is unchanged — this is a testability refactor, not a behaviour change.** `timeNow` *is* `time.Now`, so the production expressions are `time.Now().UTC()` exactly as before; the UTC semantics are deliberately preserved, because the server partitions stats by UTC day and UTC week so guilds in many timezones share one bucket. Nothing but the two test files can rebind the var; it is unexported and assigned nowhere in non-test code:

```
$ grep -rn 'timeNow *=' server/ | grep -v _test.go
server/evr/core_account_statistics.go:40:var timeNow = time.Now
```

**Why a package-level var and not a field.** `StatisticsGroup` is used as a **map key** — `type PlayerStatistics map[StatisticsGroup]Statistics` (`server/evr/core_account_statistics.go:120 @ 2ba891a29`) plus `map[evr.StatisticsGroup][]string` and `map[evr.StatisticsGroup]string` in `server/evr_statistics.go:351-352`. Go func values are not comparable, so a `now func() time.Time` **field** would make the struct non-comparable and fail to compile at every one of those maps, and at the `group != tt.expected` assertion in the existing unmarshal test. `MarshalText` also has a value receiver reached through `encoding/json` map-key marshalling, so there is no call site to thread a clock through. The package-level var is the only injection point that does not require changing all 41 `StatisticsGroup{...}` construction sites. It follows the restore-in-`t.Cleanup` idiom already used for package state in this repo (`server/evr_matchmaking_credit_test.go:13`, `server/evr_enforcement_metrics_test.go:103`).

**Log signature BEFORE:** none — test-only.
**Log signature AFTER:** none. No production log message is added, removed, or re-levelled.
**How to verify in production logs:** Not applicable; nothing reaches production. The stat group names emitted by the server are byte-identical before and after.

**Citation — the assertions are not vacuous.** `TestStatisticsGroup_MarshalText` and the new `TestStatisticsGroup_MarshalText_UTCDateBoundary` (`server/evr/core_account_statistics_test.go:102 @ 2ba891a29`). The boundary test pins two instants either side of a UTC midnight, each carried in a `time.FixedZone` whose wall clock reads the *adjacent* date — `2026-08-06T00:30:00Z` held at UTC-5 (reads Aug 5), and `2026-08-05T23:30:00Z` held at UTC+13 (reads Aug 6). That disagreement is what gives the test teeth: dropping `.UTC()` from either formatter turns it red **under `TZ=UTC`**, the very environment in which the original bug was invisible.

```
--- daily: .UTC() dropped from MarshalText, run under TZ=UTC ---
core_account_statistics_test.go:92: MarshalText() got = daily_2026_08_05, expected daily_2026_08_06
core_account_statistics_test.go:136: daily at 2026-08-06T00:30:00Z (2026-08-05 19:30 UTC-5 local): got = daily_2026_08_05, expected daily_2026_08_06
core_account_statistics_test.go:136: daily at 2026-08-05T23:30:00Z (2026-08-06 12:30 UTC+13 local): got = daily_2026_08_06, expected daily_2026_08_05

--- weekly: .UTC() dropped from mostRecentThursday, run under TZ=UTC ---
core_account_statistics_test.go:92: MarshalText() got = weekly_2026_07_30, expected weekly_2026_08_06
core_account_statistics_test.go:146: weekly at 2026-08-06T00:30:00Z (2026-08-05 19:30 UTC-5 local): got = weekly_2026_07_30, expected weekly_2026_08_06
core_account_statistics_test.go:146: weekly at 2026-08-05T23:30:00Z (2026-08-06 12:30 UTC+13 local): got = weekly_2026_08_06, expected weekly_2026_07_30
```

Both perturbations were reverted; the production diff for this commit is three lines — one `var`, and `time.Now()` → `timeNow()` at the two call sites, both keeping `.UTC()`.

The weekly case also stopped being self-referential. It previously asserted `mostRecentThursday()` against `mostRecentThursday()` (`:32 @ a26c326c3`), which passes under any implementation; it now asserts hand-checked literals (`weekly_2026_08_06` for a Thursday instant, `weekly_2026_07_30` for the Wednesday one).

---

## Test coverage: the gap this round closed

The adversarial review found that the units extracted by `9ee14efbe` were well tested but **nothing tested that the call sites pass them the right inputs**. I reproduced this independently. Changing the loadout retry callback to `func(_ *EVRProfile)` — so its body closes over the caller's pre-conflict profile — left the **entire suite green**:

```
ok  	github.com/heroiclabs/nakama/v3/server	125.805s
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.021s
EXIT=0
```

`persistGameServerLoadout` now holds the callback and the retry call in one function that a test drives end to end against an OCC-correct module that rejects the first write. Both miswirings fail loudly:

```
--- callback ignores its parameter ---
--- FAIL: TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile
    expected: "rwd_emote_test_owned_a"
    actual  : "emote_blink_smiley_a"
    Messages: the equip this request asked for must actually be stored: the retry
              callback must mutate the profile it is HANDED, not the caller's

--- stale base loadout captured before the conflict ---
--- FAIL: TestPersistGameServerLoadout_RetryComposesEquipsOntoFreshProfile
    expected: "rwd_tag_s1_vrml_s1_finalist"
    actual  : "rwd_tag_s1_a_secondary"
    Messages: the concurrent writer's tag must survive: the retry must compose onto
              the RE-READ loadout, not stamp back the pre-conflict copy
```

Note these are *different* failures. The parameter-dropping miswiring does not clobber the tag — it silently **drops the player's equip**, because `evrProfileUpdateWithRetry` writes the reloaded object while the callback mutated a different one. The test asserts both halves.

**One test I wrote was vacuous and I caught it.** The first version of the `EqualFold` test built its state with `SetGroupDisplayName`, which runs `sanitizeDisplayName`, whose anyascii transliteration rewrites the long s to a plain `s` before either comparison sees it. It passed under the `ToLower` implementation too. Rewritten to use `SetGroupIGNData` — the setter the override path actually uses, which does not sanitize — it now discriminates.

## What does NOT change

- **Matchmaking.** No matchmaking path is touched. `git diff d3e7e5549..HEAD -- 'server/*.go' ':!server/*_test.go' | grep -E "^\+.*(uuid\.Nil|GroupID\s*=)"` returns **no matches**. Cross-guild pooling is not introduced anywhere.
- **Guild scoping of early-quit enforcement.** The new `|| gg == nil` in `earlyQuitEnforcementEnabled` (`server/evr_earlyquit.go:287`) returns the same lenient default as the existing `!ok` branch.
- **COSMETIC-1 ownership.** Still enforced, and now also on the retry path against the re-read profile's wallet (`TestPersistGameServerLoadout_StripsUnownedCosmeticOnRetry`, `TestApplyGameServerLoadout_StillStripsUnownedCosmetics`).
- **`EVRProfileUpdate`'s single-attempt contract.** Unchanged. The retry is a separate wrapper; nothing re-submits a stale payload.
- **The uncontended write path.** Every retry change is behind a version conflict. With no conflict there is one write, no reload, and the callback is never re-run (`TestEVRProfileUpdateWithRetry_SucceedsFirstTryWithoutReload` asserts `applyCalls == 0`).
- **In-game names on retry.** Deliberately *not* re-applied wholesale — the guild-rename RPC writes the same map, and overwriting it would clobber a rename that landed mid-write (`TestLoginProfileReapply_KeepsUnrelatedConcurrentRename`).
- **Statistic group names.** §12 is a test-only fix. `daily_*` and `weekly_*` are still stamped from `time.Now().UTC()` — `timeNow` is `time.Now` in production — so the strings the server emits, and the leaderboard buckets keyed off them, are byte-identical. The UTC partitioning is deliberate and was preserved, not "fixed".
- **No test files deleted or renamed.**

## Production log impact

Changed, added, or re-frequency'd — the complete list:

| line | change |
|---|---|
| `Failed to track match completion in history` (`evr_runtime_event_remotelogset.go:583`, `evr_match.go:1522`) | **Debug → Warn.** Will newly appear in production logs. Not a new fault. |
| `Deleting guild group (not present in registry)` (`evr_discord_integrator.go:707`) | **New line**, Info. Replaces a process panic. |
| `Updated jersey number` (`evr_pipeline_gameserver_loadout.go:283`) | Unchanged text/level/fields; emitted **strictly less often** (only after the write commits). |
| `Successfully saved loadout update` (`evr_pipeline_gameserver_loadout.go:286`) | Unchanged text/level; its `loadout` field now reports what was persisted rather than the losing attempt. |
| guild-rename audit `old_name` (`evr_runtime_rpc_guild_rename.go`) | Unchanged text/level; the **value** is now always the replaced name. |

Everything else: **no production log messages affected.** Checked with `git diff d3e7e5549..HEAD -- 'server/*.go' ':!server/*_test.go' | grep -E "^[+-].*(logger\.|Logger\.)(Info|Warn|Error|Debug)"` and reading each hit.

## Findings I did not accept

- **"The success log lost the requested-vs-stored signal."** Not a real loss. The **raw request JSON is still logged at Info** on every request: `logger.Info("Processing save loadout request", zap.String("raw_json", string(request.Loadout)))` at `server/evr_pipeline_gameserver_loadout.go:190 @ a26c326c3`. An operator can still diff what a game server asked for against what was stored, which is exactly the COSMETIC-1 rejection signal. No change made.
- **"`GroupMetadata.MarshalMap()` has both defects from the int64 finding."** Only the swallowed-error half applies. `GroupMetadata` has **no int64/uint64 fields** — its numerics are `int` day/minute/threshold counts (`server/evr_group_metadata.go:17,31,46,48` — `MinimumAccountAgeDays`, `FraudScoreThreshold`, `DefaultBlockMinutes`, `MaintenanceMinutes`) plus one `float64` rate limit, none anywhere near 2^53. The float64-truncation exposure is not live there. Corrected in this PR body rather than in code (out of scope).
- **"The retry path enforces UsernameOnly more strictly than the normal path."** Confirmed real, **not fixed** — see follow-ups. In the main flow the UsernameOnly forcing at `evr_pipeline_login.go:791` is later overwritten for the *active* group by the Discord nickname at `:852`; `apply` sets the username last and nothing overwrites it. Making them converge means either a Discord API call inside a storage retry (unacceptable) or weakening the retry into an enforcement bypass. The divergence is in the **safe** direction: the retry is stricter. The arguably-wrong line is `:852` in the pre-existing main path, which is out of scope for this PR.

## Known follow-ups

- **Login call-site wiring is still untested.** Three perturbations in `initializeSession` leave the full suite green: forcing `setActiveGroupID` to `true` (`evr_pipeline_login.go:1050`), never appending to `usernameOnlyGroupIDs` (`:790`), never populating `displayNamesOwnedByOthers` (`:889`). `initializeSession` needs a full `sessionWS` and pipeline, so no unit test can drive it. The `persistGameServerLoadout` extraction in this PR is the template for fixing this when that function is broken up.
- **The retry emits no log on conflict.** The cited precedent (`evr_discord_integrator.go:921`) logs `Version conflict updating display name, retrying` per attempt. `evrProfileUpdateWithRetry` cannot easily do the same: its three call sites carry *different logger types* (`*zap.Logger` at two, `runtime.Logger` at the RPC). Operators currently get no signal that conflicts are occurring at all. Worth a follow-up that threads a logger or emits a metrics counter.
- **`evr_match.go:1522` has no direct test.** The log-level change is covered at the remotelogset site (`evr_runtime_event_remotelogset.go:583`) by `TestIncrementCompletedMatches_TrackFailureLogsAboveDebug`; the `evr_match.go` site is the same one-line change applied by inspection.

## Out of scope — defects observed, not fixed

The timezone-dependent failure in `server/evr/core_account_statistics_test.go` was listed here in earlier revisions of this body. It has since been fixed in this PR at the repo owner's request — see **§12**. Nothing else in this category remains.

## Verification

```
$ GOWORK=off go build ./server/...
BUILD OK
$ GOWORK=off go vet ./server/...
VET OK

$ GOWORK=off go test ./server/... -count=1
ok  	github.com/heroiclabs/nakama/v3/server	125.444s
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.014s
?   	github.com/heroiclabs/nakama/v3/server/evr/gen_cosmetic_hashes	[no test files]
?   	github.com/heroiclabs/nakama/v3/server/evr/wire	[no test files]
?   	github.com/heroiclabs/nakama/v3/server/socialauth	[no test files]
```

**The full suite is green.** Earlier revisions of this body recorded one failure here — the pre-existing timezone-dependent `TestStatisticsGroup_MarshalText/Daily_Arena`, which was then out of scope. It is now fixed by `2ba891a29` (§12), so the suite is clean end to end. Measured against the branch immediately before that commit, which failed on exactly that one test and nothing else:

```
--- baseline at a26c326c3, captured before the fix ---
ok  	github.com/heroiclabs/nakama/v3/server	127.464s
--- FAIL: TestStatisticsGroup_MarshalText (0.00s)
    --- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena (0.00s)
        core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
FAIL	github.com/heroiclabs/nakama/v3/server/evr	0.015s
EXIT=1
```

One failure before, zero after. **No new failures.**

The §12 test is hermetic under every timezone tried — the same binary, the same wall clock, four zones whose local dates disagree:

```
$ for z in UTC Pacific/Auckland America/Chicago Asia/Kolkata; do
    GOWORK=off TZ=$z go test ./server/evr/ -run TestStatisticsGroup -count=1
  done
### TZ=UTC                (local date 2026_08_06) -> ok  	github.com/heroiclabs/nakama/v3/server/evr	0.004s
### TZ=Pacific/Auckland   (local date 2026_08_06) -> ok  	github.com/heroiclabs/nakama/v3/server/evr	0.004s
### TZ=America/Chicago    (local date 2026_08_05) -> ok  	github.com/heroiclabs/nakama/v3/server/evr	0.004s
### TZ=Asia/Kolkata       (local date 2026_08_06) -> ok  	github.com/heroiclabs/nakama/v3/server/evr	0.004s
```

`America/Chicago` is the zone that was red before the fix. For contrast, the identical loop against the **unfixed** code tracked the local date exactly — `ok` wherever the local date read `2026_08_06`, `FAIL` in `America/Chicago` where it read `2026_08_05` — which is what identified the wall clock, rather than the code, as the variable.

Race detector over all 30 tests in the files this PR touches:

```
$ GOWORK=off go test -race ./server/ -run '<all 30 touched tests>' -count=1
ok  	github.com/heroiclabs/nakama/v3/server	1.805s
```
30/30 PASS, no races.

Formatting — all 18 touched Go files:

```
$ gofmt -l $(git diff --name-only d3e7e5549..HEAD -- '*.go')
[no output]
```

All 13 commits GPG-signed:

```
$ git log --format='%h %G? %s' d3e7e5549..HEAD
2ba891a29 G test(evr): pin the clock so the daily stat-group test is hermetic
a26c326c3 G fix(guild-rename): report the name the retry actually replaced
7d8d10837 G fix(account): back off between profile-update retry attempts
f6401ba88 G fix(login): prune with EqualFold on retry, matching the non-retry path
189f0fc44 G test(loadout): drive the retry call site, not just the unit
9ee14efbe G fix(login,loadout): make the profile retry safe at its call sites
3a0c8e760 G docs(login): record why the profile retry does not re-apply in-game names
cdf9c8c25 G chore(earlyquit): remove three dead functions
87924552e G chore: untrack orphaned purge-docker-ips binary, ignore tools/ build output
1906d72ea G fix(earlyquit): log TrackMatchCompletion failure at Warn, not Debug
9129693f4 G fix: retry EVRProfileUpdate on version conflict at the three unretried sites
e8e1ed829 G fix(discord): do not dereference a nil *GuildGroup on GUILD_DELETE
3115f1d96 G fix(account): stop EVRProfile.MarshalMap truncating int64 values
```

## Overlap with concurrent Tier-1 PRs

Files this PR touches, for merge-conflict triage against `fix/earlyquit-penalty-state`, `fix/storage-occ-retry`, `fix/concurrency-locking`, `fix/discord-prune-safety`, `fix/security-join-gates`, `fix/match-lifecycle`:

| file | likely overlap |
|---|---|
| `server/evr_earlyquit.go`, `server/evr/login_earlyquitconfig.go` | **`fix/earlyquit-penalty-state`** — highest risk. This PR only deletes three dead functions and adds one nil guard. |
| `server/evr_account.go` | **`fix/storage-occ-retry`** — highest risk. This PR adds `evrProfileUpdateWithRetry` + backoff and rewrites `MarshalMap`'s decode. |
| `server/evr_pipeline_login.go` | `fix/concurrency-locking`, `fix/security-join-gates` |
| `server/evr_discord_integrator.go` | `fix/discord-prune-safety` |
| `server/evr_match.go` | `fix/match-lifecycle` — one-line log level only |
| `server/evr_pipeline_gameserver_loadout.go` | largest diff in this PR; no other Tier-1 branch is expected here |
| `server/evr/core_account_statistics.go` + its test | §12 only. Three production lines (one `var`, two call sites); the rest is test. Low conflict risk unless another branch is also editing the stat-group formatters. |

Ordering suggestion: land `fix/storage-occ-retry` and this PR adjacently, since both touch `evr_account.go`'s write path.

