### PR TITLE
fix(evr): match lifecycle — independent idle timers, no nil-return match kills, bounded MatchStart retry, idempotent MatchShutdown

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1692,9 +1692,13 @@ func (m *EvrMatch) MatchShutdown(ctx context.Context, logger runtime.Logger, db 
 	}
 	state.Open = false
 	state.terminateTick = tick + int64(graceSeconds)*state.tickRate
+	// The label refresh is bookkeeping. Bailing out with nil here would make the
+	// handler Stop() without ever calling MatchTerminate, so the drain would
+	// never complete, the stored label would leak and the game server would
+	// never be told to kick its players — the exact teardown this function
+	// exists to perform.
 	if err := m.updateLabel(logger, dispatcher, state); err != nil {
-		logger.WithField("error", err).Error("failed to update label")
-		return nil
+		logger.WithField("error", err).Error("failed to update label on shutdown")
 	}
 
 	if err := StoreMatchLabel(dbCtx, nk, state); err != nil {

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1488,16 +1488,23 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 		// are therefore bounded by MatchStartMaxAttempts and, after the first,
 		// throttled to one per second so a dead game server is not re-dispatched
 		// at tick rate.
-		// MatchInit clamps tickRate to 10 when it is unset, so the guard below
-		// is belt-and-braces: this is the first modulo in MatchLoop and the
-		// branch returns before the pre-existing ones, so a zero tickRate would
-		// now panic here rather than there.
+		//
+		// The throttle gates on the gap since the last attempt, not on
+		// `tick % tickRate == 0`: a modulo aligns retries to absolute tick
+		// boundaries, so a first attempt at tick 9 (tickRate 10) would be
+		// followed by a second at tick 10, 0.1s later. lastStartAttemptTick is
+		// this throttle's own field for the same reason each idle timer got its
+		// own counter — a shared one lets an unrelated reset re-open the gate.
+		// MatchInit clamps tickRate to 10 when it is unset; the guard below is
+		// belt-and-braces for a hand-built label with a zero tickRate, which
+		// would otherwise retry every tick.
 		throttleTicks := state.tickRate
 		if throttleTicks < 1 {
 			throttleTicks = 1
 		}
-		if state.startAttempts == 0 || tick%throttleTicks == 0 {
+		if state.startAttempts == 0 || tick-state.lastStartAttemptTick >= throttleTicks {
 			state.startAttempts++
+			state.lastStartAttemptTick = tick
 			started, err := m.MatchStart(ctx, logger, nk, dispatcher, state)
 			if err != nil {
 				logger.WithFields(map[string]any{

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -422,6 +422,9 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 				delete(state.presenceMap, e.GetSessionId())
 				delete(state.presenceByEvrID, e.EvrID)
 				delete(state.joinTimestamps, e.GetSessionId())
+				// Mirror the MatchLeave cleanup: a stale join-clock entry would
+				// otherwise outlive the evicted session.
+				delete(state.joinTimeMilliseconds, e.GetSessionId())
 				state.rebuildCache()
 				break
 			}
@@ -644,11 +647,17 @@ func (m *EvrMatch) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql
 		isBackfill := time.Now().After(state.StartTime.Add(PublicMatchWaitTime))
 
 		if mp, ok := state.presenceMap[p.GetSessionId()]; !ok {
+			// MatchJoinAttempt and MatchJoin are separately queued calls on the
+			// match handler goroutine, so another join attempt can evict this
+			// session (same-user duplicate EvrID) between them. Skip the orphan
+			// presence: returning nil would Stop() the handler without ever
+			// calling MatchTerminate, killing the match for everyone.
 			logger.WithFields(map[string]any{
 				"username": p.GetUsername(),
 				"uid":      p.GetUserId(),
-			}).Error("Presence not found. this should never happen.")
-			return nil
+				"sid":      p.GetSessionId(),
+			}).Error("Presence not found in the presence map; skipping join for this session.")
+			continue
 		} else {
 			logger.WithFields(map[string]any{
 				"username": p.GetUsername(),
@@ -764,8 +773,12 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 
 	if state.Started() && len(state.presenceMap) == 0 {
 		// If the match is empty, and the server has left, then shut down.
+		// Go through MatchShutdown so the drain -> MatchTerminate sequence runs:
+		// a bare `return nil` makes the handler Stop() without MatchTerminate,
+		// skipping the summary, the stored-label cleanup and the game-server
+		// notification entirely.
 		logger.Debug("Match is empty. Shutting down.")
-		return nil
+		return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
 	}
 
 	// if the server is in the presences, then shut down.
@@ -1191,9 +1204,12 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 		logger.Debug("Match is empty. Closing it.")
 	}
 
-	// Update the label that includes the new player list.
+	// Update the label that includes the new player list. A failure here is a
+	// transient bookkeeping problem (e.g. a database blip): it must NOT end the
+	// match for everyone still in it. Returning nil would make the handler
+	// Stop() without ever calling MatchTerminate.
 	if err := m.updateLabel(logger, dispatcher, state); err != nil {
-		return nil
+		logger.WithField("error", err).Error("failed to update label after leave")
 	}
 
 	return state
@@ -1207,7 +1223,6 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 		return nil
 	}
 
-	var err error
 	var updateLabel bool
 
 	// Handle the messages, one by one
@@ -1438,21 +1453,28 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	}
 
 	// If the match has a server but never started and has been idle too long, shut it down.
+	// Route through MatchShutdown so the drain -> MatchTerminate sequence runs.
 	if !state.levelLoaded && state.server != nil && !state.Started() && len(state.presenceMap) == 0 && !state.CreatedAt.IsZero() && time.Since(state.CreatedAt) > 15*time.Minute {
 		logger.Warn("Match did not start on time. Shutting down.")
-		return nil
+		return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
 	}
 
 	// If the match is prepared and the start time has been reached, start it.
 	// Ensure the game server presence exists to avoid nil dispatch crashes.
 	if !state.levelLoaded && state.server != nil && (len(state.presenceMap) != 0 || state.Started()) {
-		if state, err = m.MatchStart(ctx, logger, nk, dispatcher, state); err != nil {
+		// A failed start is retryable on the next tick; killing the match here
+		// would Stop() the handler without MatchTerminate. MatchStart can return
+		// a nil label on failure, so keep the existing state in that case.
+		started, err := m.MatchStart(ctx, logger, nk, dispatcher, state)
+		if err != nil {
 			logger.WithField("error", err).Error("failed to start session")
-			return nil
+			return state
+		}
+		if started != nil {
+			state = started
 		}
 		if err := m.updateLabel(logger, dispatcher, state); err != nil {
 			logger.WithField("error", err).Error("failed to update label")
-			return nil
 		}
 		return state
 	}
@@ -1599,9 +1621,11 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	}
 
 	if updateLabel {
+		// Bookkeeping only: a transient failure must not tear the match down
+		// without a shutdown sequence. The next tick that sets updateLabel will
+		// retry.
 		if err := m.updateLabel(logger, dispatcher, state); err != nil {
 			logger.WithField("error", err).Error("failed to update label")
-			return nil
 		}
 	}
 

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1488,7 +1488,15 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 		// are therefore bounded by MatchStartMaxAttempts and, after the first,
 		// throttled to one per second so a dead game server is not re-dispatched
 		// at tick rate.
-		if state.startAttempts == 0 || tick%state.tickRate == 0 {
+		// MatchInit clamps tickRate to 10 when it is unset, so the guard below
+		// is belt-and-braces: this is the first modulo in MatchLoop and the
+		// branch returns before the pre-existing ones, so a zero tickRate would
+		// now panic here rather than there.
+		throttleTicks := state.tickRate
+		if throttleTicks < 1 {
+			throttleTicks = 1
+		}
+		if state.startAttempts == 0 || tick%throttleTicks == 0 {
 			state.startAttempts++
 			started, err := m.MatchStart(ctx, logger, nk, dispatcher, state)
 			if err != nil {
@@ -1714,6 +1722,21 @@ func (m *EvrMatch) MatchShutdown(ctx context.Context, logger runtime.Logger, db 
 		logger.Error("state not a valid lobby state object")
 		return nil
 	}
+	// MatchShutdown is idempotent: the drain is armed exactly once. Several
+	// callers can reach it for the same match — a straggler MatchLeave for a
+	// session that is no longer in the presence map re-enters the empty-match
+	// branch above, and SignalShutdown can be issued again by an operator or by
+	// the preemption path while the drain is already running. Every re-entry
+	// used to re-count match_shutdown_count, re-record lobby_session_duration,
+	// re-accumulate the FULL game-server time to the leaderboard, and push
+	// terminateTick further out. Re-arming can only ever delay teardown: the
+	// primary trigger in MatchLoop is "presenceMap is empty", not the deadline.
+	if state.terminateTick != 0 {
+		logger.WithField("terminate_tick", state.terminateTick).
+			Debug("MatchShutdown called on a match that is already draining; ignoring.")
+		return state
+	}
+
 	logger.WithField("state", state).Info("MatchShutdown called.")
 	nk.MetricsCounterAdd("match_shutdown_count", state.MetricsTags(), 1)
 
@@ -2170,9 +2193,9 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 	// Started() == true with levelLoaded == false, which permanently disables
 	// the "did not start on time" reclaim in MatchLoop and traps the loop in
 	// the start branch. Deferring the commit also preserves a scheduled
-	// StartTime set by SignalPrepareSession (:1893-1897) across a failed start,
-	// and stops a retry from rebuilding the SessionScoreboard (which would
-	// reset the round clock on every attempt).
+	// StartTime set by the SignalPrepareSession case in MatchSignal across a
+	// failed start, and stops a retry from rebuilding the SessionScoreboard
+	// (which would reset the round clock on every attempt).
 	var newGameState *GameState
 	switch state.Mode {
 	case evr.ModeArenaPublic, evr.ModeArenaPublicAI:

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1347,26 +1347,34 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 		}
 		return state
 	} else if state.server == nil {
-		state.emptyTicks++
-		if state.emptyTicks > 10*state.tickRate {
-			logger.Warn("Match has been empty for too long. Shutting down.")
+		// Timer (a): no game server presence. Owns its own counter — sharing one
+		// with the other two timers let a later reset wipe this count every tick
+		// (so it never fired) or a second increment halve its deadline.
+		state.noServerTicks++
+		if state.noServerTicks > 10*state.tickRate {
+			logger.Warn("Match has been without a game server for too long. Shutting down.")
 			return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 20)
 		}
-	} else if state.emptyTicks > 0 && !(state.Started() && len(state.presenceMap) == 0) {
-		state.emptyTicks = 0
+	} else {
+		state.noServerTicks = 0
 	}
 
 	if state.LobbyType == UnassignedLobby {
-		// Parking matches with a server that are never allocated should time out.
+		// Timer (b): parking matches with a server that are never allocated
+		// should time out.
 		if state.server != nil {
-			state.emptyTicks++
-			if state.emptyTicks > 120*state.tickRate { // 2 minutes
+			state.unallocatedTicks++
+			if state.unallocatedTicks > 120*state.tickRate { // 2 minutes
 				logger.Warn("Unassigned parking match with server has not been allocated. Shutting down.")
 				return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
 			}
+		} else {
+			state.unallocatedTicks = 0
 		}
 		return state
 	}
+	// The lobby has been assigned; the unallocated deadline no longer applies.
+	state.unallocatedTicks = 0
 
 	// Enforce 5-minute lifetime for post-match social lobbies.
 	if state.SpawnedBy == "post-match-transition" && !state.CreatedAt.IsZero() && time.Since(state.CreatedAt) > 5*time.Minute {

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -46,6 +46,12 @@ const (
 	PreMatchWaitTime           = 45 * time.Second
 	PublicMatchWaitTime        = PreMatchWaitTime + CatapultDuration + RoundCatapultDelayDuration
 	PreMatchToPlayingTimeout   = 60 * time.Second
+
+	// MatchStartMaxAttempts bounds how many times MatchLoop retries a failing
+	// MatchStart before giving up and shutting the match down. Attempts after
+	// the first are throttled to one per second, so this doubles as the retry
+	// window in seconds.
+	MatchStartMaxAttempts int64 = 15
 )
 
 // evrSessionRegistryProvider and evrPartyRegistryProvider are the two narrow
@@ -637,13 +643,6 @@ func (m *EvrMatch) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql
 			delete(state.TeamAlignments, p.GetUserId())
 		}
 
-		// If the session scoreboard is being used, set the join clock time
-		if state.GameState != nil && state.GameState.SessionScoreboard != nil {
-			// Do not overwrite an existing value
-			if _, ok := state.joinTimeMilliseconds[p.GetSessionId()]; !ok {
-				state.joinTimeMilliseconds[p.GetSessionId()] = state.GameState.SessionScoreboard.Elapsed().Milliseconds()
-			}
-		}
 		isBackfill := time.Now().After(state.StartTime.Add(PublicMatchWaitTime))
 
 		if mp, ok := state.presenceMap[p.GetSessionId()]; !ok {
@@ -659,6 +658,19 @@ func (m *EvrMatch) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql
 			}).Error("Presence not found in the presence map; skipping join for this session.")
 			continue
 		} else {
+			// Record the join clock time only for a session that is actually in
+			// the presence map. Writing it above this check would re-add the very
+			// joinTimeMilliseconds entry MatchJoinAttempt just evicted, and the
+			// `continue` above would leave it there for the life of the match:
+			// MatchLeave only deletes the key for sessions it finds in the
+			// presence map, so nothing would ever clean it up.
+			if state.GameState != nil && state.GameState.SessionScoreboard != nil {
+				// Do not overwrite an existing value
+				if _, ok := state.joinTimeMilliseconds[p.GetSessionId()]; !ok {
+					state.joinTimeMilliseconds[p.GetSessionId()] = state.GameState.SessionScoreboard.Elapsed().Milliseconds()
+				}
+			}
+
 			logger.WithFields(map[string]any{
 				"username": p.GetUsername(),
 				"uid":      p.GetUserId(),
@@ -771,23 +783,30 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 		}).Debug(class + " leaving the match.")
 	}
 
-	if state.Started() && len(state.presenceMap) == 0 {
-		// If the match is empty, and the server has left, then shut down.
-		// Go through MatchShutdown so the drain -> MatchTerminate sequence runs:
-		// a bare `return nil` makes the handler Stop() without MatchTerminate,
-		// skipping the summary, the stored-label cleanup and the game-server
-		// notification entirely.
-		logger.Debug("Match is empty. Shutting down.")
-		return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
-	}
-
-	// if the server is in the presences, then shut down.
+	// If the game server is in the presences, then shut down. This must be
+	// checked BEFORE the empty-match branch below: the normal end-of-life
+	// sequence is "all players leave, then the game server disconnects", which
+	// arrives here with an empty presence map. Letting the empty branch win
+	// would run MatchShutdown with state.server still pointing at the departed
+	// game server — dispatching LobbySessionEvent CODE_ENDED to a presence that
+	// is already gone, storing a label that still advertises the game server,
+	// and handing MatchTerminate a snapshot with a live serverSessionID.
 	for _, p := range presences {
 		if state.GameServer != nil && p.GetSessionId() == state.GameServer.SessionID.String() {
 			logger.Debug("Server left the match. Shutting down.")
 			state.server = nil
 			return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 2)
 		}
+	}
+
+	if state.Started() && len(state.presenceMap) == 0 {
+		// If the match is empty, then shut down.
+		// Go through MatchShutdown so the drain -> MatchTerminate sequence runs:
+		// a bare `return nil` makes the handler Stop() without MatchTerminate,
+		// skipping the summary, the stored-label cleanup and the game-server
+		// notification entirely.
+		logger.Debug("Match is empty. Shutting down.")
+		return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
 	}
 
 	rejects := make([]uuid.UUID, 0)
@@ -1462,19 +1481,35 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 	// If the match is prepared and the start time has been reached, start it.
 	// Ensure the game server presence exists to avoid nil dispatch crashes.
 	if !state.levelLoaded && state.server != nil && (len(state.presenceMap) != 0 || state.Started()) {
-		// A failed start is retryable on the next tick; killing the match here
-		// would Stop() the handler without MatchTerminate. MatchStart can return
-		// a nil label on failure, so keep the existing state in that case.
-		started, err := m.MatchStart(ctx, logger, nk, dispatcher, state)
-		if err != nil {
-			logger.WithField("error", err).Error("failed to start session")
-			return state
-		}
-		if started != nil {
-			state = started
-		}
-		if err := m.updateLabel(logger, dispatcher, state); err != nil {
-			logger.WithField("error", err).Error("failed to update label")
+		// A failed start is retryable: killing the match here would Stop() the
+		// handler without MatchTerminate. But retrying every tick forever is
+		// just as bad — this branch returns before every idle timer below, so
+		// nothing could ever reclaim a match whose start keeps failing. Retries
+		// are therefore bounded by MatchStartMaxAttempts and, after the first,
+		// throttled to one per second so a dead game server is not re-dispatched
+		// at tick rate.
+		if state.startAttempts == 0 || tick%state.tickRate == 0 {
+			state.startAttempts++
+			started, err := m.MatchStart(ctx, logger, nk, dispatcher, state)
+			if err != nil {
+				logger.WithFields(map[string]any{
+					"error":    err,
+					"attempts": state.startAttempts,
+				}).Error("failed to start session")
+				if state.startAttempts >= MatchStartMaxAttempts {
+					logger.WithField("attempts", state.startAttempts).Warn("Match failed to start after repeated attempts. Shutting down.")
+					return m.MatchShutdown(ctx, logger, db, nk, dispatcher, tick, state, 5)
+				}
+				return state
+			}
+			// MatchStart can return a nil label on failure; keep the existing
+			// state in that case.
+			if started != nil {
+				state = started
+			}
+			if err := m.updateLabel(logger, dispatcher, state); err != nil {
+				logger.WithField("error", err).Error("failed to update label")
+			}
 		}
 		return state
 	}
@@ -2129,18 +2164,28 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 		groupID = *state.GroupID
 	}
 
+	// Compute the start-time and game-state updates, but do NOT commit them to
+	// the label until the start message actually dispatches. A failed start
+	// that has already moved StartTime forward leaves the label reporting
+	// Started() == true with levelLoaded == false, which permanently disables
+	// the "did not start on time" reclaim in MatchLoop and traps the loop in
+	// the start branch. Deferring the commit also preserves a scheduled
+	// StartTime set by SignalPrepareSession (:1893-1897) across a failed start,
+	// and stops a retry from rebuilding the SessionScoreboard (which would
+	// reset the round clock on every attempt).
+	var newGameState *GameState
 	switch state.Mode {
 	case evr.ModeArenaPublic, evr.ModeArenaPublicAI:
-		state.GameState = &GameState{
+		newGameState = &GameState{
 			SessionScoreboard: NewSessionScoreboard(RoundDuration, time.Now().Add(PublicMatchWaitTime)),
 		}
 	case evr.ModeArenaPrivate:
-		state.GameState = &GameState{
+		newGameState = &GameState{
 			SessionScoreboard: NewSessionScoreboard(0, time.Time{}),
 		}
 	}
 
-	state.StartTime = time.Now().UTC()
+	startTime := time.Now().UTC()
 
 	envelope := &rtapi.Envelope{
 		Message: &rtapi.Envelope_LobbySessionCreate{
@@ -2182,6 +2227,12 @@ func (m *EvrMatch) MatchStart(ctx context.Context, logger runtime.Logger, nk run
 	if err := m.dispatchMessages(ctx, logger, dispatcher, messages, []runtime.Presence{state.server}, nil); err != nil {
 		return state, fmt.Errorf("failed to dispatch message: %w", err)
 	}
+
+	// The start is committed: only now may the label advertise it as started.
+	if newGameState != nil {
+		state.GameState = newGameState
+	}
+	state.StartTime = startTime
 	state.levelLoaded = true
 
 	// For AI CO-OP mode, send bot spawn messages to fill both teams to TeamSize.

--- a/server/evr_match_empty_ticks_test.go
+++ b/server/evr_match_empty_ticks_test.go
@@ -1,0 +1,245 @@
+package server
+
+// Regression tests for the MatchLoop idle/empty timers.
+//
+// MatchLoop runs THREE independent shutdown deadlines:
+//
+//	(a) "no game server"        -> 10s   (state.server == nil)
+//	(b) "unallocated parking"   -> 120s  (LobbyType == UnassignedLobby && server != nil)
+//	(c) "started but empty"     -> 60s   (Started() && len(presenceMap) == 0)
+//
+// They used to share a single counter (state.emptyTicks) that was incremented at
+// three sites and reset at two, with a reset running BEFORE one of the
+// increments. The result was that (b) could never fire — the counter oscillated
+// 0 -> 1 forever — and (a) either never fired (not-started matches) or fired at
+// half its nominal deadline (started matches, double increment per tick).
+//
+// Each timer must own its counter. These tests pin the exact deadline of each
+// one across started/not-started x server/no-server, and pin the cases where NO
+// timer may fire.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// emptyTickState builds a MatchLoop-safe label with no players.
+func emptyTickState(lobbyType LobbyType, hasServer bool, started bool, players int) *MatchLabel {
+	serverSession := uuid.Must(uuid.NewV4())
+	operatorID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	state := &MatchLabel{
+		ID:        MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"},
+		CreatedAt: time.Now().UTC(),
+		Open:      true,
+		LobbyType: lobbyType,
+		Mode:      evr.ModeSocialNPE, // not in ValidLeaderboardModes -> no DB write
+		Level:     evr.LevelSocial,
+		MaxSize:   16,
+		GroupID:   &groupID,
+		GameServer: &GameServerPresence{
+			SessionID:  serverSession,
+			OperatorID: operatorID,
+			GroupIDs:   []uuid.UUID{groupID},
+		},
+		GameState:             &GameState{},
+		Players:               make([]PlayerInfo, 0, 16),
+		presenceMap:           make(map[string]*EvrMatchPresence, 16),
+		reservationMap:        make(map[string]*slotReservation),
+		reconnectReservations: make(map[string]*reconnectReservation),
+		presenceByEvrID:       make(map[evr.EvrId]*EvrMatchPresence, 16),
+		TeamAlignments:        make(map[string]int, 16),
+		joinTimestamps:        make(map[string]time.Time, 16),
+		joinTimeMilliseconds:  make(map[string]int64, 16),
+		participations:        make(map[string]*PlayerParticipation, 16),
+		tickRate:              10,
+	}
+
+	if hasServer {
+		state.server = &Presence{
+			ID:     PresenceID{Node: "testnode", SessionID: serverSession},
+			UserID: operatorID,
+		}
+	}
+
+	if started {
+		state.StartTime = time.Now().UTC().Add(-time.Minute)
+		// A started match has already had its level loaded; without this the
+		// loop would divert into MatchStart instead of reaching the timers.
+		state.levelLoaded = true
+	}
+
+	for i := 0; i < players; i++ {
+		p := reconnectTestPlayer(string(rune('a'+i)), evr.TeamBlue)
+		state.presenceMap[p.GetSessionId()] = p
+		state.joinTimestamps[p.GetSessionId()] = time.Now()
+	}
+
+	state.rebuildCache()
+	return state
+}
+
+// runUntilShutdown drives MatchLoop up to maxIterations times and returns the
+// 1-based iteration on which the match began shutting down (terminateTick set,
+// or the loop returned nil). 0 means it never shut down.
+func runUntilShutdown(t *testing.T, state *MatchLabel, maxIterations int) int {
+	t.Helper()
+
+	m := &EvrMatch{}
+	nk := &drainTestNK{}
+	dispatcher := &drainTestDispatcher{}
+	logger := drainTestLogger()
+	ctx := context.Background()
+
+	for i := 1; i <= maxIterations; i++ {
+		out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, int64(i), state, nil)
+		if out == nil {
+			return i
+		}
+		if state.terminateTick != 0 {
+			return i
+		}
+	}
+	return 0
+}
+
+func TestMatchLoop_EmptyTickTimersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	const tickRate = 10
+
+	cases := []struct {
+		name          string
+		lobbyType     LobbyType
+		hasServer     bool
+		started       bool
+		players       int
+		maxIterations int
+		// wantShutdownAt is the 1-based MatchLoop iteration on which the
+		// shutdown must begin. 0 means it must never begin.
+		wantShutdownAt int
+		why            string
+	}{
+		{
+			name:           "no_server/not_started/empty fires the 10s no-server timer",
+			lobbyType:      PublicLobby,
+			hasServer:      false,
+			started:        false,
+			maxIterations:  400,
+			wantShutdownAt: 10*tickRate + 1,
+			why:            "the no-server deadline must not be reset by the started-and-empty branch",
+		},
+		{
+			name:           "no_server/started/empty fires the 10s no-server timer once, not twice per tick",
+			lobbyType:      PublicLobby,
+			hasServer:      false,
+			started:        true,
+			maxIterations:  400,
+			wantShutdownAt: 10*tickRate + 1,
+			why:            "two increments per tick would halve the deadline to ~5s",
+		},
+		{
+			name:           "no_server/unassigned parking fires the 10s no-server timer",
+			lobbyType:      UnassignedLobby,
+			hasServer:      false,
+			started:        false,
+			maxIterations:  400,
+			wantShutdownAt: 10*tickRate + 1,
+			why:            "a parking match whose game server never arrives must not leak",
+		},
+		{
+			name:           "server/unassigned parking fires the 120s unallocated timer",
+			lobbyType:      UnassignedLobby,
+			hasServer:      true,
+			started:        false,
+			maxIterations:  1400,
+			wantShutdownAt: 120*tickRate + 1,
+			why:            "a parking match with a server that is never allocated must time out",
+		},
+		{
+			name:           "server/started/empty fires the 60s empty timer",
+			lobbyType:      PublicLobby,
+			hasServer:      true,
+			started:        true,
+			maxIterations:  800,
+			wantShutdownAt: 60*tickRate + 1,
+			why:            "an abandoned started match must be reclaimed after 60s",
+		},
+		{
+			name:           "server/started/occupied never shuts down",
+			lobbyType:      PublicLobby,
+			hasServer:      true,
+			started:        true,
+			players:        2,
+			maxIterations:  1400,
+			wantShutdownAt: 0,
+			why:            "a live match with players must never be reclaimed by an idle timer",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := emptyTickState(tc.lobbyType, tc.hasServer, tc.started, tc.players)
+			got := runUntilShutdown(t, state, tc.maxIterations)
+
+			if got != tc.wantShutdownAt {
+				if tc.wantShutdownAt == 0 {
+					t.Fatalf("match shut down on iteration %d but must never shut down (%s)", got, tc.why)
+				}
+				if got == 0 {
+					t.Fatalf("match never shut down within %d iterations; expected shutdown on iteration %d (%s)",
+						tc.maxIterations, tc.wantShutdownAt, tc.why)
+				}
+				t.Fatalf("match shut down on iteration %d; expected iteration %d (%s)", got, tc.wantShutdownAt, tc.why)
+			}
+		})
+	}
+}
+
+// TestMatchLoop_OccupancyDoesNotResetTheNoServerTimer pins the interaction that
+// the shared counter got wrong: a match that lost its game server but still has
+// players must still hit the 10s no-server deadline. Under the shared counter
+// the "reset when not (started and empty)" branch wiped the no-server count on
+// every tick.
+func TestMatchLoop_OccupancyDoesNotResetTheNoServerTimer(t *testing.T) {
+	t.Parallel()
+
+	state := emptyTickState(PublicLobby, false, false, 2)
+	got := runUntilShutdown(t, state, 400)
+
+	const want = 10*10 + 1
+	if got != want {
+		t.Fatalf("no-server shutdown fired on iteration %d, want %d (players present must not reset the no-server timer)", got, want)
+	}
+}
+
+// TestMatchLoop_ParkingMatchCounterDoesNotOscillate proves the concrete failure
+// mode directly: for an unassigned parking match that HAS a game server, the
+// unallocated counter must advance monotonically, one per tick.
+func TestMatchLoop_ParkingMatchCounterDoesNotOscillate(t *testing.T) {
+	t.Parallel()
+
+	state := emptyTickState(UnassignedLobby, true, false, 0)
+
+	m := &EvrMatch{}
+	nk := &drainTestNK{}
+	dispatcher := &drainTestDispatcher{}
+	logger := drainTestLogger()
+	ctx := context.Background()
+
+	for i := 1; i <= 25; i++ {
+		if out := m.MatchLoop(ctx, logger, nil, nk, dispatcher, int64(i), state, nil); out == nil {
+			t.Fatalf("tick %d: parking match terminated far too early", i)
+		}
+		if got := state.unallocatedTicks; got != int64(i) {
+			t.Fatalf("tick %d: unallocatedTicks = %d, want %d (counter is not advancing monotonically)", i, got, i)
+		}
+	}
+}

--- a/server/evr_match_empty_ticks_test.go
+++ b/server/evr_match_empty_ticks_test.go
@@ -16,7 +16,8 @@ package server
 //
 // Each timer must own its counter. These tests pin the exact deadline of each
 // one across started/not-started x server/no-server, and pin the cases where NO
-// timer may fire.
+// timer may fire. Most cases fail against the pre-fix shared counter; the one
+// that does not is annotated inline as a plain regression pin.
 
 import (
 	"context"
@@ -150,7 +151,11 @@ func TestMatchLoop_EmptyTickTimersAreIndependent(t *testing.T) {
 			started:        false,
 			maxIterations:  400,
 			wantShutdownAt: 10*tickRate + 1,
-			why:            "a parking match whose game server never arrives must not leak",
+			// NOTE: this case also passes against the pre-fix shared counter —
+			// at base the UnassignedLobby branch returns before the reset that
+			// broke the other cases. It is kept as a plain regression pin, not
+			// as evidence that the counter split was necessary.
+			why: "a parking match whose game server never arrives must not leak",
 		},
 		{
 			name:           "server/unassigned parking fires the 120s unallocated timer",

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -73,7 +73,9 @@ type MatchLabel struct {
 	joinTimeMilliseconds map[string]int64                // The round clock time of when players joined the match. map[sessionId]time.Time
 	participations       map[string]*PlayerParticipation // map[userID]*PlayerParticipation - tracks all players who ever joined
 	tickRate             int64                           // The number of ticks per second.
-	emptyTicks           int64                           // The number of ticks the match has been empty.
+	emptyTicks           int64                           // Consecutive ticks a STARTED match has had no players (60s deadline).
+	noServerTicks        int64                           // Consecutive ticks the match has had no game server presence (10s deadline).
+	unallocatedTicks     int64                           // Consecutive ticks an unassigned parking match with a server has gone unallocated (120s deadline).
 	terminateTick        int64                           // The tick count at which the match will be shut down.
 	goals                []*evr.MatchGoal                // The goals scored in the match.
 	matchSummarySent     bool                            // Whether the match summary has been sent.

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -77,6 +77,7 @@ type MatchLabel struct {
 	noServerTicks        int64                           // Consecutive ticks the match has had no game server presence (10s deadline).
 	unallocatedTicks     int64                           // Consecutive ticks an unassigned parking match with a server has gone unallocated (120s deadline).
 	startAttempts        int64                           // Number of MatchStart attempts made; bounds the start retry loop (MatchStartMaxAttempts).
+	lastStartAttemptTick int64                           // MatchLoop tick of the most recent MatchStart attempt; throttles the retry to one per second. Its own field: sharing storage with a timer would let that timer's reset re-open the throttle.
 	terminateTick        int64                           // The tick count at which the match will be shut down.
 	goals                []*evr.MatchGoal                // The goals scored in the match.
 	matchSummarySent     bool                            // Whether the match summary has been sent.

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -76,6 +76,7 @@ type MatchLabel struct {
 	emptyTicks           int64                           // Consecutive ticks a STARTED match has had no players (60s deadline).
 	noServerTicks        int64                           // Consecutive ticks the match has had no game server presence (10s deadline).
 	unallocatedTicks     int64                           // Consecutive ticks an unassigned parking match with a server has gone unallocated (120s deadline).
+	startAttempts        int64                           // Number of MatchStart attempts made; bounds the start retry loop (MatchStartMaxAttempts).
 	terminateTick        int64                           // The tick count at which the match will be shut down.
 	goals                []*evr.MatchGoal                // The goals scored in the match.
 	matchSummarySent     bool                            // Whether the match summary has been sent.

--- a/server/evr_match_start_retry_test.go
+++ b/server/evr_match_start_retry_test.go
@@ -1,0 +1,258 @@
+package server
+
+// Regression tests for the MatchStart retry path in MatchLoop.
+//
+// The start branch in MatchLoop sits ABOVE every idle/empty timer and returns
+// unconditionally, so whatever it does is the last word for that tick. Two
+// opposite failure modes have to be pinned at once:
+//
+//  1. It must not KILL the match on a transient dispatch failure (a bare
+//     `return nil` makes the handler Stop() without MatchTerminate).
+//
+//  2. It must not KEEP the match forever either. MatchStart used to mutate the
+//     caller's label (StartTime, GameState) *before* the dispatch that could
+//     fail, so a failed start left Started() == true with levelLoaded == false.
+//     That combination disables the 15-minute "did not start on time" reclaim
+//     (it requires !Started()), makes the start branch's own guard
+//     `len(presenceMap) != 0 || state.Started()` true forever, and so starves
+//     every timer below it. The match then re-dispatched MatchStart at tick
+//     rate for the life of the process.
+//
+// So: the label may only be mutated by a start that actually dispatched, and
+// the retries must be bounded (MatchStartMaxAttempts) and throttled.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// startFailDispatcher fails every broadcast (so MatchStart's dispatchMessages,
+// and therefore MatchStart, fails) and counts the attempts.
+type startFailDispatcher struct {
+	runtime.MatchDispatcher
+	broadcasts int
+}
+
+func (d *startFailDispatcher) BroadcastMessage(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	d.broadcasts++
+	return errTerminationTestDispatch
+}
+
+func (d *startFailDispatcher) BroadcastMessageDeferred(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	d.broadcasts++
+	return errTerminationTestDispatch
+}
+
+func (d *startFailDispatcher) MatchKick(_ []runtime.Presence) error { return nil }
+func (d *startFailDispatcher) MatchLabelUpdate(_ string) error      { return nil }
+
+// startRetryState builds an assigned lobby with a game server presence that has
+// not yet loaded its level, with `players` players in the presence map.
+func startRetryState(mode evr.Symbol, players int) *MatchLabel {
+	state := reconnectTestState(mode)
+	state.levelLoaded = false
+	for i := 0; i < players; i++ {
+		p := reconnectTestPlayer("start-retry-"+string(rune('a'+i)), evr.TeamBlue)
+		state.presenceMap[p.GetSessionId()] = p
+		state.presenceByEvrID[p.EvrID] = p
+		state.joinTimestamps[p.GetSessionId()] = time.Now()
+	}
+	state.rebuildCache()
+	return state
+}
+
+// TestMatchStart_FailedStartDoesNotMutateTheLabel pins the root cause. A start
+// that never dispatched must leave StartTime and GameState exactly as it found
+// them, so the label keeps telling the truth: this match has NOT started.
+//
+// The preserved StartTime matters beyond Started(): SignalPrepareSession
+// (evr_match.go, "case SignalPrepareSession") schedules a future StartTime, and
+// clobbering it with time.Now() on a failed start would silently reschedule the
+// session.
+func TestMatchStart_FailedStartDoesNotMutateTheLabel(t *testing.T) {
+	// ModeArenaPublic is one of the modes whose MatchStart rebuilds
+	// GameState.SessionScoreboard, i.e. resets the round clock.
+	state := startRetryState(evr.ModeArenaPublic, 1)
+
+	scheduled := time.Now().UTC().Add(10 * time.Minute)
+	state.StartTime = scheduled
+	originalGameState := state.GameState
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &startFailDispatcher{}
+	m := &EvrMatch{}
+
+	got, err := m.MatchStart(context.Background(), reconnectTestLogger(), nk, dispatcher, state)
+	if err == nil {
+		t.Fatal("test did not exercise the failing-start path")
+	}
+	if got == nil {
+		t.Fatal("MatchStart returned a nil label on a dispatch failure; the caller has nothing to keep running with")
+	}
+
+	if !state.StartTime.Equal(scheduled) {
+		t.Errorf("a failed start moved StartTime from the scheduled %v to %v; Started() now reports %v with levelLoaded=%v, which disables the 15-minute reclaim and traps MatchLoop in the start branch",
+			scheduled, state.StartTime, state.Started(), state.levelLoaded)
+	}
+	if state.GameState != originalGameState {
+		t.Error("a failed start replaced GameState (and its SessionScoreboard), resetting the round clock for an attempt that never reached the game server")
+	}
+	if state.levelLoaded {
+		t.Error("a failed start marked the level as loaded")
+	}
+}
+
+// TestMatchStart_SuccessfulStartCommitsTheLabel is the other half: the deferred
+// commit must still happen when the dispatch succeeds. Without this, the
+// "don't mutate on failure" fix would silently break every normal start.
+func TestMatchStart_SuccessfulStartCommitsTheLabel(t *testing.T) {
+	state := startRetryState(evr.ModeArenaPublic, 1)
+	state.StartTime = time.Now().UTC().Add(10 * time.Minute)
+	originalGameState := state.GameState
+	before := time.Now().UTC()
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &reconnectTestDispatcher{}
+	m := &EvrMatch{}
+
+	if _, err := m.MatchStart(context.Background(), reconnectTestLogger(), nk, dispatcher, state); err != nil {
+		t.Fatalf("MatchStart failed unexpectedly: %v", err)
+	}
+
+	if !state.levelLoaded {
+		t.Error("a successful start did not mark the level as loaded")
+	}
+	if state.StartTime.Before(before) {
+		t.Errorf("a successful start did not commit StartTime: got %v, want >= %v", state.StartTime, before)
+	}
+	if !state.Started() {
+		t.Error("a successful start left Started() false")
+	}
+	if state.GameState == originalGameState {
+		t.Error("a successful arena start did not install the new GameState/SessionScoreboard")
+	}
+	if state.GameState == nil || state.GameState.SessionScoreboard == nil {
+		t.Fatal("a successful arena start left no SessionScoreboard")
+	}
+}
+
+// TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly: a game server session
+// that dies without a clean presence-leave (node partition, dropped socket)
+// leaves state.server set while every dispatch to it fails. The match must give
+// up after MatchStartMaxAttempts and run the orderly shutdown, not retry until
+// the process dies.
+func TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly(t *testing.T) {
+	state := startRetryState(evr.ModeArenaPublic, 2)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &startFailDispatcher{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	// MatchStartMaxAttempts attempts, throttled to one per second after the
+	// first, so the deadline lands around tick MatchStartMaxAttempts*tickRate.
+	maxIterations := int((MatchStartMaxAttempts + 5) * state.tickRate)
+
+	shutdownAt := 0
+	for i := 1; i <= maxIterations; i++ {
+		out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, int64(i), state, nil)
+		if out == nil {
+			t.Fatalf("MatchLoop bare-returned nil on iteration %d: the handler Stop()s without MatchTerminate, so the two players get no shutdown sequence at all", i)
+		}
+		if state.terminateTick != 0 {
+			shutdownAt = i
+			break
+		}
+	}
+
+	if shutdownAt == 0 {
+		t.Fatalf("a permanently failing MatchStart was never reclaimed: after %d ticks the loop had re-dispatched the start %d times, startAttempts=%d, and no timer can ever fire because the start branch returns above all of them",
+			maxIterations, dispatcher.broadcasts, state.startAttempts)
+	}
+	if state.startAttempts > MatchStartMaxAttempts {
+		t.Errorf("start was attempted %d times, want at most %d", state.startAttempts, MatchStartMaxAttempts)
+	}
+	if state.Open {
+		t.Error("expected the match to be closed to new joins after the shutdown")
+	}
+
+	// The retries must be throttled, not run at tick rate: one attempt per
+	// second means far fewer attempts than ticks elapsed.
+	if state.startAttempts >= int64(shutdownAt) {
+		t.Errorf("start was retried every tick (%d attempts in %d ticks); retries after the first must be throttled to one per second", state.startAttempts, shutdownAt)
+	}
+}
+
+// TestMatchLoop_FailedStartRestoresTheDidNotStartOnTimeReclaim: because a
+// failed start no longer forges Started(), the 15-minute reclaim for a match
+// that never started is reachable again. This is the path that recovers an
+// empty prepared lobby whose game server went away.
+func TestMatchLoop_FailedStartRestoresTheDidNotStartOnTimeReclaim(t *testing.T) {
+	state := startRetryState(evr.ModeArenaPublic, 1)
+	state.CreatedAt = time.Now().UTC().Add(-16 * time.Minute)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &startFailDispatcher{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	// Tick once with a player present: the start is attempted and fails.
+	if out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil); out == nil {
+		t.Fatal("MatchLoop returned nil on the first failed start")
+	}
+	if state.Started() {
+		t.Fatal("a failed start still reports Started(); the 15-minute reclaim below is unreachable")
+	}
+
+	// The player leaves; the match is now an empty, never-started lobby that
+	// was created 16 minutes ago.
+	for sid := range state.presenceMap {
+		delete(state.presenceMap, sid)
+	}
+	state.rebuildCache()
+
+	out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, 2, state, nil)
+	if out == nil {
+		t.Fatal("MatchLoop bare-returned nil for the 15-minute reclaim: the handler Stop()s without MatchTerminate")
+	}
+	if state.terminateTick == 0 {
+		t.Fatal("the 15-minute \"did not start on time\" reclaim never fired for a match whose start had failed")
+	}
+	if state.Open {
+		t.Error("expected the match to be closed to new joins after the reclaim")
+	}
+}
+
+// TestMatchLoop_PostStartLabelUpdateFailureKeepsMatchAlive covers the
+// `updateLabel` call that runs immediately AFTER a successful MatchStart.
+// labelFailDispatcher lets the start dispatch succeed and fails only
+// MatchLabelUpdate, which is the only way to reach that branch.
+func TestMatchLoop_PostStartLabelUpdateFailureKeepsMatchAlive(t *testing.T) {
+	state := startRetryState(evr.ModeSocialPublic, 1)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &labelFailDispatcher{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	got := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil)
+	if got == nil {
+		t.Fatal("MatchLoop returned nil after the post-start label update failed: the match handler Stop()s without MatchTerminate, killing a match that had just successfully started")
+	}
+	if _, ok := got.(*MatchLabel); !ok {
+		t.Fatalf("MatchLoop returned %T, want *MatchLabel", got)
+	}
+	if !state.levelLoaded {
+		t.Fatal("test did not exercise the post-start path: the start never succeeded")
+	}
+	if dispatcher.calls == 0 {
+		t.Fatal("test did not exercise the label-update failure path")
+	}
+	if state.terminateTick != 0 {
+		t.Error("a transient label-update failure must not shut the match down")
+	}
+}

--- a/server/evr_match_start_throttle_test.go
+++ b/server/evr_match_start_throttle_test.go
@@ -1,0 +1,112 @@
+package server
+
+// Regression test for the MatchStart retry THROTTLE (as opposed to the retry
+// BOUND covered in evr_match_start_retry_test.go).
+//
+// The throttle's job is to keep a dead game server from being re-dispatched at
+// tick rate. A modulo gate (`tick % tickRate == 0`) does not do that: it aligns
+// retries to absolute tick boundaries rather than enforcing a gap since the
+// last attempt. With tickRate 10, a first attempt at tick 9 is followed by a
+// second at tick 10 — 0.1s later, i.e. the full tick rate for that instant.
+//
+// This is the same class of defect this PR fixes elsewhere: a timer whose state
+// is not its own. The gate must be a function of "when did I last attempt",
+// which means the attempt tick has to be tracked per-match, in its own field
+// that no other timer touches.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// TestMatchLoop_StartRetryEnforcesMinimumGap drives MatchLoop from a tick that
+// sits just below a tickRate boundary and asserts the second attempt is at
+// least tickRate ticks after the first, regardless of where the first landed.
+func TestMatchLoop_StartRetryEnforcesMinimumGap(t *testing.T) {
+	state := startRetryState(evr.ModeArenaPublic, 1)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &startFailDispatcher{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	// Start one tick below a tickRate boundary: the worst case for a modulo
+	// gate. tickRate is 10, so the first attempt is at tick 9 and the next
+	// boundary is tick 10.
+	const firstTick = int64(9)
+
+	if out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, firstTick, state, nil); out == nil {
+		t.Fatal("MatchLoop returned nil on the first failed start")
+	}
+	if state.startAttempts != 1 {
+		t.Fatalf("test did not exercise the start branch: startAttempts=%d after the first tick, want 1", state.startAttempts)
+	}
+
+	// Walk forward until the second attempt happens.
+	secondTick := int64(0)
+	for tick := firstTick + 1; tick <= firstTick+3*state.tickRate; tick++ {
+		if out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, tick, state, nil); out == nil {
+			t.Fatalf("MatchLoop returned nil at tick %d", tick)
+		}
+		if state.startAttempts > 1 {
+			secondTick = tick
+			break
+		}
+	}
+
+	if secondTick == 0 {
+		t.Fatalf("no second start attempt within %d ticks of the first; the retry is not happening at all", 3*state.tickRate)
+	}
+
+	if gap := secondTick - firstTick; gap < state.tickRate {
+		t.Errorf("second MatchStart attempt came %d ticks (%.1fs) after the first at tick %d; the throttle must enforce at least %d ticks (1s) between attempts, not align them to absolute tick boundaries",
+			gap, float64(gap)/float64(state.tickRate), firstTick, state.tickRate)
+	}
+}
+
+// TestMatchLoop_StartRetryThrottleIsIndependentOfTheIdleTimers pins the
+// counter-aliasing hazard: the throttle's bookkeeping must live in its own
+// field. If it shared storage with noServerTicks / unallocatedTicks /
+// emptyTicks, a reset on one of those would silently re-open the throttle.
+func TestMatchLoop_StartRetryThrottleIsIndependentOfTheIdleTimers(t *testing.T) {
+	state := startRetryState(evr.ModeArenaPublic, 1)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &startFailDispatcher{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	if out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil); out == nil {
+		t.Fatal("MatchLoop returned nil on the first failed start")
+	}
+
+	// The idle timers must be untouched by a start attempt: the start branch
+	// returns above all of them, and a match with a server present has nothing
+	// to count.
+	if state.noServerTicks != 0 {
+		t.Errorf("noServerTicks=%d after a start attempt; the start throttle must not share a counter with the no-server timer", state.noServerTicks)
+	}
+	if state.unallocatedTicks != 0 {
+		t.Errorf("unallocatedTicks=%d after a start attempt; the start throttle must not share a counter with the unallocated timer", state.unallocatedTicks)
+	}
+	if state.emptyTicks != 0 {
+		t.Errorf("emptyTicks=%d after a start attempt; the start throttle must not share a counter with the empty-match timer", state.emptyTicks)
+	}
+
+	// Clearing every idle counter (what a presence change does) must not let
+	// the next tick re-attempt the start ahead of the throttle window.
+	state.noServerTicks = 0
+	state.unallocatedTicks = 0
+	state.emptyTicks = 0
+
+	attemptsBefore := state.startAttempts
+	if out := m.MatchLoop(ctx, reconnectTestLogger(), nil, nk, dispatcher, 2, state, nil); out == nil {
+		t.Fatal("MatchLoop returned nil on the tick after the failed start")
+	}
+	if state.startAttempts != attemptsBefore {
+		t.Errorf("start was re-attempted on the very next tick (attempts %d -> %d); the throttle window must survive an idle-counter reset", attemptsBefore, state.startAttempts)
+	}
+}

--- a/server/evr_match_termination_test.go
+++ b/server/evr_match_termination_test.go
@@ -370,3 +370,97 @@ func TestMatchJoinAttempt_EvictionClearsJoinTimeMilliseconds(t *testing.T) {
 		t.Error("evicted session left a stale joinTimeMilliseconds entry behind")
 	}
 }
+
+// TestMatchJoin_OrphanPresenceDoesNotLeakJoinTimeMilliseconds closes the other
+// half of the eviction cleanup. MatchJoinAttempt evicts the stale session and
+// deletes its joinTimeMilliseconds, but the MatchJoin for that same session is
+// already queued behind it on the handler goroutine. MatchJoin used to write
+// joinTimeMilliseconds BEFORE the presence-map lookup, so the orphan's entry was
+// written straight back and then skipped over by the `continue`. Nothing ever
+// removes it afterwards: MatchLeave only deletes the key for sessions it finds
+// in the presence map, so the entry survives for the life of the match.
+func TestMatchJoin_OrphanPresenceDoesNotLeakJoinTimeMilliseconds(t *testing.T) {
+	state := reconnectTestState(evr.ModeArenaPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+	// A live scoreboard is what makes MatchJoin record a join clock time at all.
+	state.GameState = &GameState{SessionScoreboard: NewSessionScoreboard(RoundDuration, time.Now())}
+	state.rebuildCache()
+
+	// The orphan is deliberately NOT in the presence map: MatchJoinAttempt
+	// already evicted it.
+	orphan := reconnectTestPlayer("join-orphan-jtms", evr.TeamBlue)
+
+	nk := &reconnectTestNakamaModule{}
+	m := &EvrMatch{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	got := m.MatchJoin(ctx, reconnectTestLogger(), nil, nk, &reconnectTestDispatcher{}, 1, state,
+		[]runtime.Presence{reconnectTestPresence{EvrMatchPresence: orphan, reason: runtime.PresenceReasonJoin}})
+	if got == nil {
+		t.Fatal("MatchJoin returned nil for an orphan presence, killing the match for everyone")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchJoin returned %T, want *MatchLabel", got)
+	}
+
+	if v, ok := after.joinTimeMilliseconds[orphan.GetSessionId()]; ok {
+		t.Errorf("the skipped orphan session left joinTimeMilliseconds=%d behind; nothing will ever delete it", v)
+	}
+}
+
+// TestMatchLeave_GameServerLeavingEmptyMatchClearsServer: the normal end-of-life
+// sequence is "all the players leave, then the game server disconnects", so the
+// game server's own leave arrives with an empty presence map. The empty-match
+// branch used to sit above the game-server check and win that race, running the
+// shutdown with state.server still pointing at the departed game server: a
+// LobbySessionEvent CODE_ENDED dispatched to a presence that has already gone, a
+// stored label still advertising the game server, a 5s grace instead of 2s, and
+// a MatchTerminate snapshot carrying a live serverSessionID.
+func TestMatchLeave_GameServerLeavingEmptyMatchClearsServer(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+	state.rebuildCache() // presenceMap is empty: every player already left
+
+	gameServer := reconnectTestPresence{
+		EvrMatchPresence: &EvrMatchPresence{
+			Node:      "test-node",
+			SessionID: state.GameServer.SessionID,
+			UserID:    state.GameServer.OperatorID,
+			Username:  "broadcaster:gameserver",
+		},
+		reason: runtime.PresenceReasonDisconnect,
+	}
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &drainTestDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	m := &EvrMatch{}
+
+	const leaveTick = int64(3)
+	got := m.MatchLeave(ctx, reconnectTestLogger(), nil, nk, dispatcher, leaveTick, state,
+		[]runtime.Presence{gameServer})
+	if got == nil {
+		t.Fatal("MatchLeave returned nil when the game server left an empty match")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchLeave returned %T, want *MatchLabel", got)
+	}
+
+	if after.server != nil {
+		t.Error("state.server still points at the departed game server; the shutdown will dispatch to a presence that has already left")
+	}
+	if wantGrace := 2 * state.tickRate; after.terminateTick-leaveTick != wantGrace {
+		t.Errorf("drain grace is %d ticks, want %d (2s): the game-server-left path uses a 2s grace, the empty-match path 5s",
+			after.terminateTick-leaveTick, wantGrace)
+	}
+	if dispatcher.broadcastCount() != 0 {
+		t.Errorf("shutdown broadcast %d message(s) to the departed game server presence", dispatcher.broadcastCount())
+	}
+	if after.Open {
+		t.Error("expected the match to be closed to new joins after shutdown")
+	}
+}

--- a/server/evr_match_termination_test.go
+++ b/server/evr_match_termination_test.go
@@ -1,0 +1,330 @@
+package server
+
+// Regression tests for unintended match termination.
+//
+// Returning nil from MatchLeave / MatchJoin / MatchLoop is not "shut the match
+// down" — it makes MatchHandler call mh.Stop() WITHOUT ever calling
+// MatchTerminate (see server/match_handler.go: only QueueTerminate reaches
+// MatchTerminate). enqueueMatchTerminationTask therefore never runs: no match
+// summary, no stored-label cleanup, no game-server notification, no player
+// disconnects. The match just evaporates.
+//
+// So nil must be reserved for "the runtime handed us something that is not a
+// MatchLabel". Two classes of site were returning it wrongly:
+//
+//  1. TRANSIENT FAILURES (a dispatcher.MatchLabelUpdate error from a DB blip, a
+//     failed MatchStart dispatch). One flaky call must not end a live match for
+//     everyone still in it. Log and keep running.
+//
+//  2. DELIBERATE SHUTDOWNS ("match is empty", "match did not start on time").
+//     These must run the orderly MatchShutdown -> drain -> MatchTerminate
+//     sequence so the game server is told and the label is cleaned up.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+var errTerminationTestDispatch = errors.New("simulated transient dispatcher failure")
+
+// labelFailDispatcher fails every MatchLabelUpdate, simulating a transient
+// database/label-update blip.
+type labelFailDispatcher struct {
+	runtime.MatchDispatcher
+	calls int
+}
+
+func (d *labelFailDispatcher) BroadcastMessage(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return nil
+}
+
+func (d *labelFailDispatcher) BroadcastMessageDeferred(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return nil
+}
+
+func (d *labelFailDispatcher) MatchKick(_ []runtime.Presence) error { return nil }
+
+func (d *labelFailDispatcher) MatchLabelUpdate(_ string) error {
+	d.calls++
+	return errTerminationTestDispatch
+}
+
+// broadcastFailDispatcher fails every outbound broadcast, which makes
+// MatchStart's dispatchMessages (and therefore MatchStart itself) fail.
+type broadcastFailDispatcher struct {
+	runtime.MatchDispatcher
+}
+
+func (d *broadcastFailDispatcher) BroadcastMessage(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return errTerminationTestDispatch
+}
+
+func (d *broadcastFailDispatcher) BroadcastMessageDeferred(_ int64, _ []byte, _ []runtime.Presence, _ runtime.Presence, _ bool) error {
+	return errTerminationTestDispatch
+}
+
+func (d *broadcastFailDispatcher) MatchKick(_ []runtime.Presence) error { return nil }
+func (d *broadcastFailDispatcher) MatchLabelUpdate(_ string) error      { return nil }
+
+// TestMatchLeave_LabelUpdateFailureKeepsMatchAlive: one player leaving a
+// six-player match must not end the match for the other five just because the
+// label update failed.
+func TestMatchLeave_LabelUpdateFailureKeepsMatchAlive(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+
+	stayers := make([]*EvrMatchPresence, 0, 5)
+	for i := 0; i < 5; i++ {
+		p := reconnectTestPlayer("stay-"+string(rune('a'+i)), evr.TeamBlue)
+		state.presenceMap[p.GetSessionId()] = p
+		state.presenceByEvrID[p.EvrID] = p
+		state.joinTimestamps[p.GetSessionId()] = time.Now().Add(-time.Minute)
+		stayers = append(stayers, p)
+	}
+	leaver := reconnectTestPlayer("label-fail-leaver", evr.TeamOrange)
+	state.presenceMap[leaver.GetSessionId()] = leaver
+	state.presenceByEvrID[leaver.EvrID] = leaver
+	state.joinTimestamps[leaver.GetSessionId()] = time.Now().Add(-time.Minute)
+	state.rebuildCache()
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &labelFailDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	m := &EvrMatch{}
+
+	got := m.MatchLeave(ctx, reconnectTestLogger(), nil, nk, dispatcher, 1, state,
+		[]runtime.Presence{reconnectTestPresence{EvrMatchPresence: leaver, reason: runtime.PresenceReasonLeave}})
+
+	if got == nil {
+		t.Fatal("MatchLeave returned nil after a transient label-update failure: the match handler will Stop() without MatchTerminate, killing the match for the 5 remaining players with no shutdown sequence")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchLeave returned %T, want *MatchLabel", got)
+	}
+	if dispatcher.calls == 0 {
+		t.Fatal("test did not exercise the label-update failure path")
+	}
+	if _, still := after.presenceMap[leaver.GetSessionId()]; still {
+		t.Error("leaver was not removed from the presence map")
+	}
+	for _, p := range stayers {
+		if _, ok := after.presenceMap[p.GetSessionId()]; !ok {
+			t.Errorf("remaining player %s was dropped from the presence map", p.GetSessionId())
+		}
+	}
+}
+
+// TestMatchLoop_LabelUpdateFailureKeepsMatchAlive: the tail-of-loop label
+// refresh is bookkeeping. A failure there must not end the match.
+func TestMatchLoop_LabelUpdateFailureKeepsMatchAlive(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+
+	p := reconnectTestPlayer("loop-label-fail", evr.TeamBlue)
+	state.presenceMap[p.GetSessionId()] = p
+	state.presenceByEvrID[p.EvrID] = p
+	state.joinTimestamps[p.GetSessionId()] = time.Now()
+
+	state.rebuildCache()
+
+	// An expired slot reservation forces updateLabel = true on this tick.
+	// Inserted after rebuildCache, which prunes expired reservations itself.
+	expired := reconnectTestPlayer("loop-label-expired", evr.TeamOrange)
+	state.reservationMap[expired.GetSessionId()] = &slotReservation{
+		Presence: expired,
+		Expiry:   time.Now().Add(-time.Minute),
+	}
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &labelFailDispatcher{}
+	m := &EvrMatch{}
+
+	got := m.MatchLoop(context.Background(), reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil)
+	if got == nil {
+		t.Fatal("MatchLoop returned nil after a transient label-update failure: a live match with players in it is killed with no shutdown sequence")
+	}
+	if dispatcher.calls == 0 {
+		t.Fatal("test did not exercise the label-update failure path")
+	}
+}
+
+// TestMatchLoop_StartFailureKeepsMatchAlive: a failed MatchStart dispatch is
+// retryable. Killing the match strands the players and the game server.
+func TestMatchLoop_StartFailureKeepsMatchAlive(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.levelLoaded = false
+
+	p := reconnectTestPlayer("start-fail", evr.TeamBlue)
+	state.presenceMap[p.GetSessionId()] = p
+	state.presenceByEvrID[p.EvrID] = p
+	state.joinTimestamps[p.GetSessionId()] = time.Now()
+	state.rebuildCache()
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &broadcastFailDispatcher{}
+	m := &EvrMatch{}
+
+	got := m.MatchLoop(context.Background(), reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil)
+	if got == nil {
+		t.Fatal("MatchLoop returned nil after a failed MatchStart dispatch: the match is killed with no shutdown sequence instead of retrying next tick")
+	}
+	if _, ok := got.(*MatchLabel); !ok {
+		t.Fatalf("MatchLoop returned %T, want *MatchLabel", got)
+	}
+}
+
+// TestMatchLeave_EmptyStartedMatchShutsDownOrderly: "match is empty, shut down"
+// is a real shutdown decision, so it must run the shutdown sequence rather than
+// bare-returning nil (which skips MatchTerminate entirely).
+func TestMatchLeave_EmptyStartedMatchShutsDownOrderly(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+	state.rebuildCache() // presenceMap is empty
+
+	ghost := reconnectTestPlayer("empty-started-ghost", evr.TeamBlue)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &reconnectTestDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	m := &EvrMatch{}
+
+	got := m.MatchLeave(ctx, reconnectTestLogger(), nil, nk, dispatcher, 7, state,
+		[]runtime.Presence{reconnectTestPresence{EvrMatchPresence: ghost, reason: runtime.PresenceReasonLeave}})
+
+	if got == nil {
+		t.Fatal("MatchLeave bare-returned nil for an empty started match: the handler Stop()s without MatchTerminate, so no summary, no label cleanup and no game-server notification ever happen")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchLeave returned %T, want *MatchLabel", got)
+	}
+	if after.terminateTick == 0 {
+		t.Error("expected the orderly shutdown to arm the drain deadline (terminateTick)")
+	}
+	if after.Open {
+		t.Error("expected the match to be closed to new joins after shutdown")
+	}
+}
+
+// TestMatchLoop_NeverStartedMatchShutsDownOrderly: same for the 15-minute
+// "match did not start on time" reclaim.
+func TestMatchLoop_NeverStartedMatchShutsDownOrderly(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.CreatedAt = time.Now().UTC().Add(-16 * time.Minute)
+	state.levelLoaded = false
+	state.rebuildCache() // presenceMap is empty, never started
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &reconnectTestDispatcher{}
+	m := &EvrMatch{}
+
+	got := m.MatchLoop(context.Background(), reconnectTestLogger(), nil, nk, dispatcher, 1, state, nil)
+	if got == nil {
+		t.Fatal("MatchLoop bare-returned nil for a match that never started: the handler Stop()s without MatchTerminate, leaking the stored label and stranding the game server")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchLoop returned %T, want *MatchLabel", got)
+	}
+	if after.terminateTick == 0 {
+		t.Error("expected the orderly shutdown to arm the drain deadline (terminateTick)")
+	}
+	if after.Open {
+		t.Error("expected the match to be closed to new joins after shutdown")
+	}
+}
+
+// TestMatchJoin_UnknownPresenceDoesNotKillMatch: MatchJoinAttempt and MatchJoin
+// are separately queued on the handler goroutine, so a presence can be evicted
+// from the presence map between them (see the same-user duplicate-EvrID eviction
+// in MatchJoinAttempt). A miss must skip that one presence, not end the match
+// for everybody.
+func TestMatchJoin_UnknownPresenceDoesNotKillMatch(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+
+	known := reconnectTestPlayer("join-known", evr.TeamBlue)
+	state.presenceMap[known.GetSessionId()] = known
+	state.presenceByEvrID[known.EvrID] = known
+	state.joinTimestamps[known.GetSessionId()] = time.Now()
+	// Pre-seed participation so the join does not need a database.
+	state.participations[known.GetUserId()] = &PlayerParticipation{}
+	state.rebuildCache()
+
+	// Evicted between MatchJoinAttempt and MatchJoin: no longer in presenceMap.
+	evicted := reconnectTestPlayer("join-evicted", evr.TeamOrange)
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &reconnectTestDispatcher{}
+	m := &EvrMatch{}
+
+	// The evicted presence comes first so a bare `return nil` aborts before the
+	// legitimate join is processed.
+	got := m.MatchJoin(context.Background(), reconnectTestLogger(), nil, nk, dispatcher, 1, state, []runtime.Presence{
+		reconnectTestPresence{EvrMatchPresence: evicted, reason: runtime.PresenceReasonJoin},
+		reconnectTestPresence{EvrMatchPresence: known, reason: runtime.PresenceReasonJoin},
+	})
+
+	if got == nil {
+		t.Fatal("MatchJoin returned nil for a presence missing from the presence map: the handler Stop()s without MatchTerminate, killing the whole match")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchJoin returned %T, want *MatchLabel", got)
+	}
+	if _, ok := after.presenceMap[known.GetSessionId()]; !ok {
+		t.Error("the legitimate join was dropped")
+	}
+	if _, ok := after.presenceMap[evicted.GetSessionId()]; ok {
+		t.Error("the unknown presence must not be resurrected into the presence map")
+	}
+}
+
+// TestMatchJoinAttempt_EvictionClearsJoinTimeMilliseconds: the same-user
+// duplicate-EvrID eviction removes the stale session from presenceMap,
+// presenceByEvrID and joinTimestamps but used to leave joinTimeMilliseconds
+// behind, unlike the MatchLeave cleanup. That stale entry is what makes the
+// scoreboard attribute the new session's join clock to the dead one.
+func TestMatchJoinAttempt_EvictionClearsJoinTimeMilliseconds(t *testing.T) {
+	state := reconnectTestState(evr.ModeArenaPublic)
+
+	userID := uuid.NewV5(uuid.Nil, "user-evict-jtms")
+	stale := reconnectTestPlayer("evict-jtms-old", evr.TeamBlue)
+	stale.UserID = userID
+	stale.EvrID = evr.EvrId{PlatformCode: 4, AccountId: 515151}
+	state.presenceMap[stale.GetSessionId()] = stale
+	state.presenceByEvrID[stale.EvrID] = stale
+	state.joinTimestamps[stale.GetSessionId()] = time.Now().Add(-30 * time.Second)
+	state.joinTimeMilliseconds[stale.GetSessionId()] = 12345
+	state.rebuildCache()
+
+	rejoined := reconnectTestPlayer("evict-jtms-new", evr.TeamBlue)
+	rejoined.UserID = userID
+	rejoined.EvrID = stale.EvrID
+	rejoined.SessionID = uuid.NewV5(uuid.Nil, "session-evict-jtms-new")
+
+	nk := &reconnectTestNakamaModule{}
+	m := &EvrMatch{}
+	metadata := NewJoinMetadata(rejoined).ToMatchMetadata()
+
+	gotState, allowed, reason := m.MatchJoinAttempt(context.Background(), reconnectTestLogger(), nil, nk, &reconnectTestDispatcher{}, 1, state, rejoined, metadata)
+	if !allowed {
+		t.Fatalf("expected the same-user duplicate EVR-ID eviction to allow the rejoin, got rejection: %s", reason)
+	}
+	after := gotState.(*MatchLabel)
+
+	if _, ok := after.joinTimeMilliseconds[stale.GetSessionId()]; ok {
+		t.Error("evicted session left a stale joinTimeMilliseconds entry behind")
+	}
+}

--- a/server/evr_match_termination_test.go
+++ b/server/evr_match_termination_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
 )
@@ -159,6 +160,14 @@ func TestMatchLoop_LabelUpdateFailureKeepsMatchAlive(t *testing.T) {
 
 // TestMatchLoop_StartFailureKeepsMatchAlive: a failed MatchStart dispatch is
 // retryable. Killing the match strands the players and the game server.
+//
+// This pins only HALF the contract — "retryable". It deliberately runs a single
+// tick, so on its own it would also pass for a match that retries forever. The
+// other half, "still bounded", lives in
+// TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly
+// (evr_match_start_retry_test.go), which drives the loop to the retry ceiling
+// and requires an orderly shutdown. Change one, check the other: the pair is
+// the contract.
 func TestMatchLoop_StartFailureKeepsMatchAlive(t *testing.T) {
 	state := reconnectTestState(evr.ModeSocialPublic)
 	state.levelLoaded = false
@@ -462,5 +471,100 @@ func TestMatchLeave_GameServerLeavingEmptyMatchClearsServer(t *testing.T) {
 	}
 	if after.Open {
 		t.Error("expected the match to be closed to new joins after shutdown")
+	}
+}
+
+// shutdownCountingNK counts the accounting side effects MatchShutdown performs
+// exactly once per match: the shutdown counter, the session-duration timer, and
+// the game-server time accumulated to the leaderboard.
+type shutdownCountingNK struct {
+	reconnectTestNakamaModule
+	shutdownCounts   int
+	durationRecords  int
+	leaderboardWrite int
+}
+
+func (m *shutdownCountingNK) MetricsCounterAdd(name string, _ map[string]string, delta int64) {
+	if name == "match_shutdown_count" {
+		m.shutdownCounts += int(delta)
+	}
+}
+
+func (m *shutdownCountingNK) MetricsTimerRecord(name string, _ map[string]string, _ time.Duration) {
+	if name == "lobby_session_duration" {
+		m.durationRecords++
+	}
+}
+
+func (m *shutdownCountingNK) LeaderboardRecordWrite(ctx context.Context, leaderboardId, ownerID, username string, score, subscore int64, metadata map[string]any, operator *int) (*api.LeaderboardRecord, error) {
+	m.leaderboardWrite++
+	return &api.LeaderboardRecord{}, nil
+}
+
+// TestMatchShutdown_IsIdempotent: several callers can reach MatchShutdown for
+// the same match. A straggler MatchLeave for a session that is no longer in the
+// presence map re-enters the empty-match branch, and SignalShutdown can be
+// issued again by an operator or by the preemption path while the drain is
+// already running. Each re-entry used to re-count match_shutdown_count,
+// re-record lobby_session_duration, re-accumulate the FULL game-server time to
+// the leaderboard (so a 30-minute match banked 30 minutes twice), and push
+// terminateTick further out.
+//
+// ModeArenaPublic is deliberate: it is in ValidLeaderboardModes, so the
+// AccumulateLeaderboardStat call in MatchShutdown is live.
+func TestMatchShutdown_IsIdempotent(t *testing.T) {
+	state := reconnectTestState(evr.ModeArenaPublic)
+	state.StartTime = time.Now().UTC().Add(-30 * time.Minute)
+	state.levelLoaded = true
+	state.rebuildCache() // presenceMap is empty: every player already left
+
+	nk := &shutdownCountingNK{}
+	dispatcher := &drainTestDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	m := &EvrMatch{}
+
+	// A player whose presence was already evicted; its leave event arrives late.
+	straggler := reconnectTestPresence{
+		EvrMatchPresence: reconnectTestPlayer("late-leaver", evr.TeamBlue),
+		reason:           runtime.PresenceReasonDisconnect,
+	}
+
+	var firstTerminateTick int64
+	var writesAfterFirst int
+	for i := 0; i < 3; i++ {
+		got := m.MatchLeave(ctx, reconnectTestLogger(), nil, nk, dispatcher, int64(i+1), state,
+			[]runtime.Presence{straggler})
+		if got == nil {
+			t.Fatalf("MatchLeave returned nil on straggler leave %d", i)
+		}
+		if i == 0 {
+			firstTerminateTick = state.terminateTick
+			writesAfterFirst = nk.leaderboardWrite
+			if firstTerminateTick == 0 {
+				t.Fatal("the first straggler leave on an empty started match did not arm the drain")
+			}
+			// One AccumulateLeaderboardStat call fans out to the daily, weekly
+			// and all-time boards, so the single legitimate shutdown is
+			// expected to write more than once here. What must not happen is
+			// the count growing on the repeats below.
+			if writesAfterFirst == 0 {
+				t.Fatal("test did not exercise the leaderboard path; pick a mode in ValidLeaderboardModes")
+			}
+		}
+	}
+
+	if nk.shutdownCounts != 1 {
+		t.Errorf("match_shutdown_count incremented %d times for one shutdown, want 1", nk.shutdownCounts)
+	}
+	if nk.durationRecords != 1 {
+		t.Errorf("lobby_session_duration recorded %d times for one shutdown, want 1", nk.durationRecords)
+	}
+	if nk.leaderboardWrite != writesAfterFirst {
+		t.Errorf("game-server time was accumulated again on the repeat shutdowns (%d leaderboard writes, want %d): each extra accumulation banks the FULL match duration a second time",
+			nk.leaderboardWrite, writesAfterFirst)
+	}
+	if state.terminateTick != firstTerminateTick {
+		t.Errorf("the drain deadline was re-armed from %d to %d; repeated shutdowns must not push teardown further out",
+			firstTerminateTick, state.terminateTick)
 	}
 }

--- a/server/evr_match_termination_test.go
+++ b/server/evr_match_termination_test.go
@@ -244,6 +244,48 @@ func TestMatchLoop_NeverStartedMatchShutsDownOrderly(t *testing.T) {
 	}
 }
 
+// TestMatchShutdown_LabelUpdateFailureStillArmsTheDrain: MatchShutdown is the
+// entry point of the orderly teardown, and it is now what the "match is empty"
+// and "match did not start on time" decisions route through. Bailing out with
+// nil when the label update fails defeats the whole point: the handler Stop()s
+// without MatchTerminate, so the drain never completes, the label is never
+// stored and the game server is never told to kick its players. The label
+// refresh is bookkeeping; the teardown must proceed regardless.
+func TestMatchShutdown_LabelUpdateFailureStillArmsTheDrain(t *testing.T) {
+	state := reconnectTestState(evr.ModeSocialPublic)
+	state.StartTime = time.Now().UTC().Add(-time.Minute)
+	state.levelLoaded = true
+
+	p := reconnectTestPlayer("shutdown-label-fail", evr.TeamBlue)
+	state.presenceMap[p.GetSessionId()] = p
+	state.presenceByEvrID[p.EvrID] = p
+	state.joinTimestamps[p.GetSessionId()] = time.Now().Add(-time.Minute)
+	state.rebuildCache()
+
+	nk := &reconnectTestNakamaModule{}
+	dispatcher := &labelFailDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	m := &EvrMatch{}
+
+	got := m.MatchShutdown(ctx, reconnectTestLogger(), nil, nk, dispatcher, 11, state, 5)
+	if got == nil {
+		t.Fatal("MatchShutdown returned nil after a transient label-update failure: the handler Stop()s without MatchTerminate, so the drain never runs, the stored label is never cleaned up and the game server is never told to kick its players")
+	}
+	after, ok := got.(*MatchLabel)
+	if !ok {
+		t.Fatalf("MatchShutdown returned %T, want *MatchLabel", got)
+	}
+	if dispatcher.calls == 0 {
+		t.Fatal("test did not exercise the label-update failure path")
+	}
+	if after.terminateTick == 0 {
+		t.Error("expected the drain deadline (terminateTick) to be armed despite the label-update failure")
+	}
+	if after.Open {
+		t.Error("expected the match to be closed to new joins")
+	}
+}
+
 // TestMatchJoin_UnknownPresenceDoesNotKillMatch: MatchJoinAttempt and MatchJoin
 // are separately queued on the handler goroutine, so a presence can be evicted
 // from the presence map between them (see the same-user duplicate-EvrID eviction

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -103,10 +103,17 @@ func TestEvrMatch_MatchLoop(t *testing.T) {
 		m    *EvrMatch
 		args args
 		want interface{}
+		// stubRuntime installs stub nk/dispatcher for this case only. Just the
+		// reclaim case needs them (it now runs the MatchShutdown sequence,
+		// which records metrics and stores the label); the other cases keep the
+		// original nil pair so the nil-dispatcher path in updateLabel stays
+		// covered.
+		stubRuntime bool
 	}{
 		{
-			name: "Match did not start on time.",
-			m:    &EvrMatch{},
+			name:        "Match did not start on time.",
+			m:           &EvrMatch{},
+			stubRuntime: true,
 			args: args{
 				tick: 500,
 				state_: func() *MatchLabel {
@@ -144,13 +151,16 @@ func TestEvrMatch_MatchLoop(t *testing.T) {
 			want: "non-nil", // match is within idle timeout, should return state
 		},
 		{
-			name: "MatchLoop increments emptyTicks when no broadcaster",
+			// The no-server deadline is counted by noServerTicks, not emptyTicks:
+			// this state has a player in the presence map and no game server, so
+			// it is the no-server timer that advances here.
+			name: "MatchLoop increments noServerTicks when no game server",
 			m:    &EvrMatch{},
 			args: args{
 				tick: 30 * 10,
 				state_: &MatchLabel{
-					emptyTicks: 0,
-					tickRate:   10,
+					noServerTicks: 0,
+					tickRate:      10,
 					presenceMap: map[string]*EvrMatchPresence{
 						uuid.Must(uuid.NewV4()).String(): {},
 					},
@@ -183,11 +193,12 @@ func TestEvrMatch_MatchLoop(t *testing.T) {
 			m := &EvrMatch{}
 			ctx := context.Background()
 			var db *sql.DB
-			// A real (stub) module is required: the idle-reclaim path now runs
-			// the MatchShutdown sequence, which records metrics and stores the
-			// label.
-			var nk runtime.NakamaModule = &reconnectTestNakamaModule{}
-			var dispatcher runtime.MatchDispatcher = &reconnectTestDispatcher{}
+			var nk runtime.NakamaModule
+			var dispatcher runtime.MatchDispatcher
+			if tt.stubRuntime {
+				nk = &reconnectTestNakamaModule{}
+				dispatcher = &reconnectTestDispatcher{}
+			}
 
 			got := m.MatchLoop(ctx, logger, db, nk, dispatcher, tt.args.tick, tt.args.state_, tt.args.messages)
 			if tt.want == "non-nil" {

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -119,7 +119,12 @@ func TestEvrMatch_MatchLoop(t *testing.T) {
 
 				messages: []runtime.MatchData{},
 			},
-			want: nil,
+			// The reclaim now runs the orderly MatchShutdown -> drain ->
+			// MatchTerminate sequence instead of bare-returning nil (which made
+			// the handler Stop() without ever calling MatchTerminate). The
+			// draining state is returned; see
+			// TestMatchLoop_NeverStartedMatchShutsDownOrderly.
+			want: "non-nil",
 		},
 		{
 			name: "MatchLoop returns state.",
@@ -178,8 +183,11 @@ func TestEvrMatch_MatchLoop(t *testing.T) {
 			m := &EvrMatch{}
 			ctx := context.Background()
 			var db *sql.DB
-			var nk runtime.NakamaModule
-			var dispatcher runtime.MatchDispatcher
+			// A real (stub) module is required: the idle-reclaim path now runs
+			// the MatchShutdown sequence, which records metrics and stores the
+			// label.
+			var nk runtime.NakamaModule = &reconnectTestNakamaModule{}
+			var dispatcher runtime.MatchDispatcher = &reconnectTestDispatcher{}
 
 			got := m.MatchLoop(ctx, logger, db, nk, dispatcher, tt.args.tick, tt.args.state_, tt.args.messages)
 			if tt.want == "non-nil" {


### PR DESCRIPTION
Match-lifecycle fixes: the three `MatchLoop` idle timers each get their own counter, match callbacks stop returning `nil` on transient failures, the `MatchStart` retry is bounded so the fix cannot strand a match forever, and `MatchShutdown` is idempotent.

Base: `d3e7e5549`. **All citations are at `a16d97f7c` unless a different SHA is stated.**

## Summary

| Scenario | Class | Gated behind | Frequency |
|---|---|---|---|
| Unassigned parking match with a server never hits its 120s deadline | FIX | none — always on | Every parking match that is never allocated |
| 10s no-server deadline never fires for an assigned not-started match | FIX | none | Every serverless assigned not-started match |
| 10s no-server deadline never fires while players are present | FIX | none | Every serverless occupied match |
| 10s no-server deadline fires at ~5s for a started empty match | FIX | none | Every serverless started empty match |
| Transient label-update failure silently evaporates a live match | FIX | none | Unquantified — depends on dispatcher/DB blip rate |
| A failed `MatchStart` killed the match with no `MatchTerminate` | FIX | none | Unquantified — game-server dispatch failures |
| A failed `MatchStart` traps the match in a 10 Hz retry loop forever | FIX (regression introduced in `4a3f64520`, fixed in `d9a65148c`) | none | **Never shipped** — caught in review |
| `MatchStart` failure forges `Started()`, disabling the 15-min reclaim | FIX | none | Same as above |
| Evicted-orphan `MatchJoin` leaks a `joinTimeMilliseconds` entry | FIX | needs a live `SessionScoreboard` | Rare — same-user duplicate-EvrID eviction race |
| Game server leaving an empty match shuts down with `state.server` still set | FIX | none | Every normal end-of-life (players leave, then server) |
| Repeated `MatchShutdown` double-counts metrics and re-banks leaderboard time | FIX | none | Every straggler leave / repeated `SignalShutdown` on a draining match |
| `MatchStart` retries emit up to 15 `failed to start session` lines | NEW | only on a failing start | Bounded at 15 per failing match |
| 10s no-server reap newly applies to assigned and occupied matches | **NEUTRAL → operator-visible** | none | See "Behavior operators should know about" |

---

## What changed

### Each `MatchLoop` idle timer gets its own counter  [FIX]

**What was tried:** An operator parks a game server that is never allocated to a lobby (`LobbyType == UnassignedLobby`, game-server presence joined).
**What they expected:** The parking match is reclaimed after the documented 120s unallocated deadline.
**What happened BEFORE this PR:** It was never reclaimed. All three deadlines shared `state.emptyTicks`, incremented at three sites and reset at two, with one reset running *before* one of the increments — so the counter oscillated `0 -> 1 -> 0` forever and the 120s branch was unreachable. The same sharing made the 10s no-server deadline never fire for an assigned not-started match or for an occupied one, and fire at ~5s (double increment per tick) for a started empty one.
**Estimated frequency:** Every unallocated parking match; every serverless assigned/occupied match. Unquantified in absolute terms — no production counter exists for it.
**What happens AFTER this PR:** Three fields — `emptyTicks`, `noServerTicks`, `unallocatedTicks` (`server/evr_match_label.go:76-78`) — each reset only by its own negative condition. Every deadline fires at its nominal value.
**Log signature BEFORE:** `Match has been empty for too long. Shutting down.` (`server/evr_match.go:1352 @ d3e7e5549` — one `Warn` shared by the no-server and empty cases) and `Unassigned parking match with server has not been allocated. Shutting down.` (never emitted).
**Log signature AFTER:** the no-server case is now distinct: `Match has been without a game server for too long. Shutting down.` at `server/evr_match.go:1389`. The 60s empty case: `Started match has been empty for too long. Shutting down.` at `:1536`. The 120s case (`:1402`) now actually emits.
**How to verify in production logs:**
```
grep -c 'Unassigned parking match with server has not been allocated' /home/echovrce/deployment/logs/nakama.log
```
Zero before, non-zero after, on a server that parks lobbies.
**Citation:** `TestMatchLoop_EmptyTickTimersAreIndependent`, `TestMatchLoop_ParkingMatchCounterDoesNotOscillate`, `TestMatchLoop_OccupancyDoesNotResetTheNoServerTimer`. Run against a clean `d3e7e5549` extract with the base label file (unused counter fields added so it compiles):
```
--- FAIL: TestMatchLoop_ParkingMatchCounterDoesNotOscillate
    evr_match_empty_ticks_test.go:247: tick 1: unallocatedTicks = 0, want 1 (counter is not advancing monotonically)
--- FAIL: TestMatchLoop_OccupancyDoesNotResetTheNoServerTimer
    evr_match_empty_ticks_test.go:224: no-server shutdown fired on iteration 0, want 101 (players present must not reset the no-server timer)
--- FAIL: TestMatchLoop_EmptyTickTimersAreIndependent
    --- FAIL: .../server/unassigned_parking_fires_the_120s_unallocated_timer
        :202: match never shut down within 1400 iterations; expected shutdown on iteration 1201
    --- FAIL: .../no_server/started/empty_fires_the_10s_no-server_timer_once,_not_twice_per_tick
        :205: match shut down on iteration 51; expected iteration 101
    --- FAIL: .../no_server/not_started/empty_fires_the_10s_no-server_timer
        :202: match never shut down within 400 iterations; expected shutdown on iteration 101
    --- PASS: .../no_server/unassigned_parking_fires_the_10s_no-server_timer
    --- PASS: .../server/started/occupied_never_shuts_down
    --- PASS: .../server/started/empty_fires_the_60s_empty_timer
```

### Match callbacks stop returning `nil` on transient failures  [FIX]

**What was tried:** A player leaves a busy match while the dispatcher's `MatchLabelUpdate` fails (DB blip).
**What they expected:** The leave is processed; everyone else keeps playing.
**What happened BEFORE this PR:** `MatchLeave` did `return nil` (`server/evr_match.go:1196 @ d3e7e5549`). Returning `nil` from a match callback is not "shut down" — `MatchHandler` calls `mh.Stop()` **without** `MatchTerminate`, so `enqueueMatchTerminationTask` never runs: no match summary, no stored-label cleanup, no game-server notification, no player disconnects. The match evaporates and every remaining player is stranded.
**Estimated frequency:** Unquantified — proportional to dispatcher/DB failure rate. Silent, so it cannot be counted retroactively.
**What happens AFTER this PR:** The error is logged and the match keeps running. `nil` is now reserved for "the runtime handed us something that is not a `MatchLabel`" (the type guards at `:631, :760, :1242, :1683, :1723`) plus `MatchTerminate`'s own terminal return at `:1716`.
**Log signature BEFORE:** `failed to update label` (Error) — then silence; nothing logged the match's disappearance.
**Log signature AFTER:** `failed to update label after leave` at `server/evr_match.go:1231`, `failed to update label on shutdown` at `:1766`, `failed to update label` at `:1526` and `:1678`. The messages were made call-site-specific so an operator can tell which path failed.
**How to verify in production logs:**
```
grep -E 'failed to update label( after leave| on shutdown)?' /home/echovrce/deployment/logs/nakama.log
```
After this PR these lines are no longer followed by the match vanishing; correlate the `match_id` against a later `MatchTerminate called.`
**Citation:** `TestMatchLeave_LabelUpdateFailureKeepsMatchAlive`, `TestMatchLoop_LabelUpdateFailureKeepsMatchAlive`, `TestMatchShutdown_LabelUpdateFailureStillArmsTheDrain`, `TestMatchJoin_UnknownPresenceDoesNotKillMatch`, `TestMatchLoop_PostStartLabelUpdateFailureKeepsMatchAlive`.

### Deliberate shutdowns route through `MatchShutdown`  [FIX]

**What was tried:** A prepared lobby's game server goes away; 15 minutes pass with nobody in it.
**What they expected:** The match is torn down cleanly — summary written, stored label removed, game server told.
**What happened BEFORE this PR:** `return nil` (`server/evr_match.go:1435 @ d3e7e5549` and `:768 @ d3e7e5549`) — same evaporation as above, so the stored match label leaked and the game server was never notified.
**Estimated frequency:** Every "match did not start on time" and every "match is empty" reclaim.
**What happens AFTER this PR:** Both route through `MatchShutdown` (`:1478`, `:809`), which arms `terminateTick` and runs drain → `MatchTerminate`.
**Log signature BEFORE:** `Match did not start on time. Shutting down.` / `Match is empty. Shutting down.` — the message was emitted but the shutdown it claimed never happened.
**Log signature AFTER:** same messages, now followed by `MatchShutdown called.` (`:1747`, Info) and later `MatchTerminate called.` (`:1693`, Debug).
**How to verify in production logs:**
```
grep -A5 'Match did not start on time' /home/echovrce/deployment/logs/nakama.log | grep -c 'MatchShutdown called'
```
**Citation:** `TestMatchLeave_EmptyStartedMatchShutsDownOrderly`, `TestMatchLoop_NeverStartedMatchShutsDownOrderly`.

### A failed `MatchStart` no longer forges `Started()`, and the retry is bounded  [FIX]

This is the fix for the blocking review finding against `4a3f64520`. **The defective intermediate state was never merged or deployed.**

**What was tried:** A game server session dies without a clean presence-leave (node partition, dropped socket), so `state.server` stays set while every dispatch to it fails.
**What they expected:** The match gives up and tears down cleanly.
**What happened BEFORE this PR (at base `d3e7e5549`):** `MatchLoop` did `return nil` on the start failure (`server/evr_match.go:1443 @ d3e7e5549`) — the handler `Stop()`s with no `MatchTerminate`. **In the intermediate commit `4a3f64520`:** worse. `MatchStart` mutated the caller's label *before* the dispatch that fails — `state.GameState` and `state.StartTime = time.Now().UTC()` (`server/evr_match.go:2098-2107 @ d3e7e5549`) — while `state.levelLoaded = true` was set only *after* a successful dispatch (`:2149 @ d3e7e5549`). A failed start therefore left `Started() == true` (`server/evr_match_label.go:321-323`) with `levelLoaded == false`, which:
  - permanently disabled the 15-minute "did not start on time" reclaim, since it requires `!state.Started()` (`:1476`);
  - made the start branch's guard `!levelLoaded && server != nil && (len(presenceMap) != 0 || Started())` true forever — and that branch `return`s above every idle timer, so `emptyTicks`/`noServerTicks`/`unallocatedTicks` could never fire;
  - re-dispatched `LobbySessionCreate` + legacy `GameServerSessionStart`, bumped `match_start_count`, pushed `StartTime` forward and rebuilt `SessionScoreboard` (resetting the round clock) at the 10 Hz tick rate, forever.

Reproduced against the reviewed HEAD before fixing (new tests run against a tree whose `evr_match.go` is the pre-fix file):
```
--- FAIL: TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly
    evr_match_start_retry_test.go:173: a permanently failing MatchStart was never reclaimed: after 200 ticks
    the loop had re-dispatched the start 200 times, startAttempts=0, and no timer can ever fire because the
    start branch returns above all of them
--- FAIL: TestMatchLoop_FailedStartRestoresTheDidNotStartOnTimeReclaim
    evr_match_start_retry_test.go:208: a failed start still reports Started(); the 15-minute reclaim below is unreachable
--- FAIL: TestMatchStart_FailedStartDoesNotMutateTheLabel
```
**Estimated frequency:** Unquantified. Never reached production — the trapping behavior existed only in the unmerged `4a3f64520`.
**What happens AFTER this PR:** Three changes.
1. `MatchStart` computes the new `GameState`/`StartTime` into locals and commits them **only after** the dispatch succeeds (`server/evr_match.go:2199` and `:2254-2259`). A failed start leaves the label untouched, so `Started()` stays false, the 15-minute reclaim works again, and a `StartTime` scheduled by the `SignalPrepareSession` case in `MatchSignal` (`:1902`) survives a failed attempt instead of being silently rescheduled to now.
2. `MatchLoop` bounds the retries at `MatchStartMaxAttempts = 15` (`:54`) and throttles them to one per second after the first (`:1506`), then routes to `MatchShutdown` (`:1515`).
3. The throttle divisor is clamped to `>= 1` (`:1495-1498`). `MatchInit` already clamps `tickRate` to 10 when unset, so this is belt-and-braces — but this is now the *first* modulo in `MatchLoop` and its branch returns above the pre-existing ones, so a zero `tickRate` would newly panic here rather than there.

**Log signature BEFORE:** `failed to start session` (Error, `server/evr_match.go:1442 @ d3e7e5549`) — once at base, then the match died silently. In `4a3f64520`: the same line at 10 Hz, unbounded.
**Log signature AFTER:** `failed to start session` at `server/evr_match.go:1513`, now carrying an `attempts` field, at most 15 times per failing match. Then, once, `Match failed to start after repeated attempts. Shutting down.` (Warn, `:1515`), followed by `MatchShutdown called.`
**How to verify in production logs:**
```
grep -c 'Match failed to start after repeated attempts' /home/echovrce/deployment/logs/nakama.log
grep 'failed to start session' /home/echovrce/deployment/logs/nakama.log | tail -20   # now has "attempts":N
```
**Citation:** `TestMatchStart_FailedStartDoesNotMutateTheLabel`, `TestMatchStart_SuccessfulStartCommitsTheLabel`, `TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly`, `TestMatchLoop_FailedStartRestoresTheDidNotStartOnTimeReclaim`.

### `MatchJoin` no longer leaks the `joinTimeMilliseconds` entry the eviction just cleared  [FIX]

**What was tried:** A player reconnects with the same EvrID while their old session is still in the match. `MatchJoinAttempt` evicts the stale session (and now deletes its `joinTimeMilliseconds`, `:433`), then the already-queued `MatchJoin` for that dead session runs.
**What they expected:** The orphan leaves no trace.
**What happened BEFORE this PR:** `MatchJoin` wrote `state.joinTimeMilliseconds[sid]` *before* the presence-map lookup, so the entry the eviction had just deleted was written straight back, then skipped by the `continue`. `MatchLeave` only deletes that key inside `if mp, ok := state.presenceMap[sid]; ok`, so nothing ever removed it — the entry persisted for the life of the match.
**Estimated frequency:** Rare. Requires a same-user duplicate-EvrID eviction to land between the queued `MatchJoinAttempt` and `MatchJoin`, in a mode with a live `SessionScoreboard`.
**What happens AFTER this PR:** The write moved inside the found branch (`server/evr_match.go:661-673`).
**Log signature BEFORE:** `Presence not found in the presence map; skipping join for this session.` (Error, `:658`) — emitted, but the leak was silent.
**Log signature AFTER:** unchanged, same message, same rate.
**How to verify in production logs:** No new signature; the message string and frequency are identical. Only the map write moved.
**Citation:** `TestMatchJoin_OrphanPresenceDoesNotLeakJoinTimeMilliseconds`. Against the pre-fix source:
```
--- FAIL: TestMatchJoin_OrphanPresenceDoesNotLeakJoinTimeMilliseconds
    evr_match_termination_test.go:409: the skipped orphan session left joinTimeMilliseconds=0 behind; nothing will ever delete it
```

### `MatchLeave` checks "the game server left" before "the match is empty"  [FIX]

**What was tried:** A match ends normally: every player leaves, then the game server disconnects.
**What they expected:** The game-server-left path runs — `state.server` cleared, 2s drain grace.
**What happened BEFORE this PR:** The empty-match branch sat above the game-server loop, so the server's own leave hit the empty branch first with `state.server` still set. At base that branch `return nil`ed so nothing happened; once it routed through `MatchShutdown` (`4a3f64520`) it dispatched `LobbySessionEvent CODE_ENDED` to a presence that had already left, armed a 5s grace instead of 2s, stored a label still advertising the game server, and handed `MatchTerminate` a snapshot with a live `serverSessionID`.

Reproduced against the pre-fix source:
```
--- FAIL: TestMatchLeave_GameServerLeavingEmptyMatchClearsServer
    :454: state.server still points at the departed game server; the shutdown will dispatch to a presence that has already left
    :457: drain grace is 50 ticks, want 20 (2s): the game-server-left path uses a 2s grace, the empty-match path 5s
    :461: shutdown broadcast 1 message(s) to the departed game server presence
```
**Estimated frequency:** Every normal end-of-life sequence in which the last player leaves before the game server does.
**What happens AFTER this PR:** The game-server loop is hoisted above the empty check (`server/evr_match.go:786-800`).
**Log signature BEFORE:** `Match is empty. Shutting down.` (Debug) for this sequence.
**Log signature AFTER:** `Server left the match. Shutting down.` (Debug, `:796`) instead. Both are Debug-level, so on a production Info-level logger neither is visible; total volume is unchanged, only which of the two fires.
**How to verify in production logs:** Only at Debug level:
```
grep -c 'Server left the match. Shutting down.' /home/echovrce/deployment/logs/nakama.log
```
should rise, and `Match is empty. Shutting down.` fall by the same amount.
**Citation:** `TestMatchLeave_GameServerLeavingEmptyMatchClearsServer`.

### `MatchShutdown` is idempotent  [FIX]

**What was tried:** A 30-minute arena match ends. The presence map empties, the drain is armed, and then a straggler leave event arrives for a session that is no longer in the presence map (or an operator issues a second `/shutdown` while the match is still draining).
**What they expected:** One shutdown is accounted once.
**What happened BEFORE this PR:** Nothing guarded re-entry. Each additional call re-ran the whole preamble: `match_shutdown_count` +1 again (`:1741`), `lobby_session_duration` recorded again (`:1743`), `AccumulateLeaderboardStat(..., GameServerTimeStatisticsID, time.Since(state.StartTime))` run again (`:1747`) — banking the **full** match duration a second time to the daily, weekly *and* all-time boards — and `terminateTick` pushed further out (`:1752`), delaying teardown.
**Estimated frequency:** Unquantified — every straggler leave on an already-empty started match, and every repeated `SignalShutdown` (`evr_discord_appbot.go:1856`, `evr_match_preemption.go:219`, `evr_runtime_rpc_match.go:324`, `evr_discord_reservation_commands.go:594`) against a draining match. **This one has a data-integrity consequence: game-server uptime leaderboards were inflated.**
**What happens AFTER this PR:** An early return when `state.terminateTick != 0` (`:1734-1738`, rationale comment at `:1725-1733`). Re-arming could only ever *delay* teardown anyway — `MatchLoop`'s primary trigger is "the presence map is empty" (`:1373`), not the deadline.
**Log signature BEFORE:** `MatchShutdown called.` (Info, `:1747`) emitted once per call, i.e. N times for N calls. No indication anything was wrong.
**Log signature AFTER:** `MatchShutdown called.` emits exactly once per match. A **NEW** Debug line covers the suppressed repeats: `MatchShutdown called on a match that is already draining; ignoring.` (`:1743`), carrying a `terminate_tick` field. Debug-level, so invisible on a production Info logger.
**How to verify in production logs:** Count `MatchShutdown called.` per `match_id` — it must now be 1:
```
grep 'MatchShutdown called' /home/echovrce/deployment/logs/nakama.log | grep -oE '"id": ?"[^"]+"' | sort | uniq -c | sort -rn | head
```
Any count > 1 before this PR is a double-banked leaderboard write.
**Citation:** `TestMatchShutdown_IsIdempotent`. With only the guard reverted (rest of the branch intact):
```
--- FAIL: TestMatchShutdown_IsIdempotent
    :549: match_shutdown_count incremented 3 times for one shutdown, want 1
    :552: lobby_session_duration recorded 3 times for one shutdown, want 1
    :555: game-server time was accumulated again on the repeat shutdowns (9 leaderboard writes, want 3):
          each extra accumulation banks the FULL match duration a second time
    :559: the drain deadline was re-armed from 51 to 53; repeated shutdowns must not push teardown further out
```
(3 writes per accumulation = daily + weekly + all-time, `evr_statistics.go:575`.)

### Test-coverage corrections  [NEUTRAL]

No production behavior change; recorded for the reviewer.

- `TestMatchLoop_StartFailureKeepsMatchAlive` (`evr_match_termination_test.go:171`) pins only "a failed start is retryable" and runs a **single** tick, so on its own it would also pass for a match that retries forever — which is exactly how the `4a3f64520` regression stayed green. It now carries a pointer to `TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly`, which pins the other half ("still bounded"). The two together are the contract.
- `TestEvrMatch_MatchLoop` now installs the stub `nk`/`dispatcher` **only** for the `Match did not start on time.` case, which is the one that reaches `MatchShutdown`. The other three cases keep the original nil pair, so the `dispatcher == nil` path in `updateLabel` (`:2313`) stays covered. An earlier draft applied the stubs to all four and quietly dropped that coverage.
- The table case `MatchLoop increments emptyTicks when no broadcaster` is renamed to `MatchLoop increments noServerTicks when no game server`: that fixture has a player in the presence map and no game server, so it is the no-server timer that advances.

---

## Behavior operators should know about

### The 10s no-server reap newly applies to assigned and to occupied matches  [NEUTRAL — but operator-visible]

This is the intended consequence of giving each timer its own counter, and it is the one change that could surprise an operator, so it is called out separately.

**What was tried:** A match's game-server presence disappears while the match is assigned to a lobby, or while players are still in it.
**What happened BEFORE this PR:** Nothing. The `else if` at `server/evr_match.go:1355 @ d3e7e5549` reset the shared counter on every tick in which the match was not "started and empty", so the 10s deadline could not accumulate for an assigned not-started match or for an occupied one. Those matches sat as zombies with no game server to talk to.
**What happens AFTER this PR:** They are reclaimed after 10s via the orderly `MatchShutdown` path.
**Frequency:** Unquantified. In the normal flow this is unreachable: `MatchLeave` sets `state.server = nil` and immediately shuts down (`:796-798`), which arms `terminateTick`, and the `terminateTick != 0` branch (`:1372`) wins over the no-server branch. It bites only when `state.server` becomes nil *without* a game-server `MatchLeave`.
**Log signature AFTER:** `Match has been without a game server for too long. Shutting down.` (Warn, `:1389`) — a Warn that could newly appear at volume on a node restart or a mass game-server reconnect.
**How to verify in production logs:**
```
grep -c 'Match has been without a game server for too long' /home/echovrce/deployment/logs/nakama.log
```
**Citation / correction to the review:** The review characterized this as "every freshly created **parking** match whose game server does not attach within 10s is now torn down — in base this branch was dead for not-started matches." **The parking half is not correct**, and I verified it rather than acting on it. At base, the `UnassignedLobby` branch `return`s (`:1368 @ d3e7e5549`) *before* the reset at `:1355 @ d3e7e5549` that broke the other cases, so parking matches with no server were **already** reaped at exactly 10s. Running the timer table against a clean `d3e7e5549` extract:
```
--- PASS: .../no_server/unassigned_parking_fires_the_10s_no-server_timer      <- already correct at base
--- FAIL: .../no_server/not_started/empty_fires_the_10s_no-server_timer       <- newly live
    :202: match never shut down within 400 iterations; expected shutdown on iteration 101
--- FAIL: TestMatchLoop_OccupancyDoesNotResetTheNoServerTimer                 <- newly live
    :224: no-server shutdown fired on iteration 0, want 101
```
So the newly-live cases are **assigned not-started** and **occupied** matches, not parking matches. No fleet-wide parking reap is introduced by this PR.

---

## Review round 2 — Copilot on `0e9d7017b`

**C1 (`evr_match.go:1501`) — VALID, fixed in `a16d97f7c`.** The `MatchStart` retry gate was
`tick % throttleTicks == 0`, which aligns retries to absolute tick boundaries instead of
enforcing a gap since the last attempt. Reproduced exactly as reported: with `tickRate` 10 a
first attempt at tick 9 was followed by a second at tick 10 — 0.1s, not 1s.

The gate is now `tick - state.lastStartAttemptTick >= throttleTicks`, with the attempt tick
recorded in its own `MatchLabel` field. A dedicated field, not a reused counter: the whole
premise of this PR is that three timers sharing one `emptyTicks` is a bug class, and hanging
the throttle off an existing counter would reintroduce it.
`TestMatchLoop_StartRetryThrottleIsIndependentOfTheIdleTimers`
(`server/evr_match_start_throttle_test.go`) pins that specifically — it fails if the throttle's
bookkeeping is aliased onto `emptyTicks`, `noServerTicks` or `unallocatedTicks`.

RED against `0e9d7017b`:
```
--- FAIL: TestMatchLoop_StartRetryEnforcesMinimumGap
    evr_match_start_throttle_test.go:65: second MatchStart attempt came 1 ticks (0.1s) after
    the first at tick 9; the throttle must enforce at least 10 ticks (1s) between attempts,
    not align them to absolute tick boundaries
```

**C2 (`evr_match.go:1402`) — VALID, fixed in this description.** The code emits
`Unassigned parking match with server has not been allocated. Shutting down.`; three places in
this body quoted it with an extra "a". **The body was wrong, not the code.** That string is
byte-identical to `d3e7e5549:1364` — this PR does not touch it, and the table row correctly
says "Message unchanged". Since the line was dead code at base it has never appeared in a log,
so there is no deployed grep or alert on either spelling to protect; the minimal correct fix is
to make the description match the shipped string rather than churn an untouched source line and
falsify its own "unchanged" claim. All three occurrences now read `with server`.

**Additional mismatch found while re-verifying every log signature in this body (not reported
by Copilot).** The row for `Started match has been empty for too long. Shutting down.` claimed
**Message changed**. It is not changed — that exact string is at `d3e7e5549:1456` and is
byte-identical at HEAD. What this PR changed at that site is the *counter* it reads. The
disambiguation happened on the other site (the no-server `Warn`, which did take a new message).
An operator reading "message changed" would have needlessly updated a working grep. Row
corrected.

Every other `file:line` and log string in this body was re-checked against the tree line by
line; the remaining 19 citations were all correct at `0e9d7017b` and have been renumbered for
the +7-line shift introduced by `a16d97f7c`.

---

## Production log impact

Every production log statement in a touched path, and whether its message, level or frequency changed:

| Message | file:line @ `a16d97f7c` | Change |
|---|---|---|
| `Match has been without a game server for too long. Shutting down.` | `evr_match.go:1389` | **Message changed** (was `Match has been empty for too long...`); level Warn unchanged. Now fires at the correct 10s for started empty matches (was ~5s) and fires at all for assigned not-started / occupied ones (was never). |
| `Started match has been empty for too long. Shutting down.` | `evr_match.go:1536` | **Message unchanged** — this exact string is at `d3e7e5549:1456`; the disambiguation happened on the row above, which took a new message. What changed here is the counter it reads (was the shared `emptyTicks`, now its own). Warn, unchanged. Operator greps on this string keep working. |
| `Unassigned parking match with server has not been allocated. Shutting down.` | `evr_match.go:1402` | Message unchanged. **Newly reachable** — was dead code. Operators will see this for the first time. |
| `failed to start session` | `evr_match.go:1513` | Message and level unchanged. **New `attempts` field.** **Frequency: up to 15 per failing match** (was 1 at base). |
| `Match failed to start after repeated attempts. Shutting down.` | `evr_match.go:1515` | **NEW message**, Warn. At most once per match. |
| `MatchShutdown called on a match that is already draining; ignoring.` | `evr_match.go:1743` | **NEW message**, Debug. Invisible at production Info level. |
| `failed to update label after leave` | `evr_match.go:1231` | **Message changed** (was `failed to update label`); Error. Frequency unchanged. |
| `failed to update label on shutdown` | `evr_match.go:1766` | **Message changed** (was `failed to update label`); Error. Frequency unchanged. |
| `failed to update label` | `evr_match.go:1526`, `:1678` | Unchanged message/level/frequency (post-`MatchStart` and `MatchLoop`-tail sites). |
| `Presence not found in the presence map; skipping join for this session.` | `evr_match.go:658` | **Message changed** (was `Presence not found. this should never happen.`); Error, same frequency. |
| `Server left the match. Shutting down.` | `evr_match.go:796` | Message/level unchanged. **Frequency up** — now also covers the empty-match-then-server-leaves sequence. |
| `Match is empty. Shutting down.` | `evr_match.go:808` | Message/level unchanged. **Frequency down** by the same amount. |
| `Match did not start on time. Shutting down.` | `evr_match.go:1477` | Unchanged message. **Newly reachable again** after the `Started()` fix. |
| `MatchShutdown called.` | `evr_match.go:1747` | Unchanged message/level. **Frequency now exactly 1 per match** (was N for N calls). |
| `MatchTerminate called.` | `evr_match.go:1693` | Unchanged. Frequency up: reclaim paths that used to `return nil` now genuinely reach it. |

How I checked: `git diff d3e7e5549 -- server/evr_match.go server/evr_match_label.go | grep -E '^[+-].*(logger\.|\.Debug\(|\.Info\(|\.Warn\(|\.Error\()'` over the production (non-test) files — the table above is the complete set of hits. No other production log statement in these files was touched.

**Metrics:**
- `match_start_count` (`evr_match.go:2255`) is still incremented per *attempt*, so a match that fails to start now contributes up to 15 instead of 1.
- `match_shutdown_count` and `lobby_session_duration` are now emitted **exactly once** per match. Dashboards that summed them may show a small step **down** where straggler leaves previously double-counted.
- `match_terminate_count` rises: reclaim paths that previously evaporated the match now reach `MatchTerminate`.
- `GameServerTimeStatisticsID` leaderboard values stop being double-banked. **Historical game-server uptime totals are inflated by the old behavior and are not corrected by this PR.**

---

## What does NOT change

- **Cross-guild matchmaking.** No matchmaking path is touched. `git diff d3e7e5549 -- server/ | grep -E "^\+" | grep -iE "uuid\.Nil|GroupID|Matchmak"` yields only test fixtures: `uuid.Must(uuid.NewV4())` group IDs and `uuid.NewV5(uuid.Nil, "…")` namespace arguments. No `GroupID = uuid.Nil` anywhere.
- **The normal start path timing.** The retry throttle is `state.startAttempts == 0 || tick%throttleTicks == 0` (`:1499`), so the *first* attempt always runs on the tick the match becomes eligible — no added latency. Pinned by `TestMatchStart_SuccessfulStartCommitsTheLabel`.
- **Scheduled start times.** The `SignalPrepareSession` case in `MatchSignal` (`:1902`) and `SignalStartSession` (`:2023`) set `StartTime` themselves; deferring `MatchStart`'s commit preserves their value across a failed attempt rather than clobbering it. Asserted directly in `TestMatchStart_FailedStartDoesNotMutateTheLabel`.
- **`return nil` as the type guard.** Still present and correct at `:631, :760, :1242, :1683, :1723` (`state not a valid lobby state object`) and `:1716` (`MatchTerminate`'s terminal return). Verified by inspecting each site.
- **The 60s started-and-empty deadline** and **the 15-minute never-started deadline** keep their nominal values; only their reachability was restored.
- **`startAttempts` never needs resetting.** `levelLoaded` is write-once (`grep -n levelLoaded server/evr_match.go` → the only assignment is `:2266`, to `true`), so once a start succeeds the retry branch is unreachable for the life of the match.
- **Early-quit gating / refusal logic.** Untouched — that is `fix/earlyquit-penalty-state`'s territory.

## Review findings determined NOT to be real

- **`nk.(*RuntimeGoNakamaModule)` assertions in `evr_match.go`.** Reported as a defect; it does not exist. `git grep -n "RuntimeGoNakamaModule)" d3e7e5549 -- server/evr_match.go` returns only the explanatory comment at `:56`. No code change made.
- **"Every freshly created parking match … is now torn down."** Half-refuted; see "Behavior operators should know about" above for the evidence. Base already reaped serverless parking matches at 10s. No change made on this basis.
- **"`AccumulateLeaderboardStat` is a *newly* reachable synchronous DB write from `MatchLeave`."** Real but pre-existing in this branch, and now bounded to one call per match by the idempotency guard. It was reachable from `MatchLeave` the moment the empty branch started routing through `MatchShutdown`; the guard removes the *repeat* writes, which were the compounding risk. Left as-is beyond that: moving the write off the handler goroutine is a larger change than this cluster warrants.

## Follow-ups (not fixed here — out of scope)

- `MatchJoin` still deletes the orphan's `TeamAlignments` entry before the presence-map check (`evr_match.go:640-644`, the `switch state.Mode` at `:641-643`). Benign in practice: the eviction is same-user, and the surviving session deletes the same key. Left alone deliberately to keep the diff minimal.
- `AccumulateLeaderboardStat` in `MatchShutdown` (`:1747`) is a synchronous DB write with a 5s `dbCtx` on the match-handler goroutine. Under a DB stall it can block the handler and trip `queueCall`'s "call processing too slow, closing match" path. Now at most once per match, but still on the hot goroutine. Worth moving into `enqueueMatchTerminationTask`.
- Historical `GameServerTimeStatisticsID` leaderboard values are inflated by the pre-fix double-banking. No backfill/correction is attempted here.
- `TestMatchLoop_ParkingMatchCounterDoesNotOscillate` asserts on the unexported `state.unallocatedTicks`. Deliberate white-box pin on the counter split; the user-visible contract is separately covered by the `server/unassigned parking fires the 120s unallocated timer` table case.
- The `no_server/unassigned parking` table case also passes against the pre-fix shared counter. Kept as a plain regression pin and annotated as such inline (`evr_match_empty_ticks_test.go:154-157`).

## Verification

Re-run at `a16d97f7c` (clean tree, `git status` → `nothing to commit, working tree clean`).
The `0e9d7017b` run this section previously carried is superseded.

```
$ GOWORK=off go build ./server/...
BUILD OK

$ GOWORK=off go vet ./server/...
VET OK

$ GOWORK=off go test ./server/... -count=1
ok  	github.com/heroiclabs/nakama/v3/server	122.538s
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
FAIL	github.com/heroiclabs/nakama/v3/server/evr	0.014s

$ GOWORK=off go test -race ./server/ -run 'Match|Latency|Tick|Lifecycle' -count=1
ok  	github.com/heroiclabs/nakama/v3/server	92.991s

$ gofmt -l server/evr_match.go server/evr_match_label.go server/evr_match_start_throttle_test.go
(no output — clean)
```

**`server/evr` is RED, and it is not this branch's fault.** `TestStatisticsGroup_MarshalText`
compares a UTC-derived period key against a locally-derived one and fails whenever the machine's
local date is behind UTC's — the run above was at 19:56 CDT, i.e. already 2026-08-06 in UTC. It
fails identically on the untouched base:

```
$ cd <clean d3e7e5549 extract> && GOWORK=off go test ./server/evr/ -run TestStatisticsGroup_MarshalText -count=1
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
FAIL	github.com/heroiclabs/nakama/v3/server/evr	0.005s
```

Out of scope for this PR (it touches neither `server/evr` nor any date handling) and left
unfixed rather than papered over. `server/...` is otherwise green.

Baseline comparison — the same full suite against a clean `git archive d3e7e5549` extract:
```
$ cd /tmp/mlv/pure && GOWORK=off go test ./server/... -count=1
ok  	github.com/heroiclabs/nakama/v3/server	125.172s
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.020s
BASE_EXIT=0
```
Both green. **No new failures versus base.**

### Non-vacuity

Every new test was run against a tree containing the new tests over the *pre-fix* `server/evr_match.go`, to confirm it actually fails without the fix:

```
=== new tests vs the pre-fix source ===
--- FAIL: TestMatchStart_FailedStartDoesNotMutateTheLabel
--- PASS: TestMatchStart_SuccessfulStartCommitsTheLabel        (regression pin — passes both ways by design)
--- FAIL: TestMatchLoop_FailedStartIsBoundedAndShutsDownOrderly
--- FAIL: TestMatchLoop_FailedStartRestoresTheDidNotStartOnTimeReclaim
--- PASS: TestMatchLoop_PostStartLabelUpdateFailureKeepsMatchAlive  (fixed by the earlier 4a3f64520; RED vs base)
--- FAIL: TestMatchJoin_OrphanPresenceDoesNotLeakJoinTimeMilliseconds
--- FAIL: TestMatchLeave_GameServerLeavingEmptyMatchClearsServer
--- FAIL: TestMatchShutdown_IsIdempotent                       (guard-only revert)
```

Round-2 tests, against the pre-fix `tick % throttleTicks == 0` gate:
```
--- FAIL: TestMatchLoop_StartRetryEnforcesMinimumGap
--- PASS: TestMatchLoop_StartRetryThrottleIsIndependentOfTheIdleTimers   (aliasing guard)
```
and, perturbing the fixed gate to alias its bookkeeping onto `emptyTicks` (the shared-counter
bug this PR exists to remove):
```
--- FAIL: TestMatchLoop_StartRetryThrottleIsIndependentOfTheIdleTimers
    evr_match_start_throttle_test.go:96: emptyTicks=1 after a start attempt; the start
    throttle must not share a counter with the empty-match timer
```
Both perturbations reverted; the tree is back to `a16d97f7c`.
and the timer-table tests against a clean `d3e7e5549` extract (quoted in full in the first section): 3 of the 6 table cases plus both standalone counter tests go RED. The 3 that pass both ways (`no_server/unassigned` 10s, `server/started/empty` 60s, `server/started/occupied` never) are deliberate regression pins, not vacuous assertions.

## Concurrent Tier-1 PRs touching these files

`fix/security-join-gates` and `fix/concurrency-locking` also touch `server/evr_match.go`; `fix/assorted-one-offs` may touch `server/evr_match_label.go`. The other branches in the stack are `fix/earlyquit-penalty-state`, `fix/storage-occ-retry` and `fix/discord-prune-safety`. Expect conflicts in the `MatchLoop` tail (`:1372-1540`), the `MatchLeave` head (`:786-810`), the `MatchShutdown` preamble (`:1725-1767`) and the `MatchLabel` unexported-field block (`evr_match_label.go:65-83`).

## Note on how this branch was produced

An earlier revision of this PR body carried an "environment note" claiming a foreign process had written uncommitted changes into this worktree (a `MatchShutdown` idempotency guard, `TestMatchShutdown_IsIdempotent`, and `stubRuntime` edits) and that they belonged to a sibling PR. **That attribution was wrong** — those were this branch's own in-progress review fixes, and they are now committed as `0e9d7017b`. The note is retracted. The related "known nit" is also resolved: the stale `(:1893-1897)` line reference in the `MatchStart` comment was replaced with a name-based reference to the `SignalPrepareSession` case, and that correction is in `0e9d7017b`.

