### PR TITLE
fix(security): scope the moderator entrant claim to the lobby's guild, make the degraded VPN gate alertable

### DIFF
--- a/server/evr_ip_info_cache.go
+++ b/server/evr_ip_info_cache.go
@@ -38,6 +38,21 @@ func NewIPInfoCache(logger *zap.Logger, metrics Metrics, clients ...IPInfoProvid
 	return &ipqs, nil
 }
 
+// IsConfigured reports whether any IP intelligence provider is wired up.
+//
+// Providers are only constructed inside `if redisClient != nil` in
+// server/evr_pipeline.go, and redisClient is nil unless REDIS_URI is set — so a
+// deployment without Redis has none at all and Get returns (nil, nil) for every
+// public IP permanently, rather than transiently. Callers that report a degraded
+// VPN gate use this to tell a standing configuration gap apart from an outage;
+// without it, a per-authorize alert on the degraded gate fires forever and
+// carries no information.
+//
+// Nil-safe so a caller can classify before dereferencing.
+func (s *IPInfoCache) IsConfigured() bool {
+	return s != nil && len(s.clients) > 0
+}
+
 // Get returns IP intelligence for ip from the first provider that has it.
 //
 // The error return is part of the IPInfoProvider shape and is always nil today:

--- a/server/evr_ip_info_cache.go
+++ b/server/evr_ip_info_cache.go
@@ -58,9 +58,17 @@ func (s *IPInfoCache) Get(ctx context.Context, ip string) (IPInfo, error) {
 			// the degradation was invisible. The fail-open policy is unchanged —
 			// a failed lookup still yields no IP info rather than a denial — but
 			// it is now counted so it can be alerted on.
-			s.metrics.CustomCounter("ip_info_provider_error", map[string]string{"provider": client.Name()}, 1)
-			s.logger.Debug("IP info provider failed, failing open.",
-				zap.String("provider", client.Name()), zap.Error(err))
+			//
+			// Both dependencies are optional: NewIPInfoCache does not require
+			// them and existing callers pass nil (server/evr_bugfix_test.go).
+			// Observability must never be the thing that panics a login path.
+			if s.metrics != nil {
+				s.metrics.CustomCounter("ip_info_provider_error", map[string]string{"provider": client.Name()}, 1)
+			}
+			if s.logger != nil {
+				s.logger.Debug("IP info provider failed, failing open.",
+					zap.String("provider", client.Name()), zap.Error(err))
+			}
 			continue
 		}
 		if result != nil {

--- a/server/evr_ip_info_cache.go
+++ b/server/evr_ip_info_cache.go
@@ -38,6 +38,11 @@ func NewIPInfoCache(logger *zap.Logger, metrics Metrics, clients ...IPInfoProvid
 	return &ipqs, nil
 }
 
+// Get returns IP intelligence for ip from the first provider that has it.
+//
+// The error return is part of the IPInfoProvider shape and is always nil today:
+// every provider failure is deliberately swallowed so the caller fails open
+// (see SEC-6). Callers must treat a nil IPInfo as "unknown", not as "clean".
 func (s *IPInfoCache) Get(ctx context.Context, ip string) (IPInfo, error) {
 
 	// ignore reserved IPs
@@ -45,12 +50,17 @@ func (s *IPInfoCache) Get(ctx context.Context, ip string) (IPInfo, error) {
 		return &StubIPInfo{}, nil
 	}
 
-	errored := make(map[string]error, 0)
-
 	for _, client := range s.clients {
 		result, err := client.Get(ctx, ip)
 		if err != nil {
-			errored[client.Name()] = err
+			// SEC-6: provider errors used to be collected into a map that was
+			// never read, so this method could never return a non-nil error and
+			// the degradation was invisible. The fail-open policy is unchanged —
+			// a failed lookup still yields no IP info rather than a denial — but
+			// it is now counted so it can be alerted on.
+			s.metrics.CustomCounter("ip_info_provider_error", map[string]string{"provider": client.Name()}, 1)
+			s.logger.Debug("IP info provider failed, failing open.",
+				zap.String("provider", client.Name()), zap.Error(err))
 			continue
 		}
 		if result != nil {
@@ -60,12 +70,11 @@ func (s *IPInfoCache) Get(ctx context.Context, ip string) (IPInfo, error) {
 	return nil, nil
 }
 
+// IsVPN reports whether the IP is a known VPN. It fails open: an unavailable or
+// failed lookup yields false. Get never returns a non-nil error (every failure
+// path is counted and swallowed above), so there is no error branch here.
 func (s *IPInfoCache) IsVPN(ip string) bool {
-	result, err := s.Get(s.ctx, ip)
-	if err != nil {
-		s.logger.Warn("Failed to get IPQS details, failing open.", zap.Error(err))
-		return false
-	}
+	result, _ := s.Get(s.ctx, ip)
 	if result == nil {
 		return false
 	}

--- a/server/evr_ip_info_provider_ipqs.go
+++ b/server/evr_ip_info_provider_ipqs.go
@@ -256,6 +256,11 @@ func (s *IPQSClient) store(ip string, result *IPQSResponse) error {
 	return nil
 }
 
+// Get returns IPQS data for ip. It fails open by design: a circuit-breaker
+// trip, an HTTP error, a non-200, or a Success:false body (what quota
+// exhaustion returns) all yield (nil, nil) so the caller proceeds without IP
+// intelligence rather than denying the player. The error return is therefore
+// always nil; failures surface through the ipqs_* metrics instead.
 func (s *IPQSClient) Get(ctx context.Context, ip string) (IPInfo, error) {
 	if s == nil {
 		return nil, nil
@@ -335,13 +340,11 @@ func (s *IPQSClient) retrieve(ctx context.Context, ip string) (*IPQSResponse, er
 	return &result, nil
 }
 
+// IsVPN reports whether the IP is a known VPN, failing open on any lookup
+// problem. Get never returns a non-nil error — every failure path below returns
+// (nil, nil) so callers fail open — so there is no error branch here.
 func (s *IPQSClient) IsVPN(ip string) bool {
-
-	result, err := s.Get(s.ctx, ip)
-	if err != nil {
-		s.logger.Warn("Failed to get IPQS details, failing open.", zap.Error(err))
-		return false
-	}
+	result, _ := s.Get(s.ctx, ip)
 	if result == nil {
 		return false
 	}

--- a/server/evr_lobby_join.go
+++ b/server/evr_lobby_join.go
@@ -41,6 +41,10 @@ func (p *EvrPipeline) lobbyJoin(ctx context.Context, logger *zap.Logger, session
 	// player count, the moderator slot pool, early-quit tracking and the
 	// post-match social transition). Fails closed: no session parameters means
 	// no verified moderator.
+	//
+	// IsModerator is re-scoped in step with GroupID and Mode just above: from
+	// here down, every guild-derived field on lobbyParams describes the lobby
+	// being joined rather than the request that asked for it.
 	sessionParams, _ := LoadParams(ctx)
 	lobbyParams.IsModerator = sessionParams != nil &&
 		isModeratorOfGroup(sessionParams.isGlobalOperator, sessionParams.guildGroups, lobbyParams.GroupID, lobbyParams.UserID.String())

--- a/server/evr_lobby_join.go
+++ b/server/evr_lobby_join.go
@@ -30,6 +30,30 @@ func (p *EvrPipeline) lobbyJoin(ctx context.Context, logger *zap.Logger, session
 	lobbyParams.GroupID = label.GetGroupID()
 	lobbyParams.Mode = label.Mode
 
+	// SEC-5: re-validate the client-claimed moderator role against the guild
+	// that actually owns this lobby.
+	//
+	// NewLobbyParametersFromRequest validated it against the group ID on the
+	// request, but a LobbyJoinSessionRequest carries no group ID — the check
+	// there fell back to the user's *active* guild. The lobby being joined can
+	// belong to a different guild, so an enforcer of guild A could otherwise
+	// enter a guild-B lobby as TeamModerator (which exempts them from the
+	// player count, the moderator slot pool, early-quit tracking and the
+	// post-match social transition). Fails closed: no session parameters means
+	// no verified moderator.
+	sessionParams, _ := LoadParams(ctx)
+	lobbyParams.IsModerator = sessionParams != nil &&
+		isModeratorOfGroup(sessionParams.isGlobalOperator, sessionParams.guildGroups, lobbyParams.GroupID, lobbyParams.UserID.String())
+
+	if lobbyParams.Role == evr.TeamModerator && !lobbyParams.IsModerator {
+		logger.Warn("Downgrading unverified moderator role claim",
+			zap.String("uid", lobbyParams.UserID.String()),
+			zap.String("gid", lobbyParams.GroupID.String()),
+			zap.String("mid", matchID.UUID.String()))
+		p.nk.MetricsCounterAdd("lobby_moderator_role_downgraded", map[string]string{"group_id": lobbyParams.GroupID.String()}, 1)
+		lobbyParams.Role = evr.TeamUnassigned
+	}
+
 	// Do authorization checks related to the lobby's guild.
 	if err := p.lobbyAuthorize(ctx, logger, session, lobbyParams); err != nil {
 		return err

--- a/server/evr_lobby_join_moderator_scope_test.go
+++ b/server/evr_lobby_join_moderator_scope_test.go
@@ -213,6 +213,13 @@ func TestIsModeratorOfGroup(t *testing.T) {
 	enforcerGroup := newTestGuildGroup(groupID, userID.String())
 	strangerGroup := newTestGuildGroup(groupID, otherID.String())
 
+	// The cross-guild case: the user enforces some *other* guild, and both
+	// guilds are present in the session's map. Without this, every case below
+	// carries at most the queried guild, so a predicate that ignored groupID
+	// entirely and scanned the whole map would still pass.
+	otherGroupID := uuid.Must(uuid.NewV4())
+	otherGuildEnforcerGroup := newTestGuildGroup(otherGroupID, userID.String())
+
 	for _, tc := range []struct {
 		name             string
 		isGlobalOperator bool
@@ -227,6 +234,13 @@ func TestIsModeratorOfGroup(t *testing.T) {
 		{"nil group entry", false, map[string]*GuildGroup{groupID.String(): nil}, groupID, false},
 		{"nil map", false, nil, groupID, false},
 		{"nil group id", false, map[string]*GuildGroup{groupID.String(): enforcerGroup}, uuid.Nil, false},
+		{"enforcer of another guild only", false, map[string]*GuildGroup{
+			otherGroupID.String(): otherGuildEnforcerGroup,
+			groupID.String():      strangerGroup,
+		}, groupID, false},
+		{"enforcer of another guild, queried guild absent", false, map[string]*GuildGroup{
+			otherGroupID.String(): otherGuildEnforcerGroup,
+		}, groupID, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, isModeratorOfGroup(tc.isGlobalOperator, tc.guildGroups, tc.groupID, userID.String()))

--- a/server/evr_lobby_join_moderator_scope_test.go
+++ b/server/evr_lobby_join_moderator_scope_test.go
@@ -1,0 +1,235 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+// SEC-5 — guild-scoped moderator claim.
+//
+// NewLobbyParametersFromRequest validates a client-claimed evr.TeamModerator
+// entrant role against the group ID carried on the request. A
+// LobbyJoinSessionRequest carries no group ID (evr.LobbyJoinSessionRequest.GetGroupID
+// returns uuid.Nil), so the validation falls back to the user's *active* guild.
+// lobbyJoin then overwrites lobbyParams.GroupID with the guild that actually
+// owns the match and pushes lobbyParams.Role straight into the entrant
+// presence — so an enforcer in guild A can join a guild-B lobby as
+// TeamModerator.
+//
+// These tests drive the real p.lobbyJoin. They deliberately stop short of a
+// successful join: the guild group registry is empty, so lobbyAuthorize errors
+// out right after the re-validation point. What is asserted is the state
+// lobbyJoin left on lobbyParams before that error — the group it re-scoped to,
+// and the role it resolved for that group.
+
+// lobbyJoinModeratorFixture builds the minimum pipeline/session/context needed
+// to run p.lobbyJoin up to (and through) the guild re-scoping step.
+type lobbyJoinModeratorFixture struct {
+	pipeline    *EvrPipeline
+	session     *sessionWS
+	ctx         context.Context
+	lobbyParams *LobbySessionParameters
+	matchID     MatchID
+}
+
+func newLobbyJoinModeratorFixture(t *testing.T, lobbyGroupID uuid.UUID, userID uuid.UUID, sessionParams *SessionParameters, requestedRole int) *lobbyJoinModeratorFixture {
+	t.Helper()
+
+	registry := newMockFollowMatchRegistry()
+	matchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	gid := lobbyGroupID
+	registry.SetMatch(matchID, &MatchLabel{
+		ID:      matchID,
+		GroupID: &gid,
+		Mode:    evr.ModeArenaPublic,
+	})
+
+	p := &EvrPipeline{
+		nk: &RuntimeGoNakamaModule{
+			matchRegistry:   registry,
+			sessionRegistry: &testSessionRegistry{},
+			metrics:         &testMetrics{},
+		},
+		guildGroupRegistry: newTestGuildGroupRegistry(),
+	}
+
+	session := &sessionWS{}
+	session.id = uuid.Must(uuid.NewV4())
+	session.userID = userID
+	session.pipeline = &Pipeline{node: "testnode"}
+	session.pipeline.tracker = newMockMatchmakingTracker()
+
+	ctx := context.WithValue(context.Background(), ctxSessionParametersKey{}, atomic.NewPointer(sessionParams))
+
+	return &lobbyJoinModeratorFixture{
+		pipeline: p,
+		session:  session,
+		ctx:      ctx,
+		lobbyParams: &LobbySessionParameters{
+			UserID: userID,
+			// The role and group as resolved from the *request*: the client
+			// asked for moderator, and the request had no group so the
+			// parameters carry the user's active guild.
+			Role:    requestedRole,
+			GroupID: uuid.Nil,
+			Mode:    evr.ModeArenaPublic,
+		},
+		matchID: matchID,
+	}
+}
+
+func TestLobbyJoin_ModeratorClaimIsScopedToTheLobbysGuild(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	guildA := uuid.Must(uuid.NewV4()) // user is an enforcer here
+	guildB := uuid.Must(uuid.NewV4()) // user is an ordinary member here
+
+	// The exploit setup: enforcer in A, plain member of B, active group A.
+	sessionParams := &SessionParameters{
+		guildGroups: map[string]*GuildGroup{
+			guildA.String(): newTestGuildGroup(guildA, userID.String()),
+			guildB.String(): newTestGuildGroup(guildB, uuid.Must(uuid.NewV4()).String()),
+		},
+	}
+
+	f := newLobbyJoinModeratorFixture(t, guildB, userID, sessionParams, evr.TeamModerator)
+
+	// The join cannot complete (empty guild group registry), but lobbyJoin must
+	// have re-scoped and re-validated before it bailed.
+	_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+	require.Equal(t, guildB, f.lobbyParams.GroupID,
+		"lobbyJoin must re-scope the lobby parameters onto the guild that owns the match")
+	require.Equal(t, evr.TeamUnassigned, f.lobbyParams.Role,
+		"SEC-5: a TeamModerator claim must be re-validated against the lobby's own guild. "+
+			"The user is an enforcer in guild A but only an ordinary member of guild B, "+
+			"so joining a guild-B lobby must downgrade the role to TeamUnassigned.")
+	require.False(t, f.lobbyParams.IsModerator,
+		"SEC-5: IsModerator must reflect the lobby's guild, not the user's active guild")
+}
+
+func TestLobbyJoin_ModeratorClaimSurvivesForEnforcerOfTheLobbysGuild(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	guildB := uuid.Must(uuid.NewV4())
+
+	sessionParams := &SessionParameters{
+		guildGroups: map[string]*GuildGroup{
+			guildB.String(): newTestGuildGroup(guildB, userID.String()),
+		},
+	}
+
+	f := newLobbyJoinModeratorFixture(t, guildB, userID, sessionParams, evr.TeamModerator)
+
+	_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+	require.Equal(t, evr.TeamModerator, f.lobbyParams.Role,
+		"a genuine enforcer of the lobby's own guild must keep the moderator role")
+	require.True(t, f.lobbyParams.IsModerator)
+}
+
+func TestLobbyJoin_ModeratorClaimSurvivesForGlobalOperator(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	guildB := uuid.Must(uuid.NewV4())
+
+	// Global operator with no membership in the lobby's guild at all.
+	sessionParams := &SessionParameters{
+		isGlobalOperator: true,
+		guildGroups:      map[string]*GuildGroup{},
+	}
+
+	f := newLobbyJoinModeratorFixture(t, guildB, userID, sessionParams, evr.TeamModerator)
+
+	_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+	require.Equal(t, evr.TeamModerator, f.lobbyParams.Role,
+		"global operators are moderators everywhere")
+	require.True(t, f.lobbyParams.IsModerator)
+}
+func TestLobbyJoin_NonModeratorRolesAreNotTouched(t *testing.T) {
+	// The downgrade must be narrow: only a TeamModerator claim is affected.
+	for _, role := range []int{evr.TeamBlue, evr.TeamOrange, evr.TeamSpectator, evr.TeamSocial, evr.TeamUnassigned} {
+		userID := uuid.Must(uuid.NewV4())
+		guildB := uuid.Must(uuid.NewV4())
+
+		sessionParams := &SessionParameters{
+			guildGroups: map[string]*GuildGroup{
+				guildB.String(): newTestGuildGroup(guildB, uuid.Must(uuid.NewV4()).String()),
+			},
+		}
+
+		f := newLobbyJoinModeratorFixture(t, guildB, userID, sessionParams, role)
+		_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+		require.Equal(t, role, f.lobbyParams.Role,
+			"role %d must be left alone by the moderator re-validation", role)
+	}
+}
+
+func TestLobbyJoin_ModeratorClaimFailsClosedWhenGuildIsUnknown(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	guildA := uuid.Must(uuid.NewV4())
+	guildB := uuid.Must(uuid.NewV4())
+
+	// The user is an enforcer in A, and the lobby's guild B is absent from the
+	// session's guild group map entirely (non-member, or a registry race).
+	sessionParams := &SessionParameters{
+		guildGroups: map[string]*GuildGroup{
+			guildA.String(): newTestGuildGroup(guildA, userID.String()),
+		},
+	}
+
+	f := newLobbyJoinModeratorFixture(t, guildB, userID, sessionParams, evr.TeamModerator)
+	_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+	require.Equal(t, evr.TeamUnassigned, f.lobbyParams.Role,
+		"an unknown guild must fail closed, not inherit the active guild's privileges")
+}
+
+func TestLobbyJoin_ModeratorClaimFailsClosedWithoutSessionParameters(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	guildB := uuid.Must(uuid.NewV4())
+
+	f := newLobbyJoinModeratorFixture(t, guildB, userID, &SessionParameters{}, evr.TeamModerator)
+	// Drop the session parameters from the context entirely.
+	f.ctx = context.Background()
+
+	_ = f.pipeline.lobbyJoin(f.ctx, loggerForTest(t), f.session, f.lobbyParams, f.matchID)
+
+	require.Equal(t, evr.TeamUnassigned, f.lobbyParams.Role,
+		"missing session parameters must fail closed — no unverified moderator role may reach the presence")
+}
+
+// isModeratorOfGroup is the guild-scoped moderator predicate the join path
+// depends on. These cases pin its boundaries directly.
+func TestIsModeratorOfGroup(t *testing.T) {
+	userID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+	otherID := uuid.Must(uuid.NewV4())
+
+	enforcerGroup := newTestGuildGroup(groupID, userID.String())
+	strangerGroup := newTestGuildGroup(groupID, otherID.String())
+
+	for _, tc := range []struct {
+		name             string
+		isGlobalOperator bool
+		guildGroups      map[string]*GuildGroup
+		groupID          uuid.UUID
+		want             bool
+	}{
+		{"global operator, no groups", true, nil, groupID, true},
+		{"enforcer of the group", false, map[string]*GuildGroup{groupID.String(): enforcerGroup}, groupID, true},
+		{"member but not enforcer", false, map[string]*GuildGroup{groupID.String(): strangerGroup}, groupID, false},
+		{"group absent from map", false, map[string]*GuildGroup{}, groupID, false},
+		{"nil group entry", false, map[string]*GuildGroup{groupID.String(): nil}, groupID, false},
+		{"nil map", false, nil, groupID, false},
+		{"nil group id", false, map[string]*GuildGroup{groupID.String(): enforcerGroup}, uuid.Nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isModeratorOfGroup(tc.isGlobalOperator, tc.guildGroups, tc.groupID, userID.String()))
+		})
+	}
+}

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -516,12 +516,12 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 			auditLog := fmt.Sprintf("vpn probability score %d >= %d", params.ipInfo.FraudScore(), gg.FraudScoreThreshold)
 			return joinRejected("vpn_user", reason, auditLog)
 		}
-	} else if gg.BlockVPNUsers && params.ipInfo == nil {
+	} else if shouldWarnVPNDegraded(gg.BlockVPNUsers, gg.IsVPNBypass(userID), params.ipInfo) {
 		// IPQS is circuit-broken: the lookup was unavailable, so params.ipInfo is
 		// nil and the gate above silently no-ops. VPN blocking is degraded — warn
 		// operators so the gap is visible. The player still passes; this is
 		// visibility, not blocking (SEC-6).
-		warnVPNDegraded(logger, session.ClientIP(), lobbyParams.DiscordID, groupID)
+		warnVPNDegraded(logger, p.nk.MetricsCounterAdd, session.ClientIP(), lobbyParams.DiscordID, groupID, params.isVPN)
 	}
 
 	if len(gg.AllowedFeatures) > 0 {
@@ -589,15 +589,53 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 	return nil
 }
 
-// warnVPNDegraded logs an operator-facing warning when a guild has
-// BlockVPNUsers enabled but the IPQS lookup was unavailable (params.ipInfo is
-// nil), so the VPN gate silently no-ops and VPN users pass with no audit trail.
-// This is visibility, not blocking — the player still passes.
-func warnVPNDegraded(logger *zap.Logger, clientIP, discordID, groupID string) {
+// vpnDegradedLogWindow is how often a single guild may re-announce that its VPN
+// gate is degraded. The IPQS circuit breaker backs off up to 5 minutes, so a
+// one-minute window re-announces a few times per outage without producing a line
+// per player per lobby authorize.
+const vpnDegradedLogWindow = time.Minute
+
+// vpnDegradedLogThrottle rate-limits the degraded-VPN warning per guild.
+// Package-level so the window spans sessions; tests replace it.
+var vpnDegradedLogThrottle = newLogThrottle(vpnDegradedLogWindow)
+
+// shouldWarnVPNDegraded reports whether the VPN gate silently no-oped for this
+// player: the guild blocks VPN users, this player is not exempt from that
+// blocking, and the IP intelligence lookup came back empty so the gate had
+// nothing to evaluate.
+//
+// SEC-6: this mirrors the gate it stands in for, minus params.isVPN — which is
+// itself derived from the same unavailable lookup and is therefore false during
+// a degradation, so requiring it would silence the warning exactly when it
+// matters. The bypass check is kept: a player the guild has explicitly exempted
+// would have passed the gate anyway, so their failed lookup is not a gap.
+func shouldWarnVPNDegraded(blockVPNUsers bool, isVPNBypass bool, ipInfo IPInfo) bool {
+	return blockVPNUsers && !isVPNBypass && ipInfo == nil
+}
+
+// warnVPNDegraded reports that a guild has BlockVPNUsers enabled but the IP
+// intelligence lookup was unavailable, so the VPN gate silently no-ops and VPN
+// users pass with no audit trail. This is visibility, not blocking — the player
+// still passes.
+//
+// SEC-6: the counter is incremented on every occurrence, so the degradation is
+// alertable and its true volume is visible. The log line is throttled per guild
+// so a multi-minute outage does not bury its own signal under one WARN per
+// player per lobby authorize.
+func warnVPNDegraded(logger *zap.Logger, metricsCounterAdd func(name string, tags map[string]string, delta int64), clientIP, discordID, groupID string, sessionFlaggedVPN bool) {
+	if metricsCounterAdd != nil {
+		metricsCounterAdd("lobby_vpn_check_degraded", map[string]string{"group_id": groupID}, 1)
+	}
+
+	if !vpnDegradedLogThrottle.allow(groupID) {
+		return
+	}
+
 	logger.Warn("VPN blocking degraded: IPQS lookup unavailable for VPN check",
 		zap.String("client_ip", clientIP),
 		zap.String("discord_id", discordID),
-		zap.String("guild_id", groupID))
+		zap.String("guild_id", groupID),
+		zap.Bool("session_flagged_vpn", sessionFlaggedVPN))
 }
 
 // roleSuspensionUserMessage returns the in-game message shown to a user suspended via guild role.

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -596,8 +596,13 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 const vpnDegradedLogWindow = time.Minute
 
 // vpnDegradedLogThrottle rate-limits the degraded-VPN warning per guild.
-// Package-level so the window spans sessions; tests replace it.
-var vpnDegradedLogThrottle = newLogThrottle(vpnDegradedLogWindow)
+// Package-level so the window spans sessions.
+//
+// Tests must not reassign this var — call vpnDegradedLogThrottle.reset() (and
+// .setClock() for a fake clock) so the mutation goes through the throttle's own
+// lock. Reassignment is an unsynchronized write to shared state and leaves the
+// next test's expectations at the mercy of whatever ran before it.
+var vpnDegradedLogThrottle = newPerKeyLogThrottle(vpnDegradedLogWindow)
 
 // shouldWarnVPNDegraded reports whether the VPN gate silently no-oped for this
 // player: the guild blocks VPN users, this player is not exempt from that

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -516,12 +516,16 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 			auditLog := fmt.Sprintf("vpn probability score %d >= %d", params.ipInfo.FraudScore(), gg.FraudScoreThreshold)
 			return joinRejected("vpn_user", reason, auditLog)
 		}
-	} else if shouldWarnVPNDegraded(gg.BlockVPNUsers, gg.IsVPNBypass(userID), params.ipInfo) {
-		// IPQS is circuit-broken: the lookup was unavailable, so params.ipInfo is
-		// nil and the gate above silently no-ops. VPN blocking is degraded — warn
-		// operators so the gap is visible. The player still passes; this is
-		// visibility, not blocking (SEC-6).
-		warnVPNDegraded(logger, p.nk.MetricsCounterAdd, session.ClientIP(), lobbyParams.DiscordID, groupID, params.isVPN)
+	} else if shouldWarnVPNDegraded(gg.BlockVPNUsers, params.ipInfo, func() bool { return gg.IsVPNBypass(userID) }) {
+		// No IP intelligence was available, so params.ipInfo is nil and the gate
+		// above silently no-ops. VPN blocking is degraded — warn operators so the
+		// gap is visible. The player still passes; this is visibility, not
+		// blocking (SEC-6).
+		//
+		// The reason separates a circuit-broken IPQS (transient, alertable) from
+		// a deployment with no provider configured at all (permanent, and
+		// otherwise indistinguishable on the wire).
+		warnVPNDegraded(logger, p.nk.MetricsCounterAdd, session.ClientIP(), lobbyParams.DiscordID, groupID, params.isVPN, vpnDegradedReasonFor(p.ipInfoCache))
 	}
 
 	if len(gg.AllowedFeatures) > 0 {
@@ -589,57 +593,114 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 	return nil
 }
 
+// vpnDegradedReason classifies why the VPN gate had no IP intelligence to act
+// on. It tags lobby_vpn_check_degraded so an alert can select the transient case
+// instead of firing forever on a deployment that has no provider at all.
+type vpnDegradedReason string
+
+const (
+	// vpnDegradedLookupFailed: providers are configured but none returned data
+	// for this IP. Transient — the IPQS circuit breaker backs off 5s→5min — and
+	// the case worth paging on.
+	vpnDegradedLookupFailed vpnDegradedReason = "lookup_failed"
+
+	// vpnDegradedNotConfigured: no IP intelligence provider is wired up, so the
+	// gate can never evaluate. Providers are only built when REDIS_URI is set
+	// (server/evr_pipeline.go), so this holds for every player in every
+	// BlockVPNUsers guild on every authorize until the process is restarted with
+	// one configured. Still a real security gap and still counted, but it is a
+	// standing condition rather than an outage, so it must not be alertable or
+	// greppable as one.
+	vpnDegradedNotConfigured vpnDegradedReason = "not_configured"
+)
+
 // vpnDegradedLogWindow is how often a single guild may re-announce that its VPN
 // gate is degraded. The IPQS circuit breaker backs off up to 5 minutes, so a
 // one-minute window re-announces a few times per outage without producing a line
 // per player per lobby authorize.
 const vpnDegradedLogWindow = time.Minute
 
-// vpnDegradedLogThrottle rate-limits the degraded-VPN warning per guild.
-// Package-level so the window spans sessions.
+// vpnUnconfiguredLogWindow is the same budget for the standing "no provider
+// configured" gap. That condition cannot resolve on its own, so a one-minute
+// window would emit a line per guild per minute forever; an hour still puts it
+// in front of an operator without burying anything.
+const vpnUnconfiguredLogWindow = time.Hour
+
+// vpnDegradedLogThrottle and vpnUnconfiguredLogThrottle rate-limit the two
+// degraded-VPN warnings per guild. Package-level so the window spans sessions,
+// and separate so a permanent configuration gap cannot consume the budget a
+// real, transient outage needs.
 //
-// Tests must not reassign this var — call vpnDegradedLogThrottle.reset() (and
-// .setClock() for a fake clock) so the mutation goes through the throttle's own
-// lock. Reassignment is an unsynchronized write to shared state and leaves the
-// next test's expectations at the mercy of whatever ran before it.
-var vpnDegradedLogThrottle = newPerKeyLogThrottle(vpnDegradedLogWindow)
+// Tests must not reassign these vars — call .reset() (and .setClock() for a fake
+// clock) so the mutation goes through the throttle's own lock. Reassignment is
+// an unsynchronized write to shared state and leaves the next test's
+// expectations at the mercy of whatever ran before it.
+var (
+	vpnDegradedLogThrottle     = newPerKeyLogThrottle(vpnDegradedLogWindow)
+	vpnUnconfiguredLogThrottle = newPerKeyLogThrottle(vpnUnconfiguredLogWindow)
+)
+
+// vpnDegradedReasonFor classifies an empty IP intelligence result: a cache with
+// providers wired up came back empty because the lookup failed, one with none
+// was never able to answer in the first place.
+func vpnDegradedReasonFor(cache *IPInfoCache) vpnDegradedReason {
+	if cache.IsConfigured() {
+		return vpnDegradedLookupFailed
+	}
+	return vpnDegradedNotConfigured
+}
 
 // shouldWarnVPNDegraded reports whether the VPN gate silently no-oped for this
-// player: the guild blocks VPN users, this player is not exempt from that
-// blocking, and the IP intelligence lookup came back empty so the gate had
-// nothing to evaluate.
+// player: the guild blocks VPN users, the IP intelligence lookup came back empty
+// so the gate had nothing to evaluate, and this player is not exempt from the
+// blocking anyway.
 //
 // SEC-6: this mirrors the gate it stands in for, minus params.isVPN — which is
 // itself derived from the same unavailable lookup and is therefore false during
 // a degradation, so requiring it would silence the warning exactly when it
 // matters. The bypass check is kept: a player the guild has explicitly exempted
 // would have passed the gate anyway, so their failed lookup is not a gap.
-func shouldWarnVPNDegraded(blockVPNUsers bool, isVPNBypass bool, ipInfo IPInfo) bool {
-	return blockVPNUsers && !isVPNBypass && ipInfo == nil
+//
+// isVPNBypass is a func so it stays short-circuited behind the two cheap
+// conditions, as it was in the original `&&` chain: it reaches through
+// GuildGroup.HasRole into a per-guild read lock, and the overwhelmingly common
+// case is a guild that does not block VPN users at all.
+func shouldWarnVPNDegraded(blockVPNUsers bool, ipInfo IPInfo, isVPNBypass func() bool) bool {
+	return blockVPNUsers && ipInfo == nil && !isVPNBypass()
 }
 
-// warnVPNDegraded reports that a guild has BlockVPNUsers enabled but the IP
-// intelligence lookup was unavailable, so the VPN gate silently no-ops and VPN
-// users pass with no audit trail. This is visibility, not blocking — the player
-// still passes.
+// warnVPNDegraded reports that a guild has BlockVPNUsers enabled but no IP
+// intelligence was available, so the VPN gate silently no-ops and VPN users pass
+// with no audit trail. This is visibility, not blocking — the player still
+// passes.
 //
 // SEC-6: the counter is incremented on every occurrence, so the degradation is
-// alertable and its true volume is visible. The log line is throttled per guild
-// so a multi-minute outage does not bury its own signal under one WARN per
-// player per lobby authorize.
-func warnVPNDegraded(logger *zap.Logger, metricsCounterAdd func(name string, tags map[string]string, delta int64), clientIP, discordID, groupID string, sessionFlaggedVPN bool) {
+// alertable and its true volume is visible. It carries the reason so an alert
+// can page on the transient case alone. The log line is throttled per guild, on
+// a separate budget per reason, so neither a multi-minute outage nor a permanent
+// configuration gap buries the signal it exists to raise.
+func warnVPNDegraded(logger *zap.Logger, metricsCounterAdd func(name string, tags map[string]string, delta int64), clientIP, discordID, groupID string, sessionFlaggedVPN bool, reason vpnDegradedReason) {
 	if metricsCounterAdd != nil {
-		metricsCounterAdd("lobby_vpn_check_degraded", map[string]string{"group_id": groupID}, 1)
+		metricsCounterAdd("lobby_vpn_check_degraded", map[string]string{
+			"group_id": groupID,
+			"reason":   string(reason),
+		}, 1)
 	}
 
-	if !vpnDegradedLogThrottle.allow(groupID) {
+	throttle, message := vpnDegradedLogThrottle, "VPN blocking degraded: IPQS lookup unavailable for VPN check"
+	if reason == vpnDegradedNotConfigured {
+		throttle, message = vpnUnconfiguredLogThrottle, "VPN blocking inert: no IP intelligence provider is configured"
+	}
+
+	if !throttle.allow(groupID) {
 		return
 	}
 
-	logger.Warn("VPN blocking degraded: IPQS lookup unavailable for VPN check",
+	logger.Warn(message,
 		zap.String("client_ip", clientIP),
 		zap.String("discord_id", discordID),
 		zap.String("guild_id", groupID),
+		zap.String("reason", string(reason)),
 		zap.Bool("session_flagged_vpn", sessionFlaggedVPN))
 }
 

--- a/server/evr_lobby_joinentrant_test.go
+++ b/server/evr_lobby_joinentrant_test.go
@@ -21,6 +21,8 @@ import (
 // degradation branch in lobbyAuthorize contains no return — and is covered by
 // the gate being an else-if rather than a rejection path.
 func TestVPNDegradedWarning_FiresWhenIPQSLookupUnavailable(t *testing.T) {
+	vpnDegradedLogThrottle = newLogThrottle(vpnDegradedLogWindow)
+
 	core, logs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
 
@@ -30,7 +32,7 @@ func TestVPNDegradedWarning_FiresWhenIPQSLookupUnavailable(t *testing.T) {
 		guildID   = "987654321098765432"
 	)
 
-	warnVPNDegraded(logger, clientIP, discordID, guildID)
+	warnVPNDegraded(logger, newRecordingMetrics().CustomCounter, clientIP, discordID, guildID, false)
 
 	entries := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
 	require.Len(t, entries, 1, "expected exactly one degraded-VPN warning")

--- a/server/evr_lobby_joinentrant_test.go
+++ b/server/evr_lobby_joinentrant_test.go
@@ -32,7 +32,7 @@ func TestVPNDegradedWarning_FiresWhenIPQSLookupUnavailable(t *testing.T) {
 		guildID   = "987654321098765432"
 	)
 
-	warnVPNDegraded(logger, newRecordingMetrics().CustomCounter, clientIP, discordID, guildID, false)
+	warnVPNDegraded(logger, newRecordingMetrics().CustomCounter, clientIP, discordID, guildID, false, vpnDegradedLookupFailed)
 
 	entries := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
 	require.Len(t, entries, 1, "expected exactly one degraded-VPN warning")

--- a/server/evr_lobby_joinentrant_test.go
+++ b/server/evr_lobby_joinentrant_test.go
@@ -21,7 +21,7 @@ import (
 // degradation branch in lobbyAuthorize contains no return — and is covered by
 // the gate being an else-if rather than a rejection path.
 func TestVPNDegradedWarning_FiresWhenIPQSLookupUnavailable(t *testing.T) {
-	vpnDegradedLogThrottle = newLogThrottle(vpnDegradedLogWindow)
+	resetVPNDegradedThrottle(t)
 
 	core, logs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)

--- a/server/evr_lobby_parameters.go
+++ b/server/evr_lobby_parameters.go
@@ -116,6 +116,28 @@ func (s LobbySessionParameters) MetricsTags() map[string]string {
 	}
 }
 
+// isModeratorOfGroup reports whether the user holds moderator privileges for a
+// specific guild group: either a global operator (moderator everywhere), or an
+// enforcer of that exact guild.
+//
+// The check is guild-scoped on purpose (SEC-5): moderator privileges in one
+// guild must never carry into another guild's lobby. It fails closed — a nil
+// group ID, a guild missing from the session's guild group map, or a nil entry
+// all mean "not a moderator".
+func isModeratorOfGroup(isGlobalOperator bool, guildGroups map[string]*GuildGroup, groupID uuid.UUID, userID string) bool {
+	if isGlobalOperator {
+		return true
+	}
+	if groupID == uuid.Nil {
+		return false
+	}
+	gg, ok := guildGroups[groupID.String()]
+	if !ok || gg == nil {
+		return false
+	}
+	return gg.IsEnforcer(userID)
+}
+
 // resolveDirectiveRole determines the entrant role when a join directive is
 // present. Explicit directive roles (orange, blue, spectator, moderator)
 // override the request. "any" or "" preserve the client's requested role,
@@ -372,12 +394,7 @@ func NewLobbyParametersFromRequest(ctx context.Context, logger *zap.Logger, nk r
 
 	// Determine if user is a moderator (enforcer or operator), independent of division.
 	// Computed early because toxic separation exempts moderators.
-	isModerator := sessionParams.isGlobalOperator
-	if !isModerator && groupID != uuid.Nil {
-		if gg, ok := sessionParams.guildGroups[groupID.String()]; ok {
-			isModerator = gg.IsEnforcer(userID)
-		}
-	}
+	isModerator := isModeratorOfGroup(sessionParams.isGlobalOperator, sessionParams.guildGroups, groupID, userID)
 
 	// SEC-5: the entrant role is client-claimed. Moderator is only legitimate
 	// for verified moderators (global operator or guild enforcer); anything

--- a/server/evr_lobby_vpn_degraded_test.go
+++ b/server/evr_lobby_vpn_degraded_test.go
@@ -1,0 +1,229 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// SEC-6 — the VPN gate fails open globally and its degradation is unalertable.
+//
+// The IPQS circuit breaker is a single process-global flag opened by any single
+// failure (1s HTTP timeout, any non-200, or a Success:false body — which is what
+// quota exhaustion returns) with backoff 5s→5min. While it is open,
+// IPQSClient.Get returns (nil, nil), IPInfoCache.Get falls through to (nil, nil),
+// and params.ipInfo is nil for every player. The lobby gate requires
+// params.isVPN && params.ipInfo != nil, so VPN blocking is off for every guild
+// for up to five minutes — and each uncached login burns two IPQS calls, so an
+// attacker cycling fresh VPN IPs can induce the outage themselves.
+//
+// This PR does not change the fail-open policy. It makes the degraded state
+// alertable and stops the warning from burying itself.
+
+// recordingMetrics records CustomCounter calls; everything else is a no-op.
+type recordingMetrics struct {
+	testMetrics
+	mu       sync.Mutex
+	counters map[string]int64
+	tags     map[string]map[string]string
+}
+
+func newRecordingMetrics() *recordingMetrics {
+	return &recordingMetrics{counters: make(map[string]int64), tags: make(map[string]map[string]string)}
+}
+
+func (m *recordingMetrics) CustomCounter(name string, tags map[string]string, delta int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.counters[name] += delta
+	m.tags[name] = tags
+}
+
+func (m *recordingMetrics) count(name string) int64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.counters[name]
+}
+
+func (m *recordingMetrics) tagsFor(name string) map[string]string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tags[name]
+}
+
+// (a) The degraded state must be alertable. Every sibling rejection path in
+// lobbyAuthorize increments a counter; the degradation path is the one place
+// where VPN blocking silently stops working, and it had only a bare zap.Warn.
+func TestWarnVPNDegraded_IncrementsAlertableCounter(t *testing.T) {
+	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+
+	core, _ := observer.New(zapcore.DebugLevel)
+	metrics := newRecordingMetrics()
+
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", false)
+
+	require.Equal(t, int64(1), metrics.count("lobby_vpn_check_degraded"),
+		"SEC-6(a): the degraded VPN gate must emit a counter so it can be alerted on")
+
+	tags := metrics.tagsFor("lobby_vpn_check_degraded")
+	require.NotNil(t, tags)
+	assert.Equal(t, "987654321098765432", tags["group_id"],
+		"the counter must be attributable to the guild whose gate stopped working")
+}
+
+// (b) During an outage the warning fired once per lobby authorize per player in
+// every VPN-blocking guild, burying its own signal. The counter must still
+// count every occurrence (that is the true volume); the log line must not.
+func TestWarnVPNDegraded_LogIsThrottledPerGuildButCounterIsNot(t *testing.T) {
+	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	metrics := newRecordingMetrics()
+
+	const guildA = "111111111111111111"
+	const guildB = "222222222222222222"
+
+	for i := 0; i < 25; i++ {
+		warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "123456789012345678", guildA, false)
+	}
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.8", "123456789012345679", guildB, true)
+
+	require.Equal(t, int64(26), metrics.count("lobby_vpn_check_degraded"),
+		"the counter carries the real per-player volume and must not be throttled")
+
+	entries := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
+	require.Len(t, entries, 2,
+		"SEC-6(b): the warning must be throttled to one line per guild per window — "+
+			"26 unthrottled lines per guild per outage bury the signal they exist to raise")
+
+	guilds := []string{entries[0].ContextMap()["guild_id"].(string), entries[1].ContextMap()["guild_id"].(string)}
+	assert.ElementsMatch(t, []string{guildA, guildB}, guilds,
+		"throttling is per guild: each affected guild must get its own line")
+}
+
+func TestWarnVPNDegraded_LogResumesAfterThrottleWindow(t *testing.T) {
+	throttle := newLogThrottle(time.Minute)
+	vpnDegradedLogThrottle = throttle
+
+	now := time.Now()
+	throttle.now = func() time.Time { return now }
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	metrics := newRecordingMetrics()
+
+	const guild = "111111111111111111"
+
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+	now = now.Add(59 * time.Second)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+	now = now.Add(2 * time.Second)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+
+	require.Len(t, logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All(), 2,
+		"a persistent outage must keep re-announcing itself once the window elapses")
+}
+
+// The warning must still carry the triage fields it always carried, plus the
+// session's VPN flag — the condition the guard dropped.
+func TestWarnVPNDegraded_CarriesTriageFields(t *testing.T) {
+	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	metrics := newRecordingMetrics()
+
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", true)
+
+	entries := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
+	require.Len(t, entries, 1)
+	require.Equal(t, zapcore.WarnLevel, entries[0].Level)
+
+	ctx := entries[0].ContextMap()
+	assert.Equal(t, "203.0.113.7", ctx["client_ip"])
+	assert.Equal(t, "123456789012345678", ctx["discord_id"])
+	assert.Equal(t, "987654321098765432", ctx["guild_id"])
+	assert.Equal(t, true, ctx["session_flagged_vpn"],
+		"params.isVPN is the signal the guard dropped; keep it as triage context")
+}
+
+// (b) The degradation warning must be scoped the same way the gate it stands in
+// for is scoped: a player the guild has explicitly exempted from VPN blocking
+// was never going to be rejected, so their lookup failing is not a gap.
+func TestShouldWarnVPNDegraded(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		blockVPNUsers   bool
+		isVPNBypass     bool
+		ipInfo          IPInfo
+		want            bool
+		wantExplainedBy string
+	}{
+		{name: "degraded in a blocking guild", blockVPNUsers: true, isVPNBypass: false, ipInfo: nil, want: true},
+		{name: "guild does not block VPNs", blockVPNUsers: false, isVPNBypass: false, ipInfo: nil, want: false},
+		{name: "player is VPN-bypassed", blockVPNUsers: true, isVPNBypass: true, ipInfo: nil, want: false,
+			wantExplainedBy: "an exempt player would have passed the gate anyway — not a gap"},
+		{name: "lookup succeeded", blockVPNUsers: true, isVPNBypass: false, ipInfo: &StubIPInfo{}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, shouldWarnVPNDegraded(tc.blockVPNUsers, tc.isVPNBypass, tc.ipInfo), tc.wantExplainedBy)
+		})
+	}
+}
+
+// (c) The `errored` map in IPInfoCache.Get was populated and never read, so Get
+// could never return a non-nil error. Provider failures must be observable.
+type erroringIPInfoProvider struct {
+	name string
+	err  error
+	info IPInfo
+}
+
+func (p *erroringIPInfoProvider) Name() string { return p.name }
+func (p *erroringIPInfoProvider) Get(_ context.Context, _ string) (IPInfo, error) {
+	return p.info, p.err
+}
+
+func TestIPInfoCache_ProviderErrorsAreCounted(t *testing.T) {
+	metrics := newRecordingMetrics()
+	core, logs := observer.New(zapcore.DebugLevel)
+
+	cache, err := NewIPInfoCache(zap.New(core), metrics,
+		&erroringIPInfoProvider{name: "IPQS", err: errors.New("quota exhausted")},
+	)
+	require.NoError(t, err)
+
+	info, err := cache.Get(context.Background(), "203.0.113.7")
+
+	require.NoError(t, err, "the cache deliberately fails open — the error channel stays nil")
+	require.Nil(t, info)
+	require.Equal(t, int64(1), metrics.count("ip_info_provider_error"),
+		"SEC-6(c): a provider error must be counted, not swallowed into a map nobody reads")
+	assert.Equal(t, "IPQS", metrics.tagsFor("ip_info_provider_error")["provider"])
+	assert.Positive(t, logs.Len(), "a provider error should leave a trace in the log too")
+}
+
+func TestIPInfoCache_SuccessfulProviderIsNotCountedAsAnError(t *testing.T) {
+	metrics := newRecordingMetrics()
+	core, _ := observer.New(zapcore.DebugLevel)
+
+	cache, err := NewIPInfoCache(zap.New(core), metrics,
+		&erroringIPInfoProvider{name: "broken", err: errors.New("boom")},
+		&erroringIPInfoProvider{name: "working", info: &StubIPInfo{}},
+	)
+	require.NoError(t, err)
+
+	info, err := cache.Get(context.Background(), "203.0.113.7")
+	require.NoError(t, err)
+	require.NotNil(t, info, "a later provider that succeeds must still be used")
+	require.Equal(t, int64(1), metrics.count("ip_info_provider_error"),
+		"only the failing provider is counted")
+}

--- a/server/evr_lobby_vpn_degraded_test.go
+++ b/server/evr_lobby_vpn_degraded_test.go
@@ -69,8 +69,12 @@ func (m *recordingMetrics) tagsFor(name string) map[string]string {
 // for entirely the wrong reason.
 func resetVPNDegradedThrottle(t *testing.T) {
 	t.Helper()
-	vpnDegradedLogThrottle.reset()
-	t.Cleanup(vpnDegradedLogThrottle.reset)
+	reset := func() {
+		vpnDegradedLogThrottle.reset()
+		vpnUnconfiguredLogThrottle.reset()
+	}
+	reset()
+	t.Cleanup(reset)
 }
 
 // (a) The degraded state must be alertable. Every sibling rejection path in
@@ -82,7 +86,7 @@ func TestWarnVPNDegraded_IncrementsAlertableCounter(t *testing.T) {
 	core, _ := observer.New(zapcore.DebugLevel)
 	metrics := newRecordingMetrics()
 
-	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", false)
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", false, vpnDegradedLookupFailed)
 
 	require.Equal(t, int64(1), metrics.count("lobby_vpn_check_degraded"),
 		"SEC-6(a): the degraded VPN gate must emit a counter so it can be alerted on")
@@ -107,9 +111,9 @@ func TestWarnVPNDegraded_LogIsThrottledPerGuildButCounterIsNot(t *testing.T) {
 	const guildB = "222222222222222222"
 
 	for i := 0; i < 25; i++ {
-		warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "123456789012345678", guildA, false)
+		warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "123456789012345678", guildA, false, vpnDegradedLookupFailed)
 	}
-	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.8", "123456789012345679", guildB, true)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.8", "123456789012345679", guildB, true, vpnDegradedLookupFailed)
 
 	require.Equal(t, int64(26), metrics.count("lobby_vpn_check_degraded"),
 		"the counter carries the real per-player volume and must not be throttled")
@@ -136,11 +140,11 @@ func TestWarnVPNDegraded_LogResumesAfterThrottleWindow(t *testing.T) {
 
 	const guild = "111111111111111111"
 
-	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false, vpnDegradedLookupFailed)
 	now = now.Add(59 * time.Second)
-	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false, vpnDegradedLookupFailed)
 	now = now.Add(2 * time.Second)
-	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false)
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false, vpnDegradedLookupFailed)
 
 	require.Len(t, logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All(), 2,
 		"a persistent outage must keep re-announcing itself once the window elapses")
@@ -154,7 +158,7 @@ func TestWarnVPNDegraded_CarriesTriageFields(t *testing.T) {
 	core, logs := observer.New(zapcore.DebugLevel)
 	metrics := newRecordingMetrics()
 
-	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", true)
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "123456789012345678", "987654321098765432", true, vpnDegradedLookupFailed)
 
 	entries := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
 	require.Len(t, entries, 1)
@@ -187,9 +191,140 @@ func TestShouldWarnVPNDegraded(t *testing.T) {
 		{name: "lookup succeeded", blockVPNUsers: true, isVPNBypass: false, ipInfo: &StubIPInfo{}, want: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.want, shouldWarnVPNDegraded(tc.blockVPNUsers, tc.isVPNBypass, tc.ipInfo), tc.wantExplainedBy)
+			got := shouldWarnVPNDegraded(tc.blockVPNUsers, tc.ipInfo, func() bool { return tc.isVPNBypass })
+			require.Equal(t, tc.want, got, tc.wantExplainedBy)
 		})
 	}
+}
+
+// Review follow-up. The bypass check reaches through GuildGroup.HasRole into a
+// per-guild RLock (server/evr_guild_group.go), so it must stay behind the two
+// cheap conditions the way the original `&&` chain had it. Passing a plain bool
+// made Go evaluate it on every lobby authorize, including the overwhelmingly
+// common case where the guild does not block VPNs at all.
+func TestShouldWarnVPNDegraded_DoesNotEvaluateBypassUnlessItMatters(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		blockVPNUsers bool
+		ipInfo        IPInfo
+	}{
+		{"guild does not block VPNs", false, nil},
+		{"lookup succeeded, so the gate ran normally", true, &StubIPInfo{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			called := false
+			require.False(t, shouldWarnVPNDegraded(tc.blockVPNUsers, tc.ipInfo, func() bool { called = true; return false }))
+			require.False(t, called,
+				"the bypass lookup takes a per-guild read lock; it must stay short-circuited behind the cheap checks")
+		})
+	}
+}
+
+// Review follow-up (blocking). SEC-6(a) made the degraded gate alertable, but on
+// an untagged counter the alert is useless on a large class of deployments.
+//
+// The IP intelligence providers are only constructed inside `if redisClient !=
+// nil` (server/evr_pipeline.go), and redisClient is nil unless REDIS_URI is set.
+// A deployment without Redis therefore has *no* providers: IPInfoCache.Get
+// returns (nil, nil) for every public IP, permanently — not transiently.
+// shouldWarnVPNDegraded is then true for every player in every BlockVPNUsers
+// guild on every lobby authorize, forever, so an alert wired to
+// lobby_vpn_check_degraded fires forever and carries zero information. That is
+// the same "buries its own signal" failure SEC-6(b) exists to fix, relocated
+// from the log into the metric.
+//
+// The fix is to tell the two apart. The standing configuration gap is still
+// counted and still logged — it is a real security gap — but on its own reason
+// tag and its own much longer log window, so it can neither be mistaken for an
+// outage nor drown one out.
+func TestVPNDegradedReasonFor_DistinguishesAStandingGapFromAnOutage(t *testing.T) {
+	configured, err := NewIPInfoCache(nil, nil, &erroringIPInfoProvider{name: "IPQS", info: &StubIPInfo{}})
+	require.NoError(t, err)
+	require.Equal(t, vpnDegradedLookupFailed, vpnDegradedReasonFor(configured),
+		"with a provider wired up, an empty result is a transient lookup failure — the alertable case")
+
+	unconfigured, err := NewIPInfoCache(nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, vpnDegradedNotConfigured, vpnDegradedReasonFor(unconfigured),
+		"with no provider at all the gate can never evaluate; this is a standing config gap, not an outage")
+
+	require.Equal(t, vpnDegradedNotConfigured, vpnDegradedReasonFor(nil),
+		"a nil cache is the same standing gap, and classifying it must not panic")
+}
+
+func TestIPInfoCache_IsConfigured(t *testing.T) {
+	none, err := NewIPInfoCache(nil, nil)
+	require.NoError(t, err)
+	require.False(t, none.IsConfigured(),
+		"no REDIS_URI means no providers are ever appended (server/evr_pipeline.go)")
+
+	some, err := NewIPInfoCache(nil, nil, &erroringIPInfoProvider{name: "IPQS", info: &StubIPInfo{}})
+	require.NoError(t, err)
+	require.True(t, some.IsConfigured())
+
+	var nilCache *IPInfoCache
+	require.False(t, nilCache.IsConfigured(), "must be nil-safe: callers classify before dereferencing")
+}
+
+func TestWarnVPNDegraded_CounterCarriesReasonSoAlertsCanSelectTheTransientCase(t *testing.T) {
+	resetVPNDegradedThrottle(t)
+
+	core, _ := observer.New(zapcore.DebugLevel)
+	metrics := newRecordingMetrics()
+
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "1", "987654321098765432", false, vpnDegradedNotConfigured)
+
+	tags := metrics.tagsFor("lobby_vpn_check_degraded")
+	require.NotNil(t, tags)
+	require.Equal(t, "not_configured", tags["reason"],
+		"a permanently-firing counter must be distinguishable from a real outage, or the alert is noise")
+
+	warnVPNDegraded(zap.New(core), metrics.CustomCounter, "203.0.113.7", "1", "987654321098765432", false, vpnDegradedLookupFailed)
+	require.Equal(t, "lookup_failed", metrics.tagsFor("lobby_vpn_check_degraded")["reason"],
+		"alert on reason=lookup_failed to page only on the transient case")
+}
+
+// The standing gap must not consume the outage warning's throttle budget, and
+// must not be reported in the outage's words: an operator grepping for the IPQS
+// outage message must not find a deployment that simply has no provider.
+func TestWarnVPNDegraded_UnconfiguredGapDoesNotImpersonateOrCrowdOutAnOutage(t *testing.T) {
+	resetVPNDegradedThrottle(t)
+
+	now := time.Now()
+	vpnDegradedLogThrottle.setClock(func() time.Time { return now })
+	vpnUnconfiguredLogThrottle.setClock(func() time.Time { return now })
+
+	core, logs := observer.New(zapcore.DebugLevel)
+	logger := zap.New(core)
+	metrics := newRecordingMetrics()
+
+	const guild = "111111111111111111"
+
+	// A whole hour of authorizes on a deployment with no provider configured.
+	for i := 0; i < 60; i++ {
+		warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false, vpnDegradedNotConfigured)
+		now = now.Add(time.Minute)
+	}
+
+	outage := logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All()
+	require.Empty(t, outage,
+		"a deployment with no provider is not an IPQS outage and must not be logged as one")
+
+	gap := logs.FilterMessage("VPN blocking inert: no IP intelligence provider is configured").All()
+	require.Len(t, gap, 1,
+		"the standing gap holds until the process is restarted with a provider configured, so it gets a "+
+			"long window — 60 lines per guild per hour, forever, is the log spam SEC-6(b) exists to prevent")
+	require.Equal(t, zapcore.WarnLevel, gap[0].Level)
+	require.Equal(t, "not_configured", gap[0].ContextMap()["reason"])
+
+	require.Equal(t, int64(60), metrics.count("lobby_vpn_check_degraded"),
+		"the counter still carries the true volume; only the prose is throttled")
+
+	// The outage warning's budget is untouched: a real IPQS failure in the same
+	// guild still gets its line immediately.
+	warnVPNDegraded(logger, metrics.CustomCounter, "203.0.113.7", "1", guild, false, vpnDegradedLookupFailed)
+	require.Len(t, logs.FilterMessage("VPN blocking degraded: IPQS lookup unavailable for VPN check").All(), 1,
+		"the two conditions must throttle independently, or a standing gap silences a real outage")
 }
 
 // (c) The `errored` map in IPInfoCache.Get was populated and never read, so Get

--- a/server/evr_lobby_vpn_degraded_test.go
+++ b/server/evr_lobby_vpn_degraded_test.go
@@ -59,11 +59,25 @@ func (m *recordingMetrics) tagsFor(name string) map[string]string {
 	return m.tags[name]
 }
 
+// resetVPNDegradedThrottle clears the process-wide degraded-VPN log throttle
+// before the test and again after it.
+//
+// It deliberately mutates the existing throttle rather than replacing the
+// package var: a reassignment is an unsynchronized write to state production
+// code reads, and leftover throttle state from a previous test would suppress
+// the very log line these tests count — making an assertion of "0 lines" pass
+// for entirely the wrong reason.
+func resetVPNDegradedThrottle(t *testing.T) {
+	t.Helper()
+	vpnDegradedLogThrottle.reset()
+	t.Cleanup(vpnDegradedLogThrottle.reset)
+}
+
 // (a) The degraded state must be alertable. Every sibling rejection path in
 // lobbyAuthorize increments a counter; the degradation path is the one place
 // where VPN blocking silently stops working, and it had only a bare zap.Warn.
 func TestWarnVPNDegraded_IncrementsAlertableCounter(t *testing.T) {
-	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+	resetVPNDegradedThrottle(t)
 
 	core, _ := observer.New(zapcore.DebugLevel)
 	metrics := newRecordingMetrics()
@@ -83,7 +97,7 @@ func TestWarnVPNDegraded_IncrementsAlertableCounter(t *testing.T) {
 // every VPN-blocking guild, burying its own signal. The counter must still
 // count every occurrence (that is the true volume); the log line must not.
 func TestWarnVPNDegraded_LogIsThrottledPerGuildButCounterIsNot(t *testing.T) {
-	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+	resetVPNDegradedThrottle(t)
 
 	core, logs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
@@ -111,11 +125,10 @@ func TestWarnVPNDegraded_LogIsThrottledPerGuildButCounterIsNot(t *testing.T) {
 }
 
 func TestWarnVPNDegraded_LogResumesAfterThrottleWindow(t *testing.T) {
-	throttle := newLogThrottle(time.Minute)
-	vpnDegradedLogThrottle = throttle
+	resetVPNDegradedThrottle(t)
 
 	now := time.Now()
-	throttle.now = func() time.Time { return now }
+	vpnDegradedLogThrottle.setClock(func() time.Time { return now })
 
 	core, logs := observer.New(zapcore.DebugLevel)
 	logger := zap.New(core)
@@ -136,7 +149,7 @@ func TestWarnVPNDegraded_LogResumesAfterThrottleWindow(t *testing.T) {
 // The warning must still carry the triage fields it always carried, plus the
 // session's VPN flag — the condition the guard dropped.
 func TestWarnVPNDegraded_CarriesTriageFields(t *testing.T) {
-	vpnDegradedLogThrottle = newLogThrottle(time.Minute)
+	resetVPNDegradedThrottle(t)
 
 	core, logs := observer.New(zapcore.DebugLevel)
 	metrics := newRecordingMetrics()
@@ -226,4 +239,27 @@ func TestIPInfoCache_SuccessfulProviderIsNotCountedAsAnError(t *testing.T) {
 	require.NotNil(t, info, "a later provider that succeeds must still be used")
 	require.Equal(t, int64(1), metrics.count("ip_info_provider_error"),
 		"only the failing provider is counted")
+}
+
+// Review follow-up. Counting the provider error introduced the first
+// dereference of s.metrics and s.logger on this path; NewIPInfoCache validates
+// neither and existing callers pass nil for both (server/evr_bugfix_test.go:62,
+// :88). Observability must never be the thing that panics a login path, so the
+// error branch has to survive a cache built with no logger and no metrics.
+func TestIPInfoCache_ProviderErrorWithNilLoggerAndMetricsDoesNotPanic(t *testing.T) {
+	cache, err := NewIPInfoCache(nil, nil,
+		&erroringIPInfoProvider{name: "IPQS", err: errors.New("quota exhausted")},
+	)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		info, getErr := cache.Get(context.Background(), "203.0.113.7")
+		require.NoError(t, getErr)
+		require.Nil(t, info, "the fail-open result is unchanged when there is nowhere to report to")
+	})
+
+	require.NotPanics(t, func() {
+		require.False(t, cache.IsVPN("203.0.113.7"),
+			"IsVPN still fails open when the provider errors and there is no logger")
+	})
 }

--- a/server/evr_log_throttle.go
+++ b/server/evr_log_throttle.go
@@ -5,19 +5,22 @@ import (
 	"time"
 )
 
-// logThrottle rate-limits repeated log lines by key, so a condition that holds
-// for every player in a guild for minutes at a time still produces a readable
-// number of log lines. Metrics counters are the right place to carry the true
-// volume; this only bounds the prose.
-type logThrottle struct {
+// perKeyLogThrottle rate-limits repeated log lines by key, so a condition that
+// holds for every player in a guild for minutes at a time still produces a
+// readable number of log lines. Metrics counters are the right place to carry
+// the true volume; this only bounds the prose.
+//
+// Every field is read and written under mu, including the clock, so a test may
+// swap in a fake clock on a throttle that production code is also calling.
+type perKeyLogThrottle struct {
 	mu       sync.Mutex
 	interval time.Duration
 	last     map[string]time.Time
 	now      func() time.Time
 }
 
-func newLogThrottle(interval time.Duration) *logThrottle {
-	return &logThrottle{
+func newPerKeyLogThrottle(interval time.Duration) *perKeyLogThrottle {
+	return &perKeyLogThrottle{
 		interval: interval,
 		last:     make(map[string]time.Time),
 		now:      time.Now,
@@ -26,7 +29,7 @@ func newLogThrottle(interval time.Duration) *logThrottle {
 
 // allow reports whether key may emit a log line now, recording the emission
 // when it does. The first call for a key always passes.
-func (t *logThrottle) allow(key string) bool {
+func (t *perKeyLogThrottle) allow(key string) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
@@ -36,4 +39,28 @@ func (t *logThrottle) allow(key string) bool {
 	}
 	t.last[key] = now
 	return true
+}
+
+// reset forgets every recorded emission and restores the real clock.
+//
+// Tests must call this instead of reassigning the package-level throttle they
+// exercise: the throttle is shared process-wide, so leftover state from one
+// test silently suppresses another test's log line and makes its assertion pass
+// for the wrong reason, and an unsynchronized reassignment is a data race the
+// moment anything runs in parallel.
+func (t *perKeyLogThrottle) reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.last = make(map[string]time.Time)
+	t.now = time.Now
+}
+
+// setClock replaces the throttle's time source. Test-only; safe to call while
+// other goroutines are in allow.
+func (t *perKeyLogThrottle) setClock(now func() time.Time) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.now = now
 }

--- a/server/evr_log_throttle.go
+++ b/server/evr_log_throttle.go
@@ -1,0 +1,39 @@
+package server
+
+import (
+	"sync"
+	"time"
+)
+
+// logThrottle rate-limits repeated log lines by key, so a condition that holds
+// for every player in a guild for minutes at a time still produces a readable
+// number of log lines. Metrics counters are the right place to carry the true
+// volume; this only bounds the prose.
+type logThrottle struct {
+	mu       sync.Mutex
+	interval time.Duration
+	last     map[string]time.Time
+	now      func() time.Time
+}
+
+func newLogThrottle(interval time.Duration) *logThrottle {
+	return &logThrottle{
+		interval: interval,
+		last:     make(map[string]time.Time),
+		now:      time.Now,
+	}
+}
+
+// allow reports whether key may emit a log line now, recording the emission
+// when it does. The first call for a key always passes.
+func (t *logThrottle) allow(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := t.now()
+	if last, ok := t.last[key]; ok && now.Sub(last) < t.interval {
+		return false
+	}
+	t.last[key] = now
+	return true
+}

--- a/server/evr_log_throttle_test.go
+++ b/server/evr_log_throttle_test.go
@@ -1,0 +1,87 @@
+package server
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerKeyLogThrottle_AllowsFirstThenSuppressesWithinWindow(t *testing.T) {
+	th := newPerKeyLogThrottle(time.Minute)
+
+	now := time.Now()
+	th.setClock(func() time.Time { return now })
+
+	assert.True(t, th.allow("guild-a"), "the first line for a key always passes")
+	assert.False(t, th.allow("guild-a"), "a second line inside the window is suppressed")
+
+	assert.True(t, th.allow("guild-b"), "throttling is per key, not global")
+
+	now = now.Add(59 * time.Second)
+	assert.False(t, th.allow("guild-a"), "still inside the window")
+
+	now = now.Add(2 * time.Second)
+	assert.True(t, th.allow("guild-a"), "the window elapsed, so the condition re-announces itself")
+}
+
+// reset is the API tests must use instead of reassigning a shared throttle var.
+// It has to actually forget prior emissions, or a test that resets and then
+// asserts "exactly one log line" would silently observe zero.
+func TestPerKeyLogThrottle_ResetForgetsEmissionsAndRestoresTheRealClock(t *testing.T) {
+	th := newPerKeyLogThrottle(time.Hour)
+
+	frozen := time.Now()
+	th.setClock(func() time.Time { return frozen })
+
+	require.True(t, th.allow("guild-a"))
+	require.False(t, th.allow("guild-a"))
+
+	th.reset()
+
+	assert.True(t, th.allow("guild-a"),
+		"after reset the key must behave as if it had never emitted")
+
+	th.mu.Lock()
+	clockIsRestored := th.now != nil
+	th.mu.Unlock()
+	assert.True(t, clockIsRestored, "reset must leave a usable clock behind for the next test")
+}
+
+// Review follow-up (fragile global): the degraded-VPN throttle is a package-level
+// var that production code reads on every lobby authorize. Tests used to swap it
+// wholesale, which is an unsynchronized write to shared state — safe only for as
+// long as nothing runs in parallel. Mutating through reset/setClock instead puts
+// every write behind the throttle's own lock, so this stays clean under -race
+// even with concurrent readers.
+func TestPerKeyLogThrottle_MutationIsRaceSafeAgainstConcurrentReaders(t *testing.T) {
+	th := newPerKeyLogThrottle(time.Millisecond)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					th.allow("guild-a")
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < 200; i++ {
+		th.reset()
+		th.setClock(time.Now)
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -491,9 +491,10 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 
 	// Get the IPQS Data
 
-	if params.ipInfo, err = p.ipInfoCache.Get(ctx, session.clientIP); err != nil {
-		logger.Debug("Failed to get IPQS details", zap.Error(err))
-	}
+	// Fails open by contract: IPInfoCache.Get never returns a non-nil error, and
+	// a nil params.ipInfo means "unknown", not "clean" (SEC-6). Lookup failures
+	// are counted by the ip_info_provider_error / ipqs_* metrics.
+	params.ipInfo, _ = p.ipInfoCache.Get(ctx, session.clientIP)
 
 	// The account is now authenticated. Authorize the session.
 	if params.profile.IsDisabled() {

--- a/server/evr_runtime_rpc_setnextmatch.go
+++ b/server/evr_runtime_rpc_setnextmatch.go
@@ -95,18 +95,8 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 		}
 
 		// Validate the role
-		if request.Role != "" && request.Role != "any" {
-			switch label.Mode {
-
-			case evr.ModeArenaPublic, evr.ModeCombatPublic:
-				return "", runtime.NewError("Match is a public match, but role is set", StatusInvalidArgument)
-			case evr.ModeArenaPrivate, evr.ModeCombatPrivate:
-				if request.Role != "orange" && request.Role != "blue" && request.Role != "spectator" {
-					return "", runtime.NewError("Match is a private match, but role is not set to 'orange', 'blue', or 'spectator'.", StatusInvalidArgument)
-				}
-			default:
-				return "", runtime.NewError(fmt.Sprintf("Role may not be set for %s matches", label.Mode.String()), StatusInvalidArgument)
-			}
+		if err := validateSetNextMatchRole(request.Role, label.Mode); err != nil {
+			return "", err
 		}
 		if gid := label.GetGroupID(); !gid.IsNil() {
 			auditGroupID = gid.String()
@@ -153,6 +143,52 @@ func SetNextMatchRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, nk 
 	return response.String(), nil
 }
 
+// validateSetNextMatchRole checks that an explicitly requested directive role is
+// legal for the mode of the match being targeted. "" and "any" mean "no explicit
+// role" and are always legal.
+//
+// Note that "moderator" is legal for no mode at all: the immediate-join path
+// this feeds does not go through lobbyJoin, so a moderator role granted here
+// would never face the guild-scoped re-validation added for SEC-5.
+func validateSetNextMatchRole(role string, mode evr.Symbol) error {
+	if role == "" || role == "any" {
+		return nil
+	}
+
+	switch mode {
+	case evr.ModeArenaPublic, evr.ModeCombatPublic:
+		return runtime.NewError("Match is a public match, but role is set", StatusInvalidArgument)
+	case evr.ModeArenaPrivate, evr.ModeCombatPrivate:
+		if role != "orange" && role != "blue" && role != "spectator" {
+			return runtime.NewError("Match is a private match, but role is not set to 'orange', 'blue', or 'spectator'.", StatusInvalidArgument)
+		}
+		return nil
+	default:
+		return runtime.NewError(fmt.Sprintf("Role may not be set for %s matches", mode.String()), StatusInvalidArgument)
+	}
+}
+
+// resolveImmediateJoinRole maps a validated directive role string to a team
+// index for the immediate-join path.
+//
+// There is deliberately no "moderator" arm. tryImmediateJoin calls
+// LobbyJoinEntrants directly, bypassing lobbyJoin and its guild-scoped
+// moderator re-validation (SEC-5), so this path must not be able to mint a
+// moderator. validateSetNextMatchRole already rejects "moderator" for every
+// mode, which is what made the arm that used to be here unreachable.
+func resolveImmediateJoinRole(role string) int {
+	switch role {
+	case "orange":
+		return evr.TeamOrange
+	case "blue":
+		return evr.TeamBlue
+	case "spectator":
+		return evr.TeamSpectator
+	default:
+		return evr.TeamUnassigned
+	}
+}
+
 // tryImmediateJoin attempts to join the target user into the match right now.
 // Returns an informational message (empty on success). Sets response.JoinedImmediately on success.
 func tryImmediateJoin(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, request SetNextMatchRPCRequest, label *MatchLabel, response *SetNextMatchRPCResponse) string {
@@ -183,21 +219,8 @@ func tryImmediateJoin(ctx context.Context, logger runtime.Logger, nk runtime.Nak
 		return "game server session not found; directive stored for next session"
 	}
 
-	// Resolve role string to int
-	role := evr.TeamUnassigned
-	switch request.Role {
-	case "orange":
-		role = evr.TeamOrange
-	case "blue":
-		role = evr.TeamBlue
-	case "spectator":
-		role = evr.TeamSpectator
-	case "moderator":
-		role = evr.TeamModerator
-	}
-
 	// Build entrant presence from the active session
-	presence, err := EntrantPresenceFromSession(session, uuid.Nil, role, types.Rating{}, label.GetGroupID().String(), 0, "")
+	presence, err := EntrantPresenceFromSession(session, uuid.Nil, resolveImmediateJoinRole(request.Role), types.Rating{}, label.GetGroupID().String(), 0, "")
 	if err != nil {
 		return fmt.Sprintf("failed to create entrant presence: %s", err.Error())
 	}

--- a/server/evr_runtime_rpc_setnextmatch_role_test.go
+++ b/server/evr_runtime_rpc_setnextmatch_role_test.go
@@ -1,0 +1,81 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/require"
+)
+
+// SEC-5, related finding. tryImmediateJoin mapped the directive role string
+// "moderator" to evr.TeamModerator and pushed it straight into an entrant
+// presence via LobbyJoinEntrants — bypassing lobbyJoin entirely, and with it
+// the guild-scoped moderator re-validation added for SEC-5.
+//
+// That case was unreachable: tryImmediateJoin only runs when label != nil,
+// which only happens when the request carried a match ID, which means the role
+// validation already ran — and that validation rejects "moderator" for every
+// mode. These tests pin that claim, so removing the unreachable mapping is
+// provably safe rather than merely plausible.
+func TestValidateSetNextMatchRole_ModeratorIsRejectedForEveryMode(t *testing.T) {
+	modes := append([]evr.Symbol{}, evr.AllModes...)
+	modes = append(modes,
+		evr.ModeUnloaded,
+		evr.ModeArenaTournment,
+		evr.ModeEchoCombatTournament,
+		evr.Symbol(0xdeadbeef), // an unknown mode must hit the default arm
+	)
+
+	for _, mode := range modes {
+		t.Run(mode.String(), func(t *testing.T) {
+			require.Error(t, validateSetNextMatchRole("moderator", mode),
+				"a directive must never be able to request the moderator role: "+
+					"tryImmediateJoin joins the entrant directly, skipping lobbyJoin's "+
+					"guild-scoped moderator re-validation")
+		})
+	}
+}
+
+func TestValidateSetNextMatchRole_AcceptedAndRejectedRoles(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		role    string
+		mode    evr.Symbol
+		wantErr bool
+	}{
+		{"empty role is always fine", "", evr.ModeArenaPublic, false},
+		{"any role is always fine", "any", evr.ModeArenaPublic, false},
+		{"any role is fine for social", "any", evr.ModeSocialPublic, false},
+		{"public arena rejects an explicit role", "blue", evr.ModeArenaPublic, true},
+		{"public combat rejects an explicit role", "blue", evr.ModeCombatPublic, true},
+		{"private arena accepts blue", "blue", evr.ModeArenaPrivate, false},
+		{"private arena accepts orange", "orange", evr.ModeArenaPrivate, false},
+		{"private arena accepts spectator", "spectator", evr.ModeArenaPrivate, false},
+		{"private combat accepts blue", "blue", evr.ModeCombatPrivate, false},
+		{"private arena rejects an unknown role", "sideline", evr.ModeArenaPrivate, true},
+		{"social rejects any explicit role", "blue", evr.ModeSocialPublic, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSetNextMatchRole(tc.role, tc.mode)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// resolveImmediateJoinRole is what tryImmediateJoin uses to turn the validated
+// directive role string into a team index. "moderator" must not be mappable:
+// this path does not go through lobbyJoin, so nothing would re-validate it.
+func TestResolveImmediateJoinRole_ModeratorIsNotGrantable(t *testing.T) {
+	require.Equal(t, evr.TeamUnassigned, resolveImmediateJoinRole("moderator"),
+		"the immediate-join path must never mint a moderator role")
+
+	require.Equal(t, evr.TeamOrange, resolveImmediateJoinRole("orange"))
+	require.Equal(t, evr.TeamBlue, resolveImmediateJoinRole("blue"))
+	require.Equal(t, evr.TeamSpectator, resolveImmediateJoinRole("spectator"))
+	require.Equal(t, evr.TeamUnassigned, resolveImmediateJoinRole(""))
+	require.Equal(t, evr.TeamUnassigned, resolveImmediateJoinRole("any"))
+}

--- a/server/evr_runtime_rpc_setnextmatch_role_test.go
+++ b/server/evr_runtime_rpc_setnextmatch_role_test.go
@@ -17,6 +17,14 @@ import (
 // validation already ran — and that validation rejects "moderator" for every
 // mode. These tests pin that claim, so removing the unreachable mapping is
 // provably safe rather than merely plausible.
+//
+// Scope note: this says nothing about a directive with NO match ID. That path
+// skips validateSetNextMatchRole entirely (SetNextMatchRPC only enters the
+// validating branch under `if !request.MatchID.IsNil()`), so `{"role":
+// "moderator"}` is still storable and resolveDirectiveRole maps it to
+// evr.TeamModerator. What contains it is the SEC-5 downgrade this PR adds in
+// lobbyJoin, not the string being unstorable. Moving the validation out of the
+// match-ID branch is a separate fix, tracked as a follow-up.
 func TestValidateSetNextMatchRole_ModeratorIsRejectedForEveryMode(t *testing.T) {
 	modes := append([]evr.Symbol{}, evr.AllModes...)
 	modes = append(modes,
@@ -29,9 +37,9 @@ func TestValidateSetNextMatchRole_ModeratorIsRejectedForEveryMode(t *testing.T) 
 	for _, mode := range modes {
 		t.Run(mode.String(), func(t *testing.T) {
 			require.Error(t, validateSetNextMatchRole("moderator", mode),
-				"a directive must never be able to request the moderator role: "+
-					"tryImmediateJoin joins the entrant directly, skipping lobbyJoin's "+
-					"guild-scoped moderator re-validation")
+				"a directive that names a match must never be able to request the "+
+					"moderator role: tryImmediateJoin joins the entrant directly, "+
+					"skipping lobbyJoin's guild-scoped moderator re-validation")
 		})
 	}
 }


### PR DESCRIPTION
Tier-1 security gates. Two independent issues in the lobby-join path:

- **SEC-5** — a client-claimed `TeamModerator` entrant role was validated against the wrong guild, so an enforcer of guild A could enter a guild-B lobby as a moderator.
- **SEC-6** — the VPN gate fails open globally and its degraded state was neither alertable nor legible.

Base `d3e7e5549` · HEAD `92feb178f` · every citation below is `file:line @ 92feb178f` unless it names another SHA.

---

## Summary

| Scenario | Class | Gated behind | Frequency |
|---|---|---|---|
| Guild-A enforcer joins a guild-B lobby as `TeamModerator` | **FIX** | nothing — any enforcer of any guild | unquantified; no counter existed before this PR |
| Degraded VPN gate is invisible to alerting | **NEW** | `BlockVPNUsers` guilds | unquantified; new counter makes it measurable |
| Degraded-VPN WARN fired per player per authorize, incl. bypassed players | **FIX** | `BlockVPNUsers` + empty IP lookup | log volume drops by the number of authorizes per guild per minute |
| No IP provider configured reads as a permanent IPQS outage | **NEW** | deployments without `REDIS_URI` | permanent when it applies; deployment-dependent |
| IP provider errors collected into a map nobody read | **NEW** | any provider returning a non-nil error | **unreachable with in-repo providers** — see §5 |
| `setnextmatch` moderator role grant | **NEUTRAL** | — | unreachable in production |
| Two unreachable `err != nil` branches + their log lines | **NEUTRAL** | — | never emitted |
| VPN-bypass lookup evaluated on every authorize | **NEUTRAL** | — | one `RLock` per authorize, removed |

---

## 1. A guild-A enforcer could enter a guild-B lobby as `TeamModerator` [FIX]

**What was tried:** A player who holds the Enforcer role in guild A opens the social menu in a guild-B lobby (or uses Echo Taxi / a match link) and sends a `LobbyJoinSessionRequest` for a guild-B match with `Role = 4` (`TeamModerator`).

**What they expected:** The server validates the moderator claim against the guild that owns the lobby, and refuses it.

**What happened BEFORE this PR:** The claim was honoured. `NewLobbyParametersFromRequest` validates a claimed `TeamModerator` role against `request.GetGroupID()`, but `LobbyJoinSessionRequest.GetGroupID()` returns `uuid.Nil` unconditionally (`server/evr/match_session_join_request.go:155-157`), so the validation fell back to the user's *active* guild — guild A, where they really are an enforcer. `lobbyJoin` then repointed the parameters at the lobby's guild (`lobbyParams.GroupID = label.GetGroupID()`) and pushed the unvalidated role straight into the entrant presence, with no re-check in between:

```go
// git show d3e7e5549:server/evr_lobby_join.go
lobbyParams.GroupID = label.GetGroupID()
lobbyParams.Mode = label.Mode

// Do authorization checks related to the lobby's guild.
if err := p.lobbyAuthorize(ctx, logger, session, lobbyParams); err != nil {
    return err
}

presence, err := EntrantPresenceFromSession(session, lobbyParams.PartyID, lobbyParams.Role, ...)
```

A `TeamModerator` entrant is exempt from the player count, draws from the moderator slot pool, is exempt from early-quit tracking, and is exempt from the post-match social transition.

**Estimated frequency:** Unquantified, and *not retrospectively countable* — there was no log line or counter on this path before this PR, which is part of the finding. Reachable by any user holding Enforcer in at least one guild, against any lobby of any other guild. The new `lobby_moderator_role_downgraded` counter makes it measurable going forward.

**What happens AFTER this PR:** `lobbyJoin` re-validates the claim against the lobby's own guild, in step with the `GroupID`/`Mode` re-scoping and *before* both `lobbyAuthorize` and presence construction (`server/evr_lobby_join.go:33-59`). A non-enforcer's claim is downgraded to `TeamUnassigned`. It fails closed: missing session parameters, or a guild absent from the session's guild map, both yield "not a moderator" rather than inheriting the active guild's privileges (`server/evr_lobby_parameters.go:127-139`, including the `groupID == uuid.Nil` guard at `:131`).

**Log signature BEFORE:** none — silent.
**Log signature AFTER:** `WARN  Downgrading unverified moderator role claim  {"uid": ..., "gid": ..., "mid": ...}` — `server/evr_lobby_join.go:53-56`. Plus counter `lobby_moderator_role_downgraded{group_id}` at `server/evr_lobby_join.go:57`.

**How to verify in production logs:**
```bash
grep 'Downgrading unverified moderator role claim' /home/echovrce/deployment/logs/nakama.log
```
Each line is one blocked cross-guild moderator claim. `gid` is the lobby's guild; `uid` the claimant.

**Citation:** `server/evr_lobby_join.go:33-59 @ 92feb178f`. Tests: `TestLobbyJoin_ModeratorClaimIsScopedToTheLobbysGuild`, `TestLobbyJoin_ModeratorClaimFailsClosedWhenGuildIsUnknown`, `TestLobbyJoin_ModeratorClaimFailsClosedWithoutSessionParameters`, `TestLobbyJoin_ModeratorClaimSurvivesForEnforcerOfTheLobbysGuild`, `TestLobbyJoin_ModeratorClaimSurvivesForGlobalOperator`, `TestLobbyJoin_NonModeratorRolesAreNotTouched` (`server/evr_lobby_join_moderator_scope_test.go`). Reverting `evr_lobby_join.go` to base yields `expected: -1, actual: 4` on the exploit test.

---

## 2. The degraded VPN gate is now alertable [NEW]

**What was tried:** An operator wires an alert to "VPN blocking has stopped working in a guild that requires it".

**What they expected:** A counter to alert on, like every sibling rejection path in `lobbyAuthorize` has.

**What happened BEFORE this PR:** There was nothing to alert on. Every other outcome in `lobbyAuthorize` increments `lobby_authorization` with an `error` tag; the degradation path had a bare `zap.Warn` and no counter (`git show d3e7e5549:server/evr_lobby_joinentrant.go:519-525, :596-600`).

**Estimated frequency:** Unquantified — the absence of this counter is precisely why the historical rate is unknown.

**What happens AFTER this PR:** `lobby_vpn_check_degraded{group_id, reason}` is incremented on **every** occurrence — unthrottled, so it carries the true per-player volume (`server/evr_lobby_joinentrant.go:684-688`).

**Log signature BEFORE:** `WARN  VPN blocking degraded: IPQS lookup unavailable for VPN check` (existed, unthrottled).
**Log signature AFTER:** same message, now throttled and carrying a new `reason` field — see §3 and §4.

**How to verify in production logs:** this one is a metric, not a log line. Alert on `rate(lobby_vpn_check_degraded{reason="lookup_failed"}[5m]) > 0`. Do **not** alert on the untagged total — see §4 for why.

**Citation:** `server/evr_lobby_joinentrant.go:684-688 @ 92feb178f`. Test: `TestWarnVPNDegraded_IncrementsAlertableCounter`. Dropping the counter yields `expected: 1, actual: 0`.

---

## 3. The degraded-VPN warning no longer buries its own signal [FIX]

**What was tried:** An operator reads the log during an IPQS outage.

**What they expected:** A few lines saying VPN blocking is degraded.

**What happened BEFORE this PR:** One `WARN` per player per lobby authorize, in every `BlockVPNUsers` guild, for the whole outage. The IPQS circuit breaker is a process-global flag tripped by any single failure (1s timeout, any non-200, or a `Success:false` body — what quota exhaustion returns) and backs off 5s→5min, so an outage lasts minutes and every join during it emits a line. The base condition was also broader than the gate it stands in for — `gg.BlockVPNUsers && params.ipInfo == nil` (`git show d3e7e5549:server/evr_lobby_joinentrant.go:519`) — so it fired for VPN-**bypassed** players too, who were never going to be rejected.

**Estimated frequency:** Bounded by join rate × number of `BlockVPNUsers` guilds, for the duration of each outage. Unquantified in absolute terms (no counter existed — see §2); the reduction is from *every* authorize to *one line per guild per minute*.

**What happens AFTER this PR:** The condition regains the bypass term, and the line is throttled to one per guild per minute (`server/evr_lobby_joinentrant.go:621`, `:668-670`, `:690-697`). The counter is deliberately **not** throttled, so no volume information is lost.

**Deviation from the literal SEC-6(b) requirement — read this.** The finding named `params.isVPN` as a condition to restore. It is deliberately **not** restored. `params.isVPN` comes from `evrPipeline.ipInfoCache.IsVPN(clientIP)` (`server/session_ws.go:189`) — the *same* lookup that returns `(nil, nil)` when the breaker is open, so it is false during exactly the degradation this warning exists to report. Requiring it would mute the warning precisely when it matters. The noise problem is solved by throttling instead. `!gg.IsVPNBypass(userID)` **is** restored, because an exempt player would have passed the gate anyway, so their failed lookup is not a gap. This is documented in the commit message of `68d72ebae` and repeated here because it is a deviation.

**Log signature BEFORE:** `WARN  VPN blocking degraded: IPQS lookup unavailable for VPN check  {"client_ip", "discord_id", "guild_id"}` — unthrottled, `d3e7e5549:server/evr_lobby_joinentrant.go:597`.
**Log signature AFTER:** **same message string**, at the same WARN level, now with two added fields (`reason`, `session_flagged_vpn`) and at most once per guild per minute — `server/evr_lobby_joinentrant.go:690`, `:699-704`.

> **Operator note — this is a volume DECREASE, not a fault.** If you currently see a burst of this message during IPQS outages, you will now see roughly one line per affected guild per minute instead. The true volume moved to `lobby_vpn_check_degraded`. A *drop* in this message's rate after deploy is the intended effect.

**How to verify in production logs:**
```bash
grep 'VPN blocking degraded: IPQS lookup unavailable' /home/echovrce/deployment/logs/nakama.log | awk '{print $1}' | uniq -c
```

**Citation:** `server/evr_lobby_joinentrant.go:668-670, :690-705 @ 92feb178f`. Tests: `TestWarnVPNDegraded_LogIsThrottledPerGuildButCounterIsNot` (26 calls → 2 lines, counter 26), `TestWarnVPNDegraded_LogResumesAfterThrottleWindow`, `TestShouldWarnVPNDegraded`, `TestWarnVPNDegraded_CarriesTriageFields`. Removing the throttle yields `should have 2 item(s), but has 26`.

---

## 4. A deployment with no IP provider no longer reads as a permanent IPQS outage [NEW]

**This is the fix for the one blocking finding raised against the earlier revision of this branch, and it is the reason the counter in §2 is tagged.**

**What was tried:** An operator runs nakama without `REDIS_URI` set (or with `IPQS_API_KEY` unset and the IPAPI client also unavailable) and wires an alert to `lobby_vpn_check_degraded`.

**What they expected:** The alert fires when VPN blocking breaks.

**What happened BEFORE this PR (i.e. with §2's counter but no reason tag):** IP intelligence providers are only constructed inside `if redisClient != nil`, and `redisClient` is nil unless `REDIS_URI` is set (`server/evr_pipeline.go:181-204`). With an empty provider list, `IPInfoCache.Get` loops zero times and returns `(nil, nil)` for every public IP — **permanently, not transiently** (`server/evr_ip_info_cache.go:93`). `shouldWarnVPNDegraded` is therefore true for every player in every `BlockVPNUsers` guild on every lobby authorize, forever. The counter would have incremented forever and the throttled WARN fired once per guild per minute forever, in the words of an IPQS outage that is not happening. An alert on it is permanently firing and carries zero information — the same "buries its own signal" failure §3 exists to fix, relocated from the log into the metric.

**Estimated frequency:** All-or-nothing per deployment, and **not determinable from this worktree** — it depends on whether `REDIS_URI` and a provider key are set in the production environment, which I cannot inspect (ssh to the production host is forbidden by `CLAUDE.md`). When it applies, it applies to 100% of authorizes in `BlockVPNUsers` guilds. The new `reason` tag is what makes this answerable from the metrics.

**What happens AFTER this PR:** `IPInfoCache.IsConfigured()` (`server/evr_ip_info_cache.go:52-54`, nil-safe) distinguishes the two, and `vpnDegradedReasonFor` (`:646-651`) classifies each occurrence:

- `reason="lookup_failed"` — providers configured, lookup came back empty. Transient. **This is the case to page on.**
- `reason="not_configured"` — no provider wired up at all. A standing configuration gap; still a real security gap, still counted, but it cannot resolve on its own.

The standing gap gets its **own log message** and its **own hour-long throttle** (`server/evr_lobby_joinentrant.go:627`, `:690-693`), so it can neither be mistaken for an outage by a `grep` nor consume the one-minute budget a real outage needs.

**Log signature BEFORE:** `WARN  VPN blocking degraded: IPQS lookup unavailable for VPN check` — emitted for this case too, which was the bug.
**Log signature AFTER:** `WARN  VPN blocking inert: no IP intelligence provider is configured  {"client_ip", "discord_id", "guild_id", "reason":"not_configured", "session_flagged_vpn"}` — `server/evr_lobby_joinentrant.go:692`, emitted at `:699-704`, once per guild per hour.

> **Operator note — this message is NEW and may appear immediately on deploy.** If nakama is running without `REDIS_URI` (or with no usable provider key), this line will start appearing at up to one per `BlockVPNUsers` guild per hour, and `lobby_vpn_check_degraded{reason="not_configured"}` will increment on every authorize in those guilds. That is not a new fault — it is the pre-existing state of VPN blocking becoming visible for the first time. Conversely, the `VPN blocking degraded: IPQS lookup unavailable` message will **stop** appearing on such a deployment; it is replaced by this one.

**How to verify in production logs:**
```bash
# Is VPN blocking inert because nothing is configured?
grep 'VPN blocking inert: no IP intelligence provider is configured' /home/echovrce/deployment/logs/nakama.log | tail -5
```
If that returns lines, `REDIS_URI` / provider keys need attention; a real IPQS outage would say `VPN blocking degraded` instead.

**Citation:** `server/evr_ip_info_cache.go:52-54`, `server/evr_lobby_joinentrant.go:596-615, :627, :646-651, :684-693 @ 92feb178f`; provider construction at `server/evr_pipeline.go:181-204 @ 92feb178f`. Tests: `TestVPNDegradedReasonFor_DistinguishesAStandingGapFromAnOutage`, `TestIPInfoCache_IsConfigured`, `TestWarnVPNDegraded_CounterCarriesReasonSoAlertsCanSelectTheTransientCase`, `TestWarnVPNDegraded_UnconfiguredGapDoesNotImpersonateOrCrowdOutAnOutage`.

Perturbation evidence (run in a `/tmp` copy; repo untouched):

| Perturbation | Result |
|---|---|
| drop the `reason` tag from the counter | RED `expected: "not_configured", actual: ""` |
| share ONE throttle between both reasons | RED `should have 1 item(s), but has 60` |
| reuse the outage message for the standing gap | RED `Should be empty, but was [... VPN blocking degraded ...]` |
| `IsConfigured` always returns true | RED on both classification tests |

---

## 5. IP provider errors are counted instead of collected into a map nobody read [NEW]

**What was tried:** An operator asks how often IP intelligence lookups are failing.

**What they expected:** A metric.

**What happened BEFORE this PR:** `IPInfoCache.Get` collected provider errors into an `errored` map that was populated and never read, so the method could never return a non-nil error — which in turn made three `if err != nil` branches at its call sites permanently dead.

**Estimated frequency: unreachable in production today — stated plainly.** Both in-repo providers return a nil error on *every* return path: `IPQSClient.Get` (7 returns, all `nil` error) and `ipapiClient.Get` (7 returns, all `nil` error). So `ip_info_provider_error` will **not** fire with the current provider set. It is a guard that makes a future provider's failures visible rather than silent, and it is what makes the removal of the dead branches safe to reason about.

**What happens AFTER this PR:** The error branch increments `ip_info_provider_error{provider}` and logs at DEBUG (`server/evr_ip_info_cache.go:79-86`). Both dependencies are optional — `NewIPInfoCache` validates neither and in-repo callers pass nil for both — so observability cannot itself panic a login path (`:80`, `:83`).

**Log signature BEFORE:** none on this path.
**Log signature AFTER:** `DEBUG  IP info provider failed, failing open.  {"provider", "error"}` — `server/evr_ip_info_cache.go:84-85`. DEBUG, so absent at normal log levels.

**How to verify in production logs:** not visible at default level by design; use the `ip_info_provider_error{provider}` counter.

**Citation:** `server/evr_ip_info_cache.go:79-86 @ 92feb178f`. Tests: `TestIPInfoCache_ProviderErrorsAreCounted`, `TestIPInfoCache_SuccessfulProviderIsNotCountedAsAnError`, `TestIPInfoCache_ProviderErrorWithNilLoggerAndMetricsDoesNotPanic`. Removing the nil guards makes that last test panic with `SIGSEGV` at `evr_ip_info_cache.go:81`.

---

## 6. `setnextmatch`: unreachable moderator role grant removed [NEUTRAL]

**What was tried:** N/A — this arm cannot be reached.

**What they expected:** N/A.

**What happened BEFORE this PR:** `SetNextMatch` mapped the directive string `"moderator"` to `evr.TeamModerator` when building the immediate-join presence.

**Estimated frequency: unreachable in production — see citation.** The RPC's own validator rejects `"moderator"` for every mode that can reach the presence-building path, so no stored directive can carry it there. Confirmed two ways: by trace, and by perturbation — allowing `"moderator"` for private modes turns `An error is expected but got nil` on `echo_arena_private` and `echo_combat_private`.

**What happens AFTER this PR:** The arm is deleted; `resolveImmediateJoinRole` (`server/evr_runtime_rpc_setnextmatch.go:179`) has no moderator case. A directive with no match ID skips validation entirely, but such a directive is contained by the §1 downgrade in `lobbyJoin`, not by the string being unstorable — noted as a follow-up below.

**Log signature BEFORE:** none. **Log signature AFTER:** none.
**How to verify in production logs:** n/a — no log statement in this path, before or after.

**Citation:** `server/evr_runtime_rpc_setnextmatch.go:153` (`validateSetNextMatchRole`), `:179` (`resolveImmediateJoinRole`), `:223` @ `92feb178f`. Tests in `server/evr_runtime_rpc_setnextmatch_role_test.go`. Restoring the arm yields `expected: -1, actual: 4`.

---

## 7. Two unreachable `err != nil` branches and their log lines deleted [NEUTRAL]

**What was tried:** N/A.

**What happened BEFORE this PR:** Two log statements sat on branches whose condition can never be true (see §5 — the error channel is always nil).

**Estimated frequency: never emitted.**

**What happens AFTER this PR:** The branches are gone, replaced by explicit `_` discards with a comment stating the fail-open contract.

**Log signature BEFORE:**
- `WARN   Failed to get IPQS details, failing open.` — `d3e7e5549:server/evr_ip_info_provider_ipqs.go` (in `IPQSClient.IsVPN`)
- `DEBUG  Failed to get IPQS details` — `d3e7e5549:server/evr_pipeline_login.go:493`

**Log signature AFTER:** none — both removed.

> **Operator note:** if you have any alert, dashboard, or saved search keyed on the string `Failed to get IPQS details`, it will now match nothing. It also matched nothing before — the branches were dead — so this is a cleanup, not a loss of signal. IPQS failures remain visible through the `ipqs_*` metrics.

**How to verify in production logs:**
```bash
grep -c 'Failed to get IPQS details' /home/echovrce/deployment/logs/nakama.log   # expect 0, before and after
```

**Citation:** `server/evr_ip_info_provider_ipqs.go` and `server/evr_pipeline_login.go:491-497 @ 92feb178f`; every return in `IPQSClient.Get` and `ipapiClient.Get` carries a nil error (verified by enumerating all 7 returns in each).

---

## 8. The VPN-bypass lookup is no longer evaluated on every authorize [NEUTRAL]

**What was tried:** N/A — internal.

**What happened BEFORE this PR (in the earlier revision of this branch):** `shouldWarnVPNDegraded(gg.BlockVPNUsers, gg.IsVPNBypass(userID), params.ipInfo)` — Go evaluates all arguments before the call, so `IsVPNBypass` ran on **every** lobby authorize, including when `BlockVPNUsers` is false, where the original `&&` chain short-circuited. `IsVPNBypass` → `HasRole` → `g.State.RLock()`.

**Estimated frequency:** one extra uncontended `RLock` per lobby authorize. Negligible in cost; the point is that it was not there before SEC-6.

**What happens AFTER this PR:** The bypass check is passed as a `func() bool` and stays behind the two cheap conditions (`server/evr_lobby_joinentrant.go:668-670`, call site `:519`).

**Log signature BEFORE / AFTER:** none — no log statement involved.
**How to verify in production logs:** n/a.

**Citation:** `server/evr_lobby_joinentrant.go:519, :668-670 @ 92feb178f`. Test: `TestShouldWarnVPNDegraded_DoesNotEvaluateBypassUnlessItMatters`. Evaluating the bypass eagerly turns it RED on both cases.

---

## Production log impact — consolidated

| Message | Change |
|---|---|
| `VPN blocking degraded: IPQS lookup unavailable for VPN check` | **string unchanged, level unchanged (WARN); volume DOWN sharply** (throttled to 1/guild/min, and no longer fires for bypassed players or for unconfigured deployments). Two new fields: `reason`, `session_flagged_vpn`. |
| `VPN blocking inert: no IP intelligence provider is configured` | **NEW** — WARN, ≤1/guild/hour. Appears only where no provider is configured. |
| `Downgrading unverified moderator role claim` | **NEW** — WARN, one per blocked cross-guild moderator claim. |
| `IP info provider failed, failing open.` | **NEW** — DEBUG (not visible at default level). Unreachable with current providers (§5). |
| `Failed to get IPQS details, failing open.` | **REMOVED** — was on a dead branch; never emitted. |
| `Failed to get IPQS details` | **REMOVED** — was on a dead branch; never emitted. |

New/changed metrics: `lobby_moderator_role_downgraded{group_id}` (new), `lobby_vpn_check_degraded{group_id, reason}` (new counter, `reason` tag added in this revision), `ip_info_provider_error{provider}` (new).

**How this was checked:** `git diff d3e7e5549 -- server/ ':(exclude)server/*_test.go'` filtered for `logger.(Debug|Info|Warn|Error)`, `MetricsCounterAdd`, and `CustomCounter` — the table above is the complete result. No other production log statement in any touched file had its message string, level, or emission frequency changed.

---

## What does NOT change

- **The fail-open policy.** A failed or absent IP lookup still admits the player; no deny-on-degraded was built. This was flagged and deliberately not implemented. `server/evr_ip_info_cache.go:56-60` states the contract; `IsVPN` still returns false on an empty lookup (`:99-105`).
- **The cross-guild matchmaking invariant.** No cross-guild path is introduced. Every `uuid.Nil` in the diff is a fail-**closed** guard (`server/evr_lobby_parameters.go:131`), a comment, a test fixture, or the pre-existing **party ID** argument at `server/evr_runtime_rpc_setnextmatch.go:223` — `EntrantPresenceFromSession`'s second parameter is `partyID`, not a group ID (`server/evr_match_presence.go:105`). Verified by enumerating every added `uuid.Nil` line in the diff.
- **The one legitimate moderator flow.** `/join-player` is the only caller that mints a `Moderator` directive. Its gate requires `isGlobalOperator || gg.IsEnforcer(userID)` in the command's own guild *and* rejects `label.GetGroupID() != groupID`, so its caller is always an enforcer of the lobby's own guild — exactly what the new check validates. `TestLobbyJoin_ModeratorClaimSurvivesForEnforcerOfTheLobbysGuild` and `..._ForGlobalOperator` pin this.
- **Non-moderator roles.** The downgrade is narrow — only a `TeamModerator` claim is touched. `TestLobbyJoin_NonModeratorRolesAreNotTouched` covers blue/orange/spectator/social/unassigned.
- **Matchmaker `is_moderator` properties.** The re-scoped `IsModerator` cannot reach `MatchmakingParameters` (`server/evr_lobby_parameters.go:765`, which sets the `is_moderator` string property read back at `server/evr_matchmaker_reservation.go:275`). Its only two callers are `server/evr_lobby_matchmake.go:345` and `server/evr_lobby_status.go:69`, both on the `lobbyFind` path; both `lobbyJoin` call sites return immediately (`server/evr_lobby_session.go:27`→`:36`, and `:100`), so a `lobbyParams` that went through `lobbyJoin` never reaches the matchmaker.
- **`lobby_authorization` tags.** Still `{group_id}` plus an `error` key on rejection — unchanged (`server/evr_lobby_joinentrant.go:291-293`).

---

## Findings from review I did NOT accept, with evidence

**"`is_moderator` metric skew" — the premise is wrong.** The review reported that `lobby_join_session` and `lobby_authorization` disagree on an `is_moderator` tag. There is no `is_moderator` metric tag anywhere in the codebase. `grep -rn '"is_moderator"' server/` returns exactly three hits, none of them a metric: a struct JSON tag (`server/evr_lobby_parameters.go:54`), a **matchmaker string property** (`:776`), and the read of that property (`server/evr_matchmaker_reservation.go:275`). `MetricsTags()` emits `mode`, `group_id`, `early_quit_level`, `role` (`server/evr_lobby_parameters.go:110-117`), and `lobby_authorization` emits only `group_id`.

The underlying concern is nonetheless **real, on a different tag** — see the `role` skew in follow-ups below. I am recording the correction rather than silently fixing a different thing than was reported.

---

## Follow-ups (deliberately not fixed here — scope discipline)

1. **`role` metric skew (the corrected form of the finding above).** `lobby_join_session` (`server/evr_lobby_session.go:97`) and `lobby_join_next_match` (`:25`) emit `MetricsTags()` — which includes `role` — *before* `lobbyJoin` downgrades it. So a blocked moderator claim is counted as `role="4"` on the attempt counter while the entrant actually joins as `role="-1"`. Both numbers are meaningful (attempts vs. outcomes) and the exact delta is already available as `lobby_moderator_role_downgraded`. Fixing it means editing `evr_lobby_session.go`, a file outside this PR's diff. Note the social-lobby `TeamUnassigned → TeamSocial` rewrite skews the same tag and predates this PR.
2. **Two more dead error branches on the now-provably-nil error channel:** `server/evr_pipeline_gameserver.go:540` (`if info, err := p.ipInfoCache.Get(...); err != nil`) and `server/evr_discord_appbot_search.go:461` (`ipErr == nil`, now trivially true). Out of scope; the "wire it up or delete it" decision is documented in 3 of 5 places.
3. **The SEC-5 tests pin `lobbyParams.Role`, not the presence.** They assert the state `lobbyJoin` left behind after `lobbyAuthorize` errors out, so they would not catch someone moving the downgrade *below* `EntrantPresenceFromSession` (`server/evr_lobby_join.go:66`) or setting `presence.RoleAlignment` (`:83`) from another source. Observing the presence requires `lobbyAuthorize` to succeed, which requires a storage-backed `EnforcementJournalsLoad` (`server/evr_enforcement_journal.go:361` calls `nk.StorageRead` unconditionally) plus a profile and event bus — not available in the DB-free suite. The contract worth pinning is "a guild-A enforcer's presence in a guild-B match has `RoleAlignment != TeamModerator`".
4. **A `SetNextMatch` directive with no match ID skips role validation entirely.** It is contained by the §1 downgrade in `lobbyJoin` rather than by the role string being unstorable. Noted in `4ce4ef527`.
5. **Throttle maps never evict.** `perKeyLogThrottle.last` is keyed by group ID, so it is bounded by guild count — fine in practice, but unbounded in principle. There are now two such maps.
6. **Session-snapshot vs live-registry asymmetry (pre-existing, now applied at a second point).** `isModeratorOfGroup` reads `sessionParams.guildGroups`, a login-time snapshot, while `lobbyAuthorize` reads the live `p.guildGroupRegistry` (`server/evr_lobby_joinentrant.go:321`). A user promoted to Enforcer mid-session is treated as a non-moderator until relogin. This is the behavior `NewLobbyParametersFromRequest` already had; the fix applies it at one more point. **Fail-closed**, so acceptable, but worth knowing.
7. **Party followers inherit the leader's role and are never individually re-validated.** `PrepareEntrantPresences` builds every entrant presence with `lobbyParams.Role` — the *leader's* — at `server/evr_lobby_find.go:1421`, and the leader's call passes every party member's session ID (`:262`). So a party member's own moderator status is never checked; they take whatever the leader resolved. **This is not the SEC-5 bug and this PR does not change it:** that path is `lobbyFind`, where `lobbyParams.GroupID` is never repointed (`server/evr_lobby_join.go:30` is the only `.GroupID =` assignment in the lobby files) and backfill is group-scoped, so there is no cross-guild escalation. It is a separate, pre-existing privilege-inheritance question that wants its own ticket. Verified by reading the code, not by running the exploit.
8. **Party priority-join does not compare the resolved match's guild against the authorized one.** Same file/path as above; pre-existing, unchanged here, and wants its own ticket.
9. **Structural changes flagged for conflict awareness, not reverted:** `server/evr_runtime_rpc_setnextmatch.go` gained two extracted functions (`validateSetNextMatchRole:153`, `resolveImmediateJoinRole:179`), relocating ~40 lines — this is what makes the RED evidence for §6 possible. `server/evr_log_throttle.go` is a new general-purpose file.

---

## Verification

All commands run in `/home/andrew/src/nakama/.claude/worktrees/tier1-security-gates` at `92feb178f`, with `GOWORK=off`.

```
$ GOWORK=off go build ./server/...      EXIT=0
$ GOWORK=off go vet   ./server/...      EXIT=0
$ gofmt -l <13 touched files>           (no output — clean)

$ GOWORK=off go test ./server/... -count=1
ok      github.com/heroiclabs/nakama/v3/server        122.464s
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena
FAIL    github.com/heroiclabs/nakama/v3/server/evr    0.015s

$ GOWORK=off go test ./server/ -count=1 -shuffle=on
ok      github.com/heroiclabs/nakama/v3/server        126.506s

$ GOWORK=off go test -race ./server/ -run '<touched tests>' -count=2
ok      github.com/heroiclabs/nakama/v3/server        1.488s     (no DATA RACE)
```

**The one failure is pre-existing and unrelated.** It reproduces identically at base `d3e7e5549` (run from a clean `git archive`):

```
$ cd /tmp/sec-ship/base && GOWORK=off go test ./server/... -count=1
ok      github.com/heroiclabs/nakama/v3/server        124.783s
--- FAIL: TestStatisticsGroup_MarshalText
FAIL    github.com/heroiclabs/nakama/v3/server/evr    0.015s
```

Root cause, for whoever owns it: the test compares production output (UTC) against an expectation built from `time.Now()` in **local** time — `expected: "daily_" + time.Now().Format("2006_01_02")` at `server/evr/core_account_statistics_test.go:24`. Running at 19:00 CDT gives `MarshalText() got = daily_2026_08_06, expected daily_2026_08_05`. It fails every day during the local/UTC date-straddle window, on any branch. This PR touches no file under `server/evr/` (`git diff --name-only d3e7e5549..HEAD -- server/evr/` is empty).

**Commits** — all six GPG-signed (`%G?` = `G`), no prompt:

```
92feb178f G  fix(security): stop the degraded-VPN alert firing forever without a provider
4ce4ef527 G  fix(security): harden the SEC-6 observability paths against their own edges
2809c7ede G  test(security): pin guild scoping in the isModeratorOfGroup unit cases
5ffc2e3aa G  refactor(setnextmatch): remove the unreachable moderator role grant
68d72ebae G  fix(security): make the degraded VPN gate alertable and stop it burying itself
5b5b2890e G  fix(security): scope the moderator entrant claim to the lobby's own guild
```

---

## Concurrent Tier-1 branches touching the same files

Checked by intersecting each branch's changed-file set with this PR's:

| Branch | Overlap with this PR |
|---|---|
| `fix/assorted-one-offs` | **`server/evr_pipeline_login.go`** — its hunk starts at line 627; mine is at 491-497. ~130 lines apart, no textual conflict expected. |
| `fix/earlyquit-penalty-state` | none |
| `fix/storage-occ-retry` | none |
| `fix/discord-prune-safety` | none |
| `fix/match-lifecycle` | none |
| `fix/concurrency-locking` | not pushed at time of writing — unchecked |
