### PR TITLE
fix(earlyquit): penalty-ladder totality, moderator sanctions as a floor, and atomic completion credit

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2834,17 +2834,13 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 				lockoutDuration = GetLockoutDuration(int(penaltyLevel))
 			}
 
-			config.PenaltyLevel = int32(penaltyLevel)
-
-			// Set the absolute lockout expiry timestamp. Without it a zero ts
-			// makes the scheduler treat the lockout as instantly expired on
-			// its next tick and IsPenaltyActive() report no active lockout.
-			if penaltyLevel > 0 {
-				config.PenaltyTimestamp = time.Now().Unix() + int64(lockoutDuration.Seconds())
-			} else {
-				// Level 0 = penalty cleared.
-				config.PenaltyTimestamp = 0
-			}
+			// Record it as a moderator-applied sanction. This sets the absolute
+			// lockout expiry timestamp — without it a zero ts makes the
+			// scheduler treat the lockout as instantly expired on its next tick
+			// and IsPenaltyActive() report no active lockout — and marks the
+			// penalty manual so the player's next early quit cannot erase it by
+			// re-resolving the quit-count ladder. Level 0 clears the penalty.
+			config.ApplyModeratorPenalty(int32(penaltyLevel), clampLockoutSec(int(lockoutDuration.Seconds())))
 
 			if err := StorableWrite(ctx, nk, targetUserID, config); err != nil {
 				return editInteractionResponse(s, i, fmt.Sprintf("Failed to save early quit config: %v", err))

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -58,6 +58,14 @@ type EarlyQuitPlayerState struct {
 	PenaltyLevel        int32 `json:"penalty_level"`          // Resolved from config (clamped uint8)
 	SteadyPlayerLevel   int32 `json:"steady_player_level"`    // Resolved from config (clamped uint8)
 
+	// PenaltyIsManual marks PenaltyLevel/PenaltyTimestamp as a
+	// moderator-applied sanction rather than a value derived from the
+	// quit-count ladder. While it is set and the lockout has not expired,
+	// ladder resolution must not lower or erase the penalty — otherwise the
+	// sanctioned player's very next early quit wipes the sanction, because one
+	// quit maps to ladder level 0 and level 0 clears the lockout.
+	PenaltyIsManual bool `json:"penalty_is_manual,omitempty"`
+
 	// Nakama extensions (kept for matchmaker/UI compat)
 	TotalCompletedMatches      int32     `json:"total_completed_matches"`
 	MatchmakingTier            int32     `json:"matchmaking_tier"`
@@ -168,21 +176,49 @@ func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int
 	return 0, 0
 }
 
+// ApplyModeratorPenalty records a moderator-applied sanction: the penalty level,
+// its absolute expiry, and the marker that keeps quit-count ladder resolution
+// from lowering or erasing it while it is in force. A lockoutSec of zero or less
+// means "penalty cleared", which also clears the marker.
+func (s *EarlyQuitPlayerState) ApplyModeratorPenalty(level int32, lockoutSec int32) {
+	s.Lock()
+	defer s.Unlock()
+	s.PenaltyLevel = level
+	if level > 0 && lockoutSec > 0 {
+		s.PenaltyTimestamp = time.Now().Unix() + int64(lockoutSec)
+		s.PenaltyIsManual = true
+	} else {
+		s.PenaltyTimestamp = 0
+		s.PenaltyIsManual = false
+	}
+}
+
 // resolveAndApplyPenaltyLockout resolves the penalty level from the STORED
 // early quit service config (EarlyQuit|config under SystemUserID) and applies
-// the resulting lockout to eqconfig. Call it after IncrementEarlyQuit() so the
-// new quit count is reflected. When the count maps to a level with no lockout
-// (level 0), any stale PenaltyLevel/PenaltyTimestamp are cleared to zero.
+// the resulting lockout to eqconfig. Call it after IncrementEarlyQuit() (or
+// after ForgiveLastQuit()) so the new quit count is reflected. When the count
+// maps to a level with no lockout (level 0), any stale
+// PenaltyLevel/PenaltyTimestamp are cleared to zero.
+//
+// A moderator-applied sanction that has not expired is left alone: the ladder
+// must not shorten or erase it. The ladder still wins when it resolves to a
+// strictly harsher level, so a sanctioned player who keeps quitting is not
+// insulated by their sanction.
 func resolveAndApplyPenaltyLockout(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, eqconfig *EarlyQuitPlayerState) {
 	config := LoadEarlyQuitServiceConfig(ctx, nk, logger)
 	level, lockoutSec := ResolvePenaltyLevel(eqconfig.NumEarlyQuits, config)
+	now := time.Now().Unix()
+	if eqconfig.PenaltyIsManual && eqconfig.PenaltyTimestamp > now && eqconfig.PenaltyLevel >= level {
+		return
+	}
 	if lockoutSec > 0 {
 		eqconfig.PenaltyLevel = level
-		eqconfig.PenaltyTimestamp = time.Now().Unix() + int64(lockoutSec)
+		eqconfig.PenaltyTimestamp = now + int64(lockoutSec)
 	} else {
 		eqconfig.PenaltyLevel = 0
 		eqconfig.PenaltyTimestamp = 0
 	}
+	eqconfig.PenaltyIsManual = false
 }
 
 // ResolveSteadyPlayerLevel determines the steady player level from the config.

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"math"
 	"sync"
 	"time"
 
@@ -113,23 +114,57 @@ func (s *EarlyQuitPlayerState) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// clampLockoutSec converts a config-supplied lockout (a 64-bit `int` read from
+// stored JSON) to the int32 the penalty state carries, saturating instead of
+// wrapping. Wrapping is not a theoretical concern: every caller gates on
+// `lockoutSec > 0`, so 2^31 (which wraps negative) and 2^32 (which wraps to
+// zero) would both take the CLEAR branch and silently disable the very penalty
+// the config asked to lengthen. Stored configs are not re-validated on read,
+// so this is the only place the bound is enforced.
+func clampLockoutSec(sec int) int32 {
+	if sec <= 0 {
+		return 0
+	}
+	if sec > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(sec)
+}
+
 // ResolvePenaltyLevel determines the penalty level and lockout duration from the
 // config's penalty_levels array, matching the binary's algorithm: find the first
 // level where numQuits >= min AND numQuits <= max.
+//
+// Resolution is total: a quit count that lands in no band (the ladder may have
+// gaps, and its first band need not start at 0 — validatePenaltyLevels closes
+// overlaps but not gaps) resolves to the highest band whose floor the count has
+// already reached, and to no penalty at all when it is below every band. Only a
+// count ABOVE every band gets the top level.
 func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int32, lockoutSec int32) {
 	if cfg == nil {
 		return 0, 0
 	}
+	var (
+		bestLevel   int32
+		bestLockout int32
+		bestMin     int
+		found       bool
+	)
 	for _, pl := range cfg.PenaltyLevels {
 		if int(numQuits) >= pl.MinEarlyQuits && int(numQuits) <= pl.MaxEarlyQuits {
-			return int32(pl.PenaltyLevel), int32(pl.MMLockoutSec)
+			return int32(pl.PenaltyLevel), clampLockoutSec(pl.MMLockoutSec)
+		}
+		// Not in this band. Remember it if the count has cleared its floor:
+		// it is the candidate for a count that sits in a gap above it or
+		// beyond the end of the ladder.
+		if int(numQuits) > pl.MaxEarlyQuits && (!found || pl.MinEarlyQuits >= bestMin) {
+			bestLevel, bestLockout, bestMin, found = int32(pl.PenaltyLevel), clampLockoutSec(pl.MMLockoutSec), pl.MinEarlyQuits, true
 		}
 	}
-	// If no level matches (quit count above all ranges), use the highest level
-	if len(cfg.PenaltyLevels) > 0 {
-		last := cfg.PenaltyLevels[len(cfg.PenaltyLevels)-1]
-		return int32(last.PenaltyLevel), int32(last.MMLockoutSec)
+	if found {
+		return bestLevel, bestLockout
 	}
+	// Below every configured band: no penalty.
 	return 0, 0
 }
 

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -58,13 +58,23 @@ type EarlyQuitPlayerState struct {
 	PenaltyLevel        int32 `json:"penalty_level"`          // Resolved from config (clamped uint8)
 	SteadyPlayerLevel   int32 `json:"steady_player_level"`    // Resolved from config (clamped uint8)
 
-	// PenaltyIsManual marks PenaltyLevel/PenaltyTimestamp as a
-	// moderator-applied sanction rather than a value derived from the
-	// quit-count ladder. While it is set and the lockout has not expired,
-	// ladder resolution must not lower or erase the penalty — otherwise the
-	// sanctioned player's very next early quit wipes the sanction, because one
-	// quit maps to ladder level 0 and level 0 clears the lockout.
-	PenaltyIsManual bool `json:"penalty_is_manual,omitempty"`
+	// ModeratorPenaltyLevel/ModeratorPenaltyUntil record a moderator-applied
+	// sanction SEPARATELY from the effective penalty above. The effective
+	// penalty is always the harsher of the quit-count ladder's result and an
+	// unexpired sanction, recomputed from both on every resolution.
+	//
+	// Keeping the sanction in its own fields is what makes that recomputation
+	// total. Marking the effective fields "manual" with a bool instead would
+	// conflate the two: once a ladder result raised the level or extended the
+	// expiry, there would be nothing left to compare against, so the raised
+	// value would ratchet — the player would keep serving the harsher of every
+	// penalty they had ever accrued for as long as the sanction ran.
+	//
+	// Without any of this, the sanctioned player's very next early quit wipes
+	// the sanction, because one quit maps to ladder level 0 and level 0 clears
+	// the lockout.
+	ModeratorPenaltyLevel int32 `json:"moderator_penalty_level,omitempty"`
+	ModeratorPenaltyUntil int64 `json:"moderator_penalty_until,omitempty"`
 
 	// Nakama extensions (kept for matchmaker/UI compat)
 	TotalCompletedMatches      int32     `json:"total_completed_matches"`
@@ -176,21 +186,34 @@ func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int
 	return 0, 0
 }
 
-// ApplyModeratorPenalty records a moderator-applied sanction: the penalty level,
-// its absolute expiry, and the marker that keeps quit-count ladder resolution
-// from lowering or erasing it while it is in force. A lockoutSec of zero or less
-// means "penalty cleared", which also clears the marker.
+// ApplyModeratorPenalty records a moderator-applied sanction: it becomes the
+// effective penalty immediately AND is retained in its own fields so that
+// quit-count ladder resolution cannot afterwards lower or shorten it while it
+// is in force. A lockoutSec of zero or less means "no lockout", which retains
+// nothing — there is no sanction to protect.
 func (s *EarlyQuitPlayerState) ApplyModeratorPenalty(level int32, lockoutSec int32) {
 	s.Lock()
 	defer s.Unlock()
 	s.PenaltyLevel = level
 	if level > 0 && lockoutSec > 0 {
 		s.PenaltyTimestamp = time.Now().Unix() + int64(lockoutSec)
-		s.PenaltyIsManual = true
+		s.ModeratorPenaltyLevel = level
+		s.ModeratorPenaltyUntil = s.PenaltyTimestamp
 	} else {
 		s.PenaltyTimestamp = 0
-		s.PenaltyIsManual = false
+		s.ModeratorPenaltyLevel = 0
+		s.ModeratorPenaltyUntil = 0
 	}
+}
+
+// ClearModeratorPenalty drops any retained moderator sanction. Call it when the
+// player's record is reset: leaving the sanction behind would keep blocking
+// ladder resolution for the rest of its original lockout.
+func (s *EarlyQuitPlayerState) ClearModeratorPenalty() {
+	s.Lock()
+	defer s.Unlock()
+	s.ModeratorPenaltyLevel = 0
+	s.ModeratorPenaltyUntil = 0
 }
 
 // resolveAndApplyPenaltyLockout resolves the penalty level from the STORED
@@ -200,25 +223,50 @@ func (s *EarlyQuitPlayerState) ApplyModeratorPenalty(level int32, lockoutSec int
 // maps to a level with no lockout (level 0), any stale
 // PenaltyLevel/PenaltyTimestamp are cleared to zero.
 //
-// A moderator-applied sanction that has not expired is left alone: the ladder
-// must not shorten or erase it. The ladder still wins when it resolves to a
-// strictly harsher level, so a sanctioned player who keeps quitting is not
-// insulated by their sanction.
+// An unexpired moderator sanction is a FLOOR in both dimensions: the ladder may
+// raise the level or extend the expiry, never lower or shorten either. Without
+// the expiry half of that floor the direction is perverse — a player under a
+// long, light sanction shortens it by quitting more, because the harsher ladder
+// level also brings the ladder's much shorter lockout with it.
 func resolveAndApplyPenaltyLockout(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, eqconfig *EarlyQuitPlayerState) {
-	config := LoadEarlyQuitServiceConfig(ctx, nk, logger)
-	level, lockoutSec := ResolvePenaltyLevel(eqconfig.NumEarlyQuits, config)
-	now := time.Now().Unix()
-	if eqconfig.PenaltyIsManual && eqconfig.PenaltyTimestamp > now && eqconfig.PenaltyLevel >= level {
-		return
-	}
+	eqconfig.applyLadderPenalty(LoadEarlyQuitServiceConfig(ctx, nk, logger), time.Now().Unix())
+}
+
+// applyLadderPenalty recomputes the effective penalty from the quit-count ladder
+// and any unexpired moderator sanction. It is the whole of
+// resolveAndApplyPenaltyLockout's logic, split out so it can be exercised
+// without a storage round trip and so the mutation happens under the state's
+// own lock.
+func (s *EarlyQuitPlayerState) applyLadderPenalty(cfg *evr.SNSEarlyQuitConfig, now int64) {
+	s.Lock()
+	defer s.Unlock()
+
+	level, lockoutSec := ResolvePenaltyLevel(s.NumEarlyQuits, cfg)
+	var expiry int64
 	if lockoutSec > 0 {
-		eqconfig.PenaltyLevel = level
-		eqconfig.PenaltyTimestamp = now + int64(lockoutSec)
+		expiry = now + int64(lockoutSec)
 	} else {
-		eqconfig.PenaltyLevel = 0
-		eqconfig.PenaltyTimestamp = 0
+		// A level carrying no lockout is no penalty at all.
+		level = 0
 	}
-	eqconfig.PenaltyIsManual = false
+
+	if s.ModeratorPenaltyUntil > now {
+		// Both floors come from the SANCTION, never from the currently stored
+		// penalty: comparing against the stored value would let a ladder result
+		// that has since lapsed ratchet the sanction permanently upward.
+		if level < s.ModeratorPenaltyLevel {
+			level = s.ModeratorPenaltyLevel
+		}
+		if expiry < s.ModeratorPenaltyUntil {
+			expiry = s.ModeratorPenaltyUntil
+		}
+	} else {
+		s.ModeratorPenaltyLevel = 0
+		s.ModeratorPenaltyUntil = 0
+	}
+
+	s.PenaltyLevel = level
+	s.PenaltyTimestamp = expiry
 }
 
 // ResolveSteadyPlayerLevel determines the steady player level from the config.

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -137,8 +137,16 @@ func (s *EarlyQuitPlayerState) UnmarshalJSON(data []byte) error {
 // wrapping. Wrapping is not a theoretical concern: every caller gates on
 // `lockoutSec > 0`, so 2^31 (which wraps negative) and 2^32 (which wraps to
 // zero) would both take the CLEAR branch and silently disable the very penalty
-// the config asked to lengthen. Stored configs are not re-validated on read,
-// so this is the only place the bound is enforced.
+// the config asked to lengthen.
+//
+// Validation does not cover this. LoadEarlyQuitServiceConfig DOES re-validate a
+// stored config on the read-success path (evr_early_quit_message_trigger.go, the
+// `config.Validate()` after the blank-config fill-in), but validatePenaltyLevels
+// bounds MMLockoutSec only from BELOW — `if level.MMLockoutSec < 0 { … = 0 }` in
+// server/evr/login_earlyquitconfig.go — and imposes no upper bound anywhere. The
+// admin RPC's own loader, loadEarlyQuitServiceConfigOrDefault in
+// evr_runtime_rpc_earlyquit_manage.go, skips Validate entirely. So this is the
+// only place the upper bound is enforced on either path.
 func clampLockoutSec(sec int) int32 {
 	if sec <= 0 {
 		return 0
@@ -155,9 +163,19 @@ func clampLockoutSec(sec int) int32 {
 //
 // Resolution is total: a quit count that lands in no band (the ladder may have
 // gaps, and its first band need not start at 0 — validatePenaltyLevels closes
-// overlaps but not gaps) resolves to the highest band whose floor the count has
-// already reached, and to no penalty at all when it is below every band. Only a
-// count ABOVE every band gets the top level.
+// overlaps but not gaps) resolves to the band with the highest FLOOR among those
+// the count has cleared ENTIRELY, i.e. those whose ceiling it is already above
+// (`numQuits > MaxEarlyQuits`, the condition below). It resolves to no penalty
+// at all when it has cleared no band. Only a count ABOVE every band gets the top
+// level.
+//
+// "Cleared entirely" and "reached the floor" coincide for every well-formed band,
+// since Min <= Max makes numQuits > Max imply numQuits >= Min. They diverge only
+// for an inverted Min > Max band, which validatePenaltyLevels swaps back
+// (server/evr/login_earlyquitconfig.go) — but the admin RPC's
+// loadEarlyQuitServiceConfigOrDefault does not call Validate, so an inverted band
+// can still reach this function from evr_runtime_rpc_earlyquit_manage.go. The
+// ceiling test is the operative one; prefer it when reasoning about that case.
 func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int32, lockoutSec int32) {
 	if cfg == nil {
 		return 0, 0

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -505,7 +505,15 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 	// Reduce early quit penalty by one level without inflating match completion statistics.
 	// This forgives the early quit since the player logged out entirely rather than
 	// just leaving the match to join another.
+	oldPenaltyLevel := eqconfig.GetPenaltyLevel()
 	eqconfig.ForgiveLastQuit()
+
+	// Re-resolve the lockout from the reduced quit count. ForgiveLastQuit only
+	// touches the counters and leaves PenaltyLevel/PenaltyTimestamp to the
+	// caller; without this the forgiven player keeps serving the full lockout
+	// the forgiven quit caused, and UpdateTier below reads a stale penalty
+	// level so the tier never recovers.
+	resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
 
 	// Check if tier should be updated after penalty reduction
 	serviceSettings := ServiceSettings()
@@ -522,7 +530,7 @@ func CheckAndStrikeEarlyQuitIfLoggedOut(ctx context.Context, logger runtime.Logg
 
 	logger.WithFields(map[string]any{
 		"uid":               userID,
-		"old_penalty_level": eqconfig.GetPenaltyLevel() + 1, // +1 because we just decremented it
+		"old_penalty_level": oldPenaltyLevel,
 		"new_penalty_level": eqconfig.GetPenaltyLevel(),
 		"old_tier":          oldTier,
 		"new_tier":          newTier,

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -209,15 +209,34 @@ func ResolvePenaltyLevel(numQuits int32, cfg *evr.SNSEarlyQuitConfig) (level int
 // quit-count ladder resolution cannot afterwards lower or shorten it while it
 // is in force. A lockoutSec of zero or less means "no lockout", which retains
 // nothing — there is no sanction to protect.
+//
+// A level with no lockout clears the level too, exactly as applyLadderPenalty
+// does ("A level carrying no lockout is no penalty at all"). Setting the level
+// while zeroing the expiry left a penalty nothing could lift: the level alone
+// governs UpdateTier and the client profile's EarlyQuitFeatures.PenaltyLevel,
+// neither of which consults the timestamp, while IsPenaltyActive() reported no
+// penalty. Since the completion paths (evr_match.go's MatchOver,
+// EventRemoteLogSet.incrementCompletedMatches) call UpdateTier WITHOUT
+// re-resolving the level first, that phantom put the player in the Tier 2 queue
+// and sent the "flagged for early quitting" DM permanently — "complete full
+// matches to restore Tier 1 status" could never come true, because completing
+// matches never recomputes the level.
+//
+// This does not discard the moderator's request. The one reachable caller,
+// earlyquit/modify's set_penalty action, records the requested level in the
+// guild override (GuildOverrides[groupID].PenaltyLevel) before calling here, and
+// reports the resulting state — PenaltyLevel alongside PenaltyActive — straight
+// back to the moderator.
 func (s *EarlyQuitPlayerState) ApplyModeratorPenalty(level int32, lockoutSec int32) {
 	s.Lock()
 	defer s.Unlock()
-	s.PenaltyLevel = level
 	if level > 0 && lockoutSec > 0 {
+		s.PenaltyLevel = level
 		s.PenaltyTimestamp = time.Now().Unix() + int64(lockoutSec)
 		s.ModeratorPenaltyLevel = level
 		s.ModeratorPenaltyUntil = s.PenaltyTimestamp
 	} else {
+		s.PenaltyLevel = 0
 		s.PenaltyTimestamp = 0
 		s.ModeratorPenaltyLevel = 0
 		s.ModeratorPenaltyUntil = 0

--- a/server/evr_earlyquit_completion_credit_test.go
+++ b/server/evr_earlyquit_completion_credit_test.go
@@ -67,6 +67,14 @@ func (m *completionTestNK) StorageWrite(ctx context.Context, writes []*runtime.S
 	return m.evrTestNakamaModule.StorageWrite(ctx, writes)
 }
 
+// MultiUpdate is the entry point StorableWriteMany actually calls. The atomic
+// completion path carries storage writes only, so it routes through the same
+// whole-batch validation and fault injection as StorageWrite above.
+func (m *completionTestNK) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	acks, err := m.StorageWrite(ctx, storageWrites)
+	return acks, nil, err
+}
+
 // storedCompletionState reads back the player's counter and history.
 func storedCompletionState(t *testing.T, ctx context.Context, nk runtime.NakamaModule, userID string) (*EarlyQuitPlayerState, *EarlyQuitHistory) {
 	t.Helper()

--- a/server/evr_earlyquit_completion_credit_test.go
+++ b/server/evr_earlyquit_completion_credit_test.go
@@ -1,0 +1,252 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// completionTestNK adds two things the shared in-memory double does not model,
+// both of which the completion-credit paths depend on:
+//
+//  1. ATOMICITY. Real Nakama runs a multi-object StorageWrite inside one
+//     database transaction (StorageWriteObjects wraps storageWriteObjects in
+//     ExecuteInTxPgx), so a version rejection on ANY object rolls the whole
+//     batch back. The shared double applies writes one at a time and returns on
+//     the first conflict, which would let a partially-applied batch through.
+//     This wrapper validates every write up front and delegates only when the
+//     entire batch is admissible.
+//
+//  2. FAULT INJECTION. beforeWrite runs just before a batch is admitted, so a
+//     test can deterministically stage the "someone else got there first"
+//     interleaving without goroutines: it can seed a row, or reject the batch.
+type completionTestNK struct {
+	*evrTestNakamaModule
+
+	// beforeWrite is called with each batch before it is validated. Returning
+	// a non-nil error rejects the whole batch, applying nothing.
+	beforeWrite func(writes []*runtime.StorageWrite) error
+}
+
+func newCompletionTestNK() *completionTestNK {
+	return &completionTestNK{evrTestNakamaModule: newEvrTestNakamaModule()}
+}
+
+func (m *completionTestNK) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	if m.beforeWrite != nil {
+		if err := m.beforeWrite(writes); err != nil {
+			return nil, err
+		}
+	}
+
+	// Validate the whole batch before any of it is applied.
+	m.mu.Lock()
+	for _, w := range writes {
+		existing, ok := m.objects[occStorageKey(w.UserID, w.Collection, w.Key)]
+		switch w.Version {
+		case "":
+			// Unconditional.
+		case "*":
+			if ok {
+				m.mu.Unlock()
+				return nil, runtime.ErrStorageRejectedVersion
+			}
+		default:
+			if !ok || existing.Version != w.Version {
+				m.mu.Unlock()
+				return nil, runtime.ErrStorageRejectedVersion
+			}
+		}
+	}
+	m.mu.Unlock()
+
+	return m.evrTestNakamaModule.StorageWrite(ctx, writes)
+}
+
+// storedCompletionState reads back the player's counter and history.
+func storedCompletionState(t *testing.T, ctx context.Context, nk runtime.NakamaModule, userID string) (*EarlyQuitPlayerState, *EarlyQuitHistory) {
+	t.Helper()
+	state := NewEarlyQuitPlayerState()
+	if err := StorableRead(ctx, nk, userID, state, false); err != nil {
+		t.Fatalf("read early quit state: %v", err)
+	}
+	history := NewEarlyQuitHistory(userID)
+	if err := StorableRead(ctx, nk, userID, history, false); err != nil {
+		// No history row at all is a legitimate outcome for some cases.
+		history = NewEarlyQuitHistory(userID)
+	}
+	return state, history
+}
+
+func countCompletionsFor(h *EarlyQuitHistory, matchID MatchID) int {
+	n := 0
+	for _, r := range h.Completions {
+		if r.MatchID.Equals(matchID) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestMatchCompletion_CreditSurvivesARejectedCounterWrite pins the ordering
+// between the dedupe record and the credit it guards.
+//
+// A completed match is reported twice — once by the MatchLoop MatchOver
+// dispatch and once by the post-match stats upload — and the completion history
+// is the dedupe record that makes only the first report count. That record was
+// committed BEFORE the counter write, and the counter write's failure was only
+// Warn-logged. So when the counter write lost an optimistic-concurrency race
+// (another writer touched the player's early quit row in between — a quit, the
+// tier scheduler, the other reporter) the credit was dropped, and because the
+// dedupe record was already committed the other reporter returned first=false.
+// The completion was recorded as counted and never counted: credit gone for
+// good, with no error surfaced to anyone.
+//
+// Correct behaviour: the dedupe record and the credit are committed together or
+// not at all. A rejected write leaves nothing behind, so the other reporter
+// still sees an uncounted match and credits it.
+func TestMatchCompletion_CreditSurvivesARejectedCounterWrite(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+	nk := newCompletionTestNK()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	userID := uuid.Must(uuid.NewV4()).String()
+	matchID, err := NewMatchID(uuid.Must(uuid.NewV4()), "test-node")
+	if err != nil {
+		t.Fatalf("new match id: %v", err)
+	}
+
+	// One concurrent writer wins the race against the counter row, exactly
+	// once. Every later write goes through.
+	rejected := false
+	nk.beforeWrite = func(writes []*runtime.StorageWrite) error {
+		if rejected {
+			return nil
+		}
+		for _, w := range writes {
+			if w.Collection == StorageCollectionEarlyQuit && w.Key == StorageKeyEarlyQuit && w.UserID == userID && w.Version != "" {
+				rejected = true
+				return runtime.ErrStorageRejectedVersion
+			}
+		}
+		return nil
+	}
+
+	s := &EventRemoteLogSet{}
+
+	// Reporter 1: the counter write is rejected out from under it.
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", matchID); err != nil {
+		t.Fatalf("first report: %v", err)
+	}
+	if !rejected {
+		t.Fatal("precondition: the injected rejection never fired; the counter write was not attempted")
+	}
+
+	// Reporter 2: the other production reporter for the same match.
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", matchID); err != nil {
+		t.Fatalf("second report: %v", err)
+	}
+
+	state, history := storedCompletionState(t, ctx, nk, userID)
+	if state.TotalCompletedMatches != 1 {
+		t.Errorf("TotalCompletedMatches = %d, want 1: the completion was recorded but never credited",
+			state.TotalCompletedMatches)
+	}
+	if got := countCompletionsFor(history, matchID); got != 1 {
+		t.Errorf("completion records for the match = %d, want 1", got)
+	}
+}
+
+// TestMatchCompletion_FirstEverCompletionDoesNotClobberAConcurrentOne pins the
+// create path of the completion history.
+//
+// TrackMatchCompletion read the history with create=false and, on NotFound,
+// carried on with a fresh history whose storage version was still "" —
+// StorableRead never calls SetStorageMeta on its error paths. An empty version
+// is an UNCONDITIONAL write. So the first-ever completion for a player did not
+// merely fail to notice a concurrently created history: it overwrote it,
+// destroying the completion record already committed there. The destroyed
+// record is the dedupe marker for its own match, so that match's other reporter
+// then sees an uncounted match and credits it a second time.
+//
+// (Note: the write must be conditional here without relying on StorableRead
+// itself learning to honour "*" — that is a separate, concurrent fix.)
+//
+// Correct behaviour: creating the history is conditional on it not existing.
+// A loser of that race writes nothing and credits nothing, leaving the match
+// available to be credited on a later report.
+func TestMatchCompletion_FirstEverCompletionDoesNotClobberAConcurrentOne(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+	nk := newCompletionTestNK()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	userID := uuid.Must(uuid.NewV4()).String()
+	mine, err := NewMatchID(uuid.Must(uuid.NewV4()), "test-node")
+	if err != nil {
+		t.Fatalf("new match id: %v", err)
+	}
+	theirs, err := NewMatchID(uuid.Must(uuid.NewV4()), "test-node")
+	if err != nil {
+		t.Fatalf("new match id: %v", err)
+	}
+
+	s := &EventRemoteLogSet{}
+
+	// A concurrent reporter for a DIFFERENT match of the same player creates
+	// the history row first, in the window between our reporter's read (which
+	// found nothing) and its write. Staged from the write hook so the
+	// interleaving is identical on every run.
+	raced := false
+	nk.beforeWrite = func(writes []*runtime.StorageWrite) error {
+		if raced {
+			return nil
+		}
+		for _, w := range writes {
+			if w.Collection == StorageCollectionEarlyQuitHistory && w.UserID == userID {
+				raced = true
+				other := NewEarlyQuitHistory(userID)
+				other.AddCompletion(theirs, time.Now().UTC())
+				if err := StorableWrite(ctx, nk.evrTestNakamaModule, userID, other); err != nil {
+					t.Errorf("stage concurrent history: %v", err)
+				}
+				break
+			}
+		}
+		return nil
+	}
+
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", mine); err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	if !raced {
+		t.Fatal("precondition: the history write was never attempted, so nothing was raced")
+	}
+	nk.beforeWrite = nil
+
+	_, history := storedCompletionState(t, ctx, nk, userID)
+	if got := countCompletionsFor(history, theirs); got != 1 {
+		t.Errorf("the concurrently created completion record was destroyed: found %d records for it, want 1", got)
+	}
+
+	// The loser credited nothing, so its match is still creditable: the other
+	// reporter for it must be able to record and credit it.
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", mine); err != nil {
+		t.Fatalf("re-report: %v", err)
+	}
+
+	state, history := storedCompletionState(t, ctx, nk, userID)
+	if got := countCompletionsFor(history, mine); got != 1 {
+		t.Errorf("completion records for the re-reported match = %d, want 1", got)
+	}
+	if got := countCompletionsFor(history, theirs); got != 1 {
+		t.Errorf("completion records for the concurrent match = %d, want 1", got)
+	}
+	if state.TotalCompletedMatches != 1 {
+		t.Errorf("TotalCompletedMatches = %d, want 1 (only our own match was credited by this reporter)",
+			state.TotalCompletedMatches)
+	}
+}

--- a/server/evr_earlyquit_completion_credit_test.go
+++ b/server/evr_earlyquit_completion_credit_test.go
@@ -250,3 +250,52 @@ func TestMatchCompletion_FirstEverCompletionDoesNotClobberAConcurrentOne(t *test
 			state.TotalCompletedMatches)
 	}
 }
+
+// TestMatchCompletion_CorruptHistoryRowStillCreditsTheCompletion pins the
+// interaction between the completion history's version staging and the atomic
+// batch that now commits the history together with the credit.
+//
+// The history row is read with create=false, so a row that EXISTS but does not
+// unmarshal comes back as codes.Internal — not NotFound. Staging that read
+// failure as a create-only write ("*") makes the batch fail against the row
+// that is still sitting there, and because the credit is in the same
+// transaction the credit is rolled back with it. Nothing on this path ever
+// repairs the row, so the player never gains completion credit or recovers
+// tier again — every completed match, forever.
+//
+// Correct behaviour: only a genuinely absent row is staged create-only. A row
+// that could not be read is overwritten unconditionally, which is what this
+// path did before the batch existed and is how the quit-record path recovers
+// too.
+func TestMatchCompletion_CorruptHistoryRowStillCreditsTheCompletion(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+	nk := newCompletionTestNK()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	userID := uuid.Must(uuid.NewV4()).String()
+	matchID, err := NewMatchID(uuid.Must(uuid.NewV4()), "test-node")
+	if err != nil {
+		t.Fatalf("new match id: %v", err)
+	}
+
+	// The row exists and is unreadable.
+	nk.seedObject(userID, StorageCollectionEarlyQuitHistory, StorageKeyEarlyQuitHistory, "{ not json")
+
+	s := &EventRemoteLogSet{}
+
+	// Report the same match three times: the first must credit it, the rest
+	// must dedupe against the now-repaired history.
+	for i := 0; i < 3; i++ {
+		if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", matchID); err != nil {
+			t.Fatalf("report %d: %v", i+1, err)
+		}
+	}
+
+	state, history := storedCompletionState(t, ctx, nk, userID)
+	if state.TotalCompletedMatches != 1 {
+		t.Errorf("TotalCompletedMatches = %d, want 1: an unreadable history row rolled back the credit", state.TotalCompletedMatches)
+	}
+	if got := countCompletionsFor(history, matchID); got != 1 {
+		t.Errorf("completion records for the match = %d, want 1 (the corrupt row was not repaired)", got)
+	}
+}

--- a/server/evr_earlyquit_completion_loglevel_test.go
+++ b/server/evr_earlyquit_completion_loglevel_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/heroiclabs/nakama-common/api"
@@ -35,14 +36,29 @@ func (m *completionTrackFailModule) StorageDelete(ctx context.Context, deletes [
 	return nil
 }
 
-// TestIncrementCompletedMatches_TrackFailureLogsAboveDebug pins the log level of
-// the TrackMatchCompletion failure in the post-match stats path.
+// MultiUpdate must fail too: StorableWriteMany writes the batch through this
+// entry point, and inheriting the base double's MultiUpdate would route around
+// the failing StorageWrite above and let the write appear to succeed.
+func (m *completionTrackFailModule) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	acks, err := m.StorageWrite(ctx, storageWrites)
+	return acks, nil, err
+}
+
+// TestIncrementCompletedMatches_TrackFailureLogsAboveDebug pins the visibility of
+// the failure that costs the player match credit in the post-match stats path.
 //
-// This is the failure that costs the player match credit: without the history
-// write, IncrementCompletedMatches is never called and the completion is lost.
-// It was logged at Debug while the ADJACENT, less consequential eqconfig write
-// failure logged at Warn — so at production log levels the expensive failure was
-// invisible and the cheap one was not.
+// Originally this asserted on "Failed to track match completion in history": the
+// history write was a SEPARATE write that ran before the counter, it was logged
+// at Debug, and the ADJACENT, less consequential eqconfig write failure logged at
+// Warn — so at production log levels the expensive failure was invisible and the
+// cheap one was not.
+//
+// That asymmetry no longer has anywhere to live. The history record and the
+// credit are now committed in ONE atomic StorableWriteMany, so there is exactly
+// one write that can cost the player the credit, and exactly one failure to
+// report. The invariant this test exists to defend is unchanged and is what it
+// still asserts: that failure must not be hidden below Warn. Only the message it
+// arrives under moved, because the two writes it used to compare became one.
 func TestIncrementCompletedMatches_TrackFailureLogsAboveDebug(t *testing.T) {
 	ctx := context.Background()
 	logger := newCaptureLogger()
@@ -62,12 +78,19 @@ func TestIncrementCompletedMatches_TrackFailureLogsAboveDebug(t *testing.T) {
 	_, loadFailed := logger.find("warn", "Failed to load early quitter config")
 	require.False(t, loadFailed, "precondition: the early quit config row must load")
 
-	const msg = "Failed to track match completion in history"
+	// The atomic write of {counter, history record} failed, so the player was not
+	// credited. That must be visible at Warn.
+	const msg = "Failed to store early quitter config"
 	_, atDebug := logger.find("debug", msg)
-	_, atWarn := logger.find("warn", msg)
+	entry, atWarn := logger.find("warn", msg)
 
 	require.False(t, atDebug,
 		"the failure that costs the player match credit must not be hidden at Debug")
 	require.True(t, atWarn,
-		"it must be at least Warn, matching the adjacent eqconfig write failure")
+		"the failure that costs the player match credit must be at least Warn")
+
+	// It must also still be diagnosable: a batch failure that named only one of
+	// the two rows would send whoever reads the log at the wrong record.
+	require.Contains(t, fmt.Sprint(entry.fields["error"]), StorageCollectionEarlyQuitHistory,
+		"the batch failure must name the history row, not just the counter row")
 }

--- a/server/evr_earlyquit_detailed.go
+++ b/server/evr_earlyquit_detailed.go
@@ -339,14 +339,27 @@ func CreateQuitRecordFromParticipation(state *MatchLabel, participation *PlayerP
 	}
 }
 
-// TrackMatchCompletion tracks a match completion in the player's early quit history
-// This is a helper function to reduce code duplication
+// PrepareMatchCompletion loads the player's early quit history and stages a
+// completion record for the match, WITHOUT writing anything.
 //
-// Returns (true, nil) when the completion is a new occurrence for this match and
-// was persisted; (false, nil) when the match was already tracked (the same match
-// is reported by both the post-match stats upload and the MatchLoop MatchOver
-// dispatch, so only the first occurrence is a real completion credit).
-func TrackMatchCompletion(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, userID string, matchID MatchID, completionTime time.Time) (bool, error) {
+// Returns first=false when the match is already recorded: the same completed
+// match is reported by both the post-match stats upload and the MatchLoop
+// MatchOver dispatch, so only the first report is a real completion credit.
+//
+// When first=true the returned history carries the staged record and the caller
+// must commit it together with the credited counter in one atomic
+// StorableWriteMany. Committing the record on its own is what previously lost
+// credits for good: the record is the dedupe marker, so once it is stored the
+// other reporter returns first=false and the credit can never be re-earned.
+//
+// The history is staged with version "*" when the player has none yet, so
+// creating it is conditional on it not already existing. An unconditional
+// create would overwrite a history another reporter created in the meantime,
+// destroying the completion record — and therefore the dedupe marker — already
+// committed there. This is set here explicitly rather than by asking
+// StorableRead to create the row, so it does not depend on StorableRead's own
+// version handling.
+func PrepareMatchCompletion(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, userID string, matchID MatchID, completionTime time.Time) (bool, *EarlyQuitHistory, error) {
 	history := NewEarlyQuitHistory(userID)
 	if err := StorableRead(ctx, nk, userID, history, false); err != nil {
 		if status.Code(err) == codes.NotFound {
@@ -356,21 +369,19 @@ func TrackMatchCompletion(ctx context.Context, logger runtime.Logger, nk runtime
 			// Align behavior with quit tracking: log but proceed with a new history so completions are still tracked.
 			logger.WithField("error", err).Warn("Failed to load early quit history for completion tracking, proceeding with new history")
 		}
+		meta := history.StorageMeta()
+		meta.Version = "*"
+		history.SetStorageMeta(meta)
 	}
 
 	// Dedupe: the same (user, match) can arrive from the post-match stats upload
 	// AND from the MatchLoop MatchOver dispatch. Count it only once.
 	for _, record := range history.Completions {
 		if record.MatchID.Equals(matchID) {
-			return false, nil
+			return false, nil, nil
 		}
 	}
 
 	history.AddCompletion(matchID, completionTime)
-	if err := StorableWrite(ctx, nk, userID, history); err != nil {
-		logger.WithField("error", err).Warn("Failed to write completion to early quit history")
-		return false, err
-	}
-
-	return true, nil
+	return true, history, nil
 }

--- a/server/evr_earlyquit_detailed.go
+++ b/server/evr_earlyquit_detailed.go
@@ -352,36 +352,45 @@ func CreateQuitRecordFromParticipation(state *MatchLabel, participation *PlayerP
 // credits for good: the record is the dedupe marker, so once it is stored the
 // other reporter returns first=false and the credit can never be re-earned.
 //
-// The history is staged with version "*" when the player has none yet, so
-// creating it is conditional on it not already existing. An unconditional
-// create would overwrite a history another reporter created in the meantime,
-// destroying the completion record — and therefore the dedupe marker — already
-// committed there. This is set here explicitly rather than by asking
-// StorableRead to create the row, so it does not depend on StorableRead's own
-// version handling.
-func PrepareMatchCompletion(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, userID string, matchID MatchID, completionTime time.Time) (bool, *EarlyQuitHistory, error) {
+// The history is staged with version "*" when the read says the player has NO
+// history row, so creating it is conditional on it not already existing. An
+// unconditional create would overwrite a history another reporter created in
+// the meantime, destroying the completion record — and therefore the dedupe
+// marker — already committed there. This is set here explicitly rather than by
+// asking StorableRead to create the row, so it does not depend on
+// StorableRead's own version handling.
+func PrepareMatchCompletion(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule, userID string, matchID MatchID, completionTime time.Time) (bool, *EarlyQuitHistory) {
 	history := NewEarlyQuitHistory(userID)
 	if err := StorableRead(ctx, nk, userID, history, false); err != nil {
 		if status.Code(err) == codes.NotFound {
 			// First-time player with no history yet; proceed with a new history so completions are still tracked.
 			logger.WithField("error", err).Debug("No early quit history found for completion tracking, starting new history")
+			meta := history.StorageMeta()
+			meta.Version = "*"
+			history.SetStorageMeta(meta)
 		} else {
-			// Align behavior with quit tracking: log but proceed with a new history so completions are still tracked.
+			// The row may well EXIST and simply not be readable — corrupt JSON
+			// unmarshals to codes.Internal on this create=false path. Staging
+			// "*" here would make the batch write below fail against that row
+			// on every single completion, forever, and because the credit is
+			// committed in the same atomic batch the player would never gain
+			// completion credit or recover tier again.
+			//
+			// So fall back to the unconditional write this path used before the
+			// batch existed: it self-heals the corrupt row, which is also how
+			// the quit-record path recovers (evr_match.go, MatchLeave).
 			logger.WithField("error", err).Warn("Failed to load early quit history for completion tracking, proceeding with new history")
 		}
-		meta := history.StorageMeta()
-		meta.Version = "*"
-		history.SetStorageMeta(meta)
 	}
 
 	// Dedupe: the same (user, match) can arrive from the post-match stats upload
 	// AND from the MatchLoop MatchOver dispatch. Count it only once.
 	for _, record := range history.Completions {
 		if record.MatchID.Equals(matchID) {
-			return false, nil, nil
+			return false, nil
 		}
 	}
 
 	history.AddCompletion(matchID, completionTime)
-	return true, history, nil
+	return true, history
 }

--- a/server/evr_earlyquit_forgiveness_test.go
+++ b/server/evr_earlyquit_forgiveness_test.go
@@ -2,6 +2,10 @@ package server
 
 import (
 	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -122,5 +126,106 @@ func TestCheckAndStrikeEarlyQuitIfLoggedOut_ForgivenessLiftsTheLockout(t *testin
 					got.MatchmakingTier, tc.wantTier)
 			}
 		})
+	}
+}
+
+// unreachableDBDriver is a database/sql driver whose connections always fail.
+// It stands in for "a real *sql.DB is wired up but the query does not succeed",
+// which is the only shape of database interaction this DB-free suite can drive.
+// It counts Open calls so a test can prove a code path that touches the database
+// was actually entered.
+type unreachableDBDriver struct{ opens atomic.Int64 }
+
+func (d *unreachableDBDriver) Open(string) (driver.Conn, error) {
+	d.opens.Add(1)
+	return nil, errors.New("no database is reachable in this test")
+}
+
+var unreachableDB = func() *unreachableDBDriver {
+	d := &unreachableDBDriver{}
+	sql.Register("evr-earlyquit-unreachable", d)
+	return d
+}()
+
+// TestCheckAndStrikeEarlyQuitIfLoggedOut_TierRestoredNotificationIsReachable
+// covers a path that only became live in this PR.
+//
+// The tier-change notification block at the end of
+// CheckAndStrikeEarlyQuitIfLoggedOut is gated on `tierChanged`. Before the
+// forgiveness fix, UpdateTier there was fed a PenaltyLevel that forgiveness had
+// never re-resolved, so it always matched the stored tier and `tierChanged` was
+// permanently false: the whole block — GetDiscordIDByUserID against the *sql.DB,
+// SendEarlyQuitUpdateNotification, the Discord DM — was dead code. Re-resolving
+// the penalty makes it execute in production for the first time.
+//
+// Newly-live code with no coverage is exactly where a nil dereference hides, so
+// this pins two things: the block IS entered (the database is touched, which
+// cannot happen unless tierChanged was true), and it survives the database being
+// unusable rather than taking the whole goroutine down. The player's forgiven
+// state must still be persisted either way — a notification failure must not
+// cost the player their lockout release.
+func TestCheckAndStrikeEarlyQuitIfLoggedOut_TierRestoredNotificationIsReachable(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+
+	// The block is gated on the penalty system being enabled and not silent.
+	saved := ServiceSettings()
+	settings := &ServiceSettingsData{}
+	settings.Matchmaking.EnableEarlyQuitPenalty = true
+	settings.Matchmaking.SilentEarlyQuitSystem = false
+	ServiceSettingsUpdate(settings)
+	t.Cleanup(func() { ServiceSettingsUpdate(saved) })
+
+	db, err := sql.Open("evr-earlyquit-unreachable", "")
+	if err != nil {
+		t.Fatalf("open stub db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	nk := newEvrTestNakamaModule()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+	seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+	userID := uuid.Must(uuid.NewV4()).String()
+	sessionID := uuid.Must(uuid.NewV4()).String()
+
+	// 3 quits => level 1 => Tier 2. Forgiving one drops it to 2 quits => level 0
+	// => Tier 1, which is the tier-RESTORED transition this block reports.
+	state := NewEarlyQuitPlayerState()
+	state.NumEarlyQuits = 3
+	state.NumSteadyEarlyQuits = 3
+	state.PenaltyLevel = 1
+	state.PenaltyTimestamp = time.Now().Unix() + 120
+	state.UpdateTier(nil)
+	if state.MatchmakingTier != MatchmakingTier2 {
+		t.Fatalf("precondition: seeded tier = %d, want %d", state.MatchmakingTier, MatchmakingTier2)
+	}
+	if err := StorableWrite(ctx, nk, userID, state); err != nil {
+		t.Fatalf("seed player state: %v", err)
+	}
+
+	opensBefore := unreachableDB.opens.Load()
+
+	// Must not panic: this is the first execution of this block, ever.
+	CheckAndStrikeEarlyQuitIfLoggedOut(ctx, logger, nk, db, &testSessionRegistry{}, userID, sessionID, 0)
+
+	if got := unreachableDB.opens.Load(); got <= opensBefore {
+		t.Errorf("the database was never touched (opens %d -> %d): the tier-change notification block was not reached, so this test is not covering it",
+			opensBefore, got)
+	}
+
+	got := NewEarlyQuitPlayerState()
+	if err := StorableRead(ctx, nk, userID, got, false); err != nil {
+		t.Fatalf("read back player state: %v", err)
+	}
+	if got.NumEarlyQuits != 2 {
+		t.Errorf("NumEarlyQuits = %d, want 2", got.NumEarlyQuits)
+	}
+	if got.PenaltyLevel != 0 || got.PenaltyTimestamp != 0 {
+		t.Errorf("PenaltyLevel/PenaltyTimestamp = %d/%d, want 0/0: the forgiveness was lost",
+			got.PenaltyLevel, got.PenaltyTimestamp)
+	}
+	if got.MatchmakingTier != MatchmakingTier1 {
+		t.Errorf("MatchmakingTier = %d, want %d: an unreachable database cost the player their tier restoration",
+			got.MatchmakingTier, MatchmakingTier1)
 	}
 }

--- a/server/evr_earlyquit_forgiveness_test.go
+++ b/server/evr_earlyquit_forgiveness_test.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// TestCheckAndStrikeEarlyQuitIfLoggedOut_ForgivenessLiftsTheLockout pins the
+// whole point of the logout-forgiveness path: a player who quit the game
+// entirely (rather than abandoning one match for another) gets the quit
+// forgiven, and forgiving a quit must actually release the matchmaking lockout
+// it caused.
+//
+// CheckAndStrikeEarlyQuitIfLoggedOut called ForgiveLastQuit — whose own doc
+// comment says "PenaltyLevel and PenaltyTimestamp are re-resolved by the
+// caller" — and then never re-resolved them. Its sibling
+// CheckAndApplyEarlyQuitIfStillOnline does call resolveAndApplyPenaltyLockout.
+// So the decremented quit count was persisted while the stale
+// PenaltyLevel/PenaltyTimestamp rode along untouched: the forgiven player
+// stayed locked out for the full original duration, and because UpdateTier
+// reads that same stale PenaltyLevel, tierChanged was always false and the
+// notification block below it was unreachable.
+func TestCheckAndStrikeEarlyQuitIfLoggedOut_ForgivenessLiftsTheLockout(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+
+	// Pin service settings: the notification block dereferences a *sql.DB that
+	// is nil here, and it is reached only when the penalty system is enabled.
+	saved := ServiceSettings()
+	ServiceSettingsUpdate(&ServiceSettingsData{})
+	t.Cleanup(func() { ServiceSettingsUpdate(saved) })
+
+	for _, tc := range []struct {
+		name string
+
+		quits        int32 // quit count BEFORE forgiveness
+		penaltyLevel int32 // penalty in force before forgiveness
+		lockoutSec   int64 // remaining lockout before forgiveness
+
+		wantQuits      int32
+		wantLevel      int32
+		wantLockoutSec int64 // 0 means "no lockout at all"
+		wantTier       int32
+	}{
+		{
+			// Default ladder: 3 quits => level 1 / 120s, 2 quits => level 0 / none.
+			name:  "forgiving the quit that caused the lockout clears it",
+			quits: 3, penaltyLevel: 1, lockoutSec: 120,
+			wantQuits: 2, wantLevel: 0, wantLockoutSec: 0, wantTier: MatchmakingTier1,
+		},
+		{
+			// 6 quits => level 2 / 300s, 5 quits => level 1 / 120s. Forgiveness
+			// steps the lockout DOWN a rung rather than leaving level 2 in force.
+			name:  "forgiving a quit steps the lockout down a rung",
+			quits: 6, penaltyLevel: 2, lockoutSec: 300,
+			wantQuits: 5, wantLevel: 1, wantLockoutSec: 120, wantTier: MatchmakingTier2,
+		},
+		{
+			// Nothing to forgive: the state must be left coherent, not corrupted.
+			name:  "forgiving with no quits on record leaves a clean player clean",
+			quits: 0, penaltyLevel: 0, lockoutSec: 0,
+			wantQuits: 0, wantLevel: 0, wantLockoutSec: 0, wantTier: MatchmakingTier1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			nk := newEvrTestNakamaModule()
+			ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+			seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+			userID := uuid.Must(uuid.NewV4()).String()
+			sessionID := uuid.Must(uuid.NewV4()).String()
+
+			state := NewEarlyQuitPlayerState()
+			state.NumEarlyQuits = tc.quits
+			state.NumSteadyEarlyQuits = tc.quits
+			state.PenaltyLevel = tc.penaltyLevel
+			if tc.lockoutSec > 0 {
+				state.PenaltyTimestamp = time.Now().Unix() + tc.lockoutSec
+			}
+			state.UpdateTier(nil)
+			if err := StorableWrite(ctx, nk, userID, state); err != nil {
+				t.Fatalf("seed player state: %v", err)
+			}
+
+			// The player has no live session: testSessionRegistry.Range never
+			// yields one, which is exactly "logged out entirely".
+			before := time.Now().Unix()
+			CheckAndStrikeEarlyQuitIfLoggedOut(ctx, logger, nk, nil, &testSessionRegistry{}, userID, sessionID, 0)
+			after := time.Now().Unix()
+
+			got := NewEarlyQuitPlayerState()
+			if err := StorableRead(ctx, nk, userID, got, false); err != nil {
+				t.Fatalf("read back player state: %v", err)
+			}
+
+			if got.NumEarlyQuits != tc.wantQuits {
+				t.Errorf("NumEarlyQuits = %d, want %d", got.NumEarlyQuits, tc.wantQuits)
+			}
+			if got.PenaltyLevel != tc.wantLevel {
+				t.Errorf("PenaltyLevel = %d, want %d: the penalty was not re-resolved after forgiveness",
+					got.PenaltyLevel, tc.wantLevel)
+			}
+			if tc.wantLockoutSec == 0 {
+				if got.PenaltyTimestamp != 0 {
+					t.Errorf("PenaltyTimestamp = %d, want 0: the forgiven player is still locked out", got.PenaltyTimestamp)
+				}
+				if got.IsPenaltyActive() {
+					t.Errorf("IsPenaltyActive() = true after forgiveness: the lockout was never lifted")
+				}
+			} else {
+				if got.PenaltyTimestamp < before+tc.wantLockoutSec || got.PenaltyTimestamp > after+tc.wantLockoutSec {
+					t.Errorf("PenaltyTimestamp = %d, want a %ds lockout from now (between %d and %d)",
+						got.PenaltyTimestamp, tc.wantLockoutSec, before+tc.wantLockoutSec, after+tc.wantLockoutSec)
+				}
+			}
+			if got.MatchmakingTier != tc.wantTier {
+				t.Errorf("MatchmakingTier = %d, want %d: the tier was computed from a stale penalty level",
+					got.MatchmakingTier, tc.wantTier)
+			}
+		})
+	}
+}

--- a/server/evr_earlyquit_ladder_test.go
+++ b/server/evr_earlyquit_ladder_test.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"math"
+	"testing"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty pins the
+// direction of the "no band matched" fallback.
+//
+// ResolvePenaltyLevel walks the ladder looking for a band that contains the
+// quit count. The fallback for "no band matched" returned the LAST configured
+// level — the maximum penalty — with the comment "quit count above all ranges".
+// That comment only describes one of the three ways the loop can fall through:
+//
+//   - the count is ABOVE every band (the intended case: max penalty is right),
+//   - the count is BELOW the first band (a player with fewer quits than the
+//     ladder's floor got the harshest lockout in the ladder),
+//   - the count lands in a GAP between two bands. validatePenaltyLevels only
+//     ever raises MinEarlyQuits to close overlaps, never lowers it to close
+//     gaps, and nothing forces the first band to start at 0 — so both of those
+//     shapes survive validation and reach production.
+//
+// Correct behaviour: resolution must be total and monotonic. A count that is
+// not inside any band resolves to the highest band whose floor it has already
+// reached (i.e. the band below the gap), and to no penalty at all when it is
+// below every band.
+func TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty(t *testing.T) {
+	// Ladder with a gap: 3 and 4 quits belong to no band.
+	gapped := &evr.SNSEarlyQuitConfig{
+		PenaltyLevels: []evr.EarlyQuitPenaltyLevelConfig{
+			{PenaltyLevel: 0, MinEarlyQuits: 0, MaxEarlyQuits: 2, MMLockoutSec: 0},
+			{PenaltyLevel: 1, MinEarlyQuits: 5, MaxEarlyQuits: 10, MMLockoutSec: 120},
+			{PenaltyLevel: 3, MinEarlyQuits: 11, MaxEarlyQuits: 999, MMLockoutSec: 900},
+		},
+	}
+
+	// Ladder whose floor is above zero: 0, 1 and 2 quits are below every band.
+	floored := &evr.SNSEarlyQuitConfig{
+		PenaltyLevels: []evr.EarlyQuitPenaltyLevelConfig{
+			{PenaltyLevel: 1, MinEarlyQuits: 3, MaxEarlyQuits: 5, MMLockoutSec: 120},
+			{PenaltyLevel: 2, MinEarlyQuits: 6, MaxEarlyQuits: 999, MMLockoutSec: 300},
+		},
+	}
+
+	for _, tc := range []struct {
+		name           string
+		cfg            *evr.SNSEarlyQuitConfig
+		quits          int32
+		wantLevel      int32
+		wantLockoutSec int32
+	}{
+		// --- in-band lookups still work (guards against a fix that breaks the happy path) ---
+		{"gapped: in first band", gapped, 1, 0, 0},
+		{"gapped: at band floor", gapped, 5, 1, 120},
+		{"gapped: at band ceiling", gapped, 10, 1, 120},
+		{"gapped: in top band", gapped, 50, 3, 900},
+
+		// --- the gap: 3 and 4 quits belong to no band ---
+		{"gapped: first count in gap falls to the band below", gapped, 3, 0, 0},
+		{"gapped: last count in gap falls to the band below", gapped, 4, 0, 0},
+
+		// --- above every band: the max penalty IS correct here ---
+		{"gapped: above every band gets the top level", gapped, 1000, 3, 900},
+		{"floored: above every band gets the top level", floored, 5000, 2, 300},
+
+		// --- below every band: no penalty, not the harshest one ---
+		{"floored: zero quits is below the ladder floor", floored, 0, 0, 0},
+		{"floored: one quit is below the ladder floor", floored, 1, 0, 0},
+		{"floored: one short of the floor", floored, 2, 0, 0},
+		{"floored: at the floor", floored, 3, 1, 120},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			level, lockoutSec := ResolvePenaltyLevel(tc.quits, tc.cfg)
+			if level != tc.wantLevel || lockoutSec != tc.wantLockoutSec {
+				t.Errorf("ResolvePenaltyLevel(%d) = (level %d, lockout %ds), want (level %d, lockout %ds)",
+					tc.quits, level, lockoutSec, tc.wantLevel, tc.wantLockoutSec)
+			}
+		})
+	}
+}
+
+// TestResolvePenaltyLevel_LockoutSaturatesInsteadOfWrapping pins the int32
+// conversion of the config-supplied lockout.
+//
+// MMLockoutSec is a plain `int` (64-bit) that arrives from stored JSON.
+// validatePenaltyLevels clamps only negatives, and configs read back through
+// StorableRead are never re-validated at all, so an out-of-range value reaches
+// ResolvePenaltyLevel intact. `int32(pl.MMLockoutSec)` then wraps: 2^31 becomes
+// negative and 2^32 becomes exactly zero. Every caller gates on
+// `lockoutSec > 0`, so a wrapped value takes the CLEAR branch — the penalty is
+// silently disabled by a config value that asked for a longer one.
+//
+// Correct behaviour: saturate at math.MaxInt32. An absurdly long lockout is
+// still a lockout.
+func TestResolvePenaltyLevel_LockoutSaturatesInsteadOfWrapping(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		lockoutSec  int
+		wantLockout int32
+	}{
+		{"ordinary value passes through", 900, 900},
+		{"exactly MaxInt32 passes through", math.MaxInt32, math.MaxInt32},
+		{"MaxInt32+1 saturates instead of going negative", math.MaxInt32 + 1, math.MaxInt32},
+		{"2^32 saturates instead of becoming zero", 1 << 32, math.MaxInt32},
+		{"negative is clamped to zero", -5, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &evr.SNSEarlyQuitConfig{
+				PenaltyLevels: []evr.EarlyQuitPenaltyLevelConfig{
+					{PenaltyLevel: 2, MinEarlyQuits: 0, MaxEarlyQuits: 999, MMLockoutSec: tc.lockoutSec},
+				},
+			}
+
+			level, lockoutSec := ResolvePenaltyLevel(1, cfg)
+			if level != 2 {
+				t.Errorf("ResolvePenaltyLevel level = %d, want 2", level)
+			}
+			if lockoutSec != tc.wantLockout {
+				t.Errorf("ResolvePenaltyLevel lockout = %d, want %d (config asked for %d)",
+					lockoutSec, tc.wantLockout, tc.lockoutSec)
+			}
+		})
+	}
+}

--- a/server/evr_earlyquit_ladder_test.go
+++ b/server/evr_earlyquit_ladder_test.go
@@ -24,9 +24,9 @@ import (
 //     shapes survive validation and reach production.
 //
 // Correct behaviour: resolution must be total and monotonic. A count that is
-// not inside any band resolves to the highest band whose floor it has already
-// reached (i.e. the band below the gap), and to no penalty at all when it is
-// below every band.
+// not inside any band resolves to the band with the highest floor among those it
+// has cleared entirely — those whose CEILING it is already above, i.e. the band
+// below the gap — and to no penalty at all when it has cleared no band.
 func TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty(t *testing.T) {
 	// Ladder with a gap: 3 and 4 quits belong to no band.
 	gapped := &evr.SNSEarlyQuitConfig{
@@ -86,8 +86,11 @@ func TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty(t *testing.T) {
 // conversion of the config-supplied lockout.
 //
 // MMLockoutSec is a plain `int` (64-bit) that arrives from stored JSON.
-// validatePenaltyLevels clamps only negatives, and configs read back through
-// StorableRead are never re-validated at all, so an out-of-range value reaches
+// Re-validation on read does not help: LoadEarlyQuitServiceConfig does call
+// config.Validate() on the read-success path, but validatePenaltyLevels bounds
+// MMLockoutSec only from below (`if level.MMLockoutSec < 0 { … = 0 }`) and never
+// from above — and the admin RPC's loadEarlyQuitServiceConfigOrDefault skips
+// Validate altogether. Either way an out-of-range value reaches
 // ResolvePenaltyLevel intact. `int32(pl.MMLockoutSec)` then wraps: 2^31 becomes
 // negative and 2^32 becomes exactly zero. Every caller gates on
 // `lockoutSec > 0`, so a wrapped value takes the CLEAR branch — the penalty is
@@ -96,18 +99,35 @@ func TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty(t *testing.T) {
 // Correct behaviour: saturate at math.MaxInt32. An absurdly long lockout is
 // still a lockout.
 func TestResolvePenaltyLevel_LockoutSaturatesInsteadOfWrapping(t *testing.T) {
+	// The out-of-int32-range cases are built at RUN time, not as untyped
+	// constants: on a 32-bit GOARCH `int` is int32, so a literal
+	// `math.MaxInt32 + 1` in the table below is a compile-time overflow that
+	// makes the whole package unbuildable there (`GOARCH=386 go vet ./server/`:
+	// "cannot use math.MaxInt32 + 1 (untyped int constant 2147483648) as int
+	// value in struct literal (overflows)"). Deriving them from a variable
+	// keeps the file portable; the subtests themselves are skipped where the
+	// values are not representable, since there is nothing to saturate.
+	maxInt32 := int(math.MaxInt32)
+	overByOne := maxInt32 + 1      // 2^31 on a 64-bit int; wraps on a 32-bit one
+	twoPow32 := (maxInt32 + 1) * 2 // 2^32 on a 64-bit int; wraps on a 32-bit one
+	intIs64Bit := overByOne > maxInt32
+
 	for _, tc := range []struct {
 		name        string
 		lockoutSec  int
 		wantLockout int32
+		needs64Bit  bool
 	}{
-		{"ordinary value passes through", 900, 900},
-		{"exactly MaxInt32 passes through", math.MaxInt32, math.MaxInt32},
-		{"MaxInt32+1 saturates instead of going negative", math.MaxInt32 + 1, math.MaxInt32},
-		{"2^32 saturates instead of becoming zero", 1 << 32, math.MaxInt32},
-		{"negative is clamped to zero", -5, 0},
+		{"ordinary value passes through", 900, 900, false},
+		{"exactly MaxInt32 passes through", math.MaxInt32, math.MaxInt32, false},
+		{"MaxInt32+1 saturates instead of going negative", overByOne, math.MaxInt32, true},
+		{"2^32 saturates instead of becoming zero", twoPow32, math.MaxInt32, true},
+		{"negative is clamped to zero", -5, 0, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.needs64Bit && !intIs64Bit {
+				t.Skip("int is 32 bits on this GOARCH: an out-of-int32-range MMLockoutSec is not representable")
+			}
 			cfg := &evr.SNSEarlyQuitConfig{
 				PenaltyLevels: []evr.EarlyQuitPenaltyLevelConfig{
 					{PenaltyLevel: 2, MinEarlyQuits: 0, MaxEarlyQuits: 999, MMLockoutSec: tc.lockoutSec},

--- a/server/evr_earlyquit_moderator_penalty_test.go
+++ b/server/evr_earlyquit_moderator_penalty_test.go
@@ -264,14 +264,20 @@ func TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries(t *testing.T)
 		seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
 
 		state := sanction(t, ctx, nk, groupID, targetID, 3)
-		state.PenaltyTimestamp = time.Now().Unix() - 1 // sanction just lapsed
-		state.NumEarlyQuits = 1                        // ladder level 0
+		// The sanction just lapsed.
+		state.PenaltyTimestamp = time.Now().Unix() - 1
+		state.ModeratorPenaltyUntil = state.PenaltyTimestamp
+		state.NumEarlyQuits = 1 // ladder level 0
 
 		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
 
 		if state.PenaltyLevel != 0 || state.PenaltyTimestamp != 0 {
 			t.Errorf("after the sanction expired, ladder resolution must apply: got level %d ts %d, want 0/0",
 				state.PenaltyLevel, state.PenaltyTimestamp)
+		}
+		if state.ModeratorPenaltyLevel != 0 || state.ModeratorPenaltyUntil != 0 {
+			t.Errorf("a lapsed sanction must be dropped, not retained: got level %d until %d",
+				state.ModeratorPenaltyLevel, state.ModeratorPenaltyUntil)
 		}
 	})
 
@@ -309,4 +315,101 @@ func TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries(t *testing.T)
 			t.Errorf("ladder penalty was not lifted: got level %d ts %d, want 0/0", state.PenaltyLevel, state.PenaltyTimestamp)
 		}
 	})
+}
+
+// TestEarlyQuit_QuittingMoreCannotShortenAModeratorSanction is the second half
+// of the sanction-wipe bug: the guard that stopped a quit ERASING a sanction
+// compared levels only, so a quit could still SHORTEN one.
+//
+// The Discord /early-quit handler takes an explicit duration-minutes
+// (evr_discord_appbot.go, "duration-minutes" option), so a moderator can hand
+// out a long, deliberately light sanction — level 1 for 24 hours. The default
+// ladder's harshest rung is level 3 for 900 seconds. A player who then quits
+// their way to 11 quits resolves to level 3, and because level 3 > level 1 the
+// guard stood aside and the ladder wrote its own 900s expiry over the
+// moderator's — the player served 15 minutes instead of 24 hours. Quitting MORE
+// shortened the punishment.
+//
+// Correct behaviour: an unexpired sanction is a floor in BOTH dimensions. The
+// ladder may raise the level and it may extend the expiry; it may do neither in
+// reverse.
+func TestEarlyQuit_QuittingMoreCannotShortenAModeratorSanction(t *testing.T) {
+	nk, ctx, _, _ := newEarlyQuitAdminHarness(t)
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+	seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+	// A moderator sanctions level 1 for 24 hours.
+	state := NewEarlyQuitPlayerState()
+	state.ApplyModeratorPenalty(1, 24*60*60)
+	sanctionExpiry := state.PenaltyTimestamp
+
+	// The player racks up quits until the ladder resolves to level 3 / 900s.
+	state.NumEarlyQuits = 11
+	resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+
+	if state.PenaltyLevel != 3 {
+		t.Errorf("PenaltyLevel = %d, want 3: the ladder must still be able to RAISE the level", state.PenaltyLevel)
+	}
+	if state.PenaltyTimestamp < sanctionExpiry {
+		t.Errorf("PenaltyTimestamp = %d, want >= %d: quitting more shortened the moderator's sanction by %ds",
+			state.PenaltyTimestamp, sanctionExpiry, sanctionExpiry-state.PenaltyTimestamp)
+	}
+
+	// ...and the sanction keeps flooring the level for its full duration, even
+	// after the quits that raised it are forgiven.
+	state.NumEarlyQuits = 0
+	resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+	if state.PenaltyLevel != 1 {
+		t.Errorf("PenaltyLevel = %d after the quits were forgiven, want 1 (the sanctioned level): "+
+			"the ladder's transient level 3 ratcheted into the sanction", state.PenaltyLevel)
+	}
+	if state.PenaltyTimestamp != sanctionExpiry {
+		t.Errorf("PenaltyTimestamp = %d after the quits were forgiven, want %d (the sanction's own expiry)",
+			state.PenaltyTimestamp, sanctionExpiry)
+	}
+}
+
+// TestEarlyQuit_ResetLiftsAModeratorSanction pins that the admin reset action
+// drops the retained sanction. Without that, the sanction would keep flooring
+// ladder resolution for the rest of its original lockout even though the
+// operator just wiped the player's record.
+func TestEarlyQuit_ResetLiftsAModeratorSanction(t *testing.T) {
+	nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+	seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+	state := NewEarlyQuitPlayerState()
+	state.ApplyModeratorPenalty(3, 24*60*60)
+	state.NumEarlyQuits = 20
+	if err := StorableWrite(ctx, nk, targetID, state); err != nil {
+		t.Fatalf("seed player state: %v", err)
+	}
+
+	payload, err := json.Marshal(EarlyQuitModifyRequest{
+		GroupID:      groupID,
+		TargetUserID: targetID,
+		Action:       "reset",
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, err := EarlyQuitModifyRPC(ctx, logger, nil, nk, string(payload)); err != nil {
+		t.Fatalf("EarlyQuitModifyRPC: %v", err)
+	}
+
+	after := NewEarlyQuitPlayerState()
+	if err := StorableRead(ctx, nk, targetID, after, false); err != nil {
+		t.Fatalf("read reset state: %v", err)
+	}
+	if after.ModeratorPenaltyLevel != 0 || after.ModeratorPenaltyUntil != 0 {
+		t.Errorf("reset left a retained sanction: level %d until %d", after.ModeratorPenaltyLevel, after.ModeratorPenaltyUntil)
+	}
+
+	// A subsequent quit must resolve purely from the ladder again.
+	after.NumEarlyQuits = 1
+	resolveAndApplyPenaltyLockout(ctx, nk, logger, after)
+	if after.PenaltyLevel != 0 || after.PenaltyTimestamp != 0 {
+		t.Errorf("after a reset the ladder must govern: got level %d ts %d, want 0/0",
+			after.PenaltyLevel, after.PenaltyTimestamp)
+	}
 }

--- a/server/evr_earlyquit_moderator_penalty_test.go
+++ b/server/evr_earlyquit_moderator_penalty_test.go
@@ -1,0 +1,312 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// earlyQuitAdminNK is an evrTestNakamaModule that also answers GroupsGetId, so
+// RequireEnforcerOperatorOrBot's GuildGroupLoad succeeds without a database.
+// The caller is a global operator (supplied through the permissions context),
+// so the guild's own enforcer list is never consulted.
+type earlyQuitAdminNK struct {
+	*evrTestNakamaModule
+	groupID string
+}
+
+func (m *earlyQuitAdminNK) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
+	for _, id := range groupIDs {
+		if id == m.groupID {
+			return []*api.Group{{Id: m.groupID, Name: "test-guild", Metadata: "{}"}}, nil
+		}
+	}
+	return nil, nil
+}
+
+// newEarlyQuitAdminHarness wires up the in-memory module, an operator context
+// and the global service settings the admin RPC path reads. It returns the
+// module, the context, the caller and target user IDs and the group ID.
+func newEarlyQuitAdminHarness(t *testing.T) (*earlyQuitAdminNK, context.Context, string, string) {
+	t.Helper()
+
+	groupID := uuid.Must(uuid.NewV4()).String()
+	nk := &earlyQuitAdminNK{evrTestNakamaModule: newEvrTestNakamaModule(), groupID: groupID}
+
+	// GuildGroupLoad reads the guild state row owned by the Discord bot user;
+	// StorableRead rejects an empty owner ID, so the settings must name one.
+	saved := ServiceSettings()
+	settings := &ServiceSettingsData{}
+	settings.DiscordBotUserID = uuid.Must(uuid.NewV4()).String()
+	ServiceSettingsUpdate(settings)
+	t.Cleanup(func() { ServiceSettingsUpdate(saved) })
+
+	callerID := uuid.Must(uuid.NewV4()).String()
+	targetID := uuid.Must(uuid.NewV4()).String()
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_NODE, "test-node")
+	ctx = context.WithValue(ctx, runtime.RUNTIME_CTX_USER_ID, callerID)
+	ctx = WithUserPermissions(ctx, &UserPermissions{IsGlobalOperator: true})
+
+	return nk, ctx, targetID, groupID
+}
+
+// seedEarlyQuitLadder stores a custom system-wide penalty ladder.
+func seedEarlyQuitLadder(t *testing.T, ctx context.Context, nk runtime.NakamaModule, levels []evr.EarlyQuitPenaltyLevelConfig) {
+	t.Helper()
+	cfg := &evr.SNSEarlyQuitConfig{
+		PenaltyLevels:      levels,
+		SteadyPlayerLevels: evr.DefaultEarlyQuitLevels().SteadyPlayerLevels,
+	}
+	value, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal ladder: %v", err)
+	}
+	if _, err := nk.StorageWrite(ctx, []*runtime.StorageWrite{{
+		Collection:      evr.StorageCollectionEarlyQuitConfig,
+		Key:             evr.StorageKeyEarlyQuitConfig,
+		UserID:          SystemUserID,
+		Value:           string(value),
+		PermissionRead:  int(runtime.STORAGE_PERMISSION_NO_READ),
+		PermissionWrite: int(runtime.STORAGE_PERMISSION_NO_WRITE),
+	}}); err != nil {
+		t.Fatalf("seed ladder: %v", err)
+	}
+}
+
+// TestEarlyQuitModifyRPC_SetPenaltyDoesNotBorrowAnotherLevelsLockout pins the
+// lockout the set_penalty action applies.
+//
+// The handler seeded lockoutSec from ResolvePenaltyLevel(state.NumEarlyQuits) —
+// the lockout for the level the player's CURRENT quit count maps to — discarded
+// it with `_ = lockoutSec`, and then overwrote it only if the requested level
+// happened to appear in the ladder. When the requested level is absent from the
+// ladder the seed survived, so a moderator asking for level 2 silently applied
+// a DIFFERENT level's lockout (here level 3's 900s) to the player.
+//
+// Correct behaviour: the lockout must come from the level being set. When the
+// ladder does not configure that level, fall back to the built-in duration for
+// it (GetLockoutDuration) — never to whatever the quit count happened to map to.
+func TestEarlyQuitModifyRPC_SetPenaltyDoesNotBorrowAnotherLevelsLockout(t *testing.T) {
+	nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+
+	// Ladder with NO level 2 entry, and a distinctive level 3 lockout.
+	seedEarlyQuitLadder(t, ctx, nk, []evr.EarlyQuitPenaltyLevelConfig{
+		{PenaltyLevel: 0, MinEarlyQuits: 0, MaxEarlyQuits: 2, MMLockoutSec: 0},
+		{PenaltyLevel: 1, MinEarlyQuits: 3, MaxEarlyQuits: 10, MMLockoutSec: 777},
+		{PenaltyLevel: 3, MinEarlyQuits: 11, MaxEarlyQuits: 999, MMLockoutSec: 900},
+	})
+
+	// The player's quit count puts them in the level 3 band.
+	state := NewEarlyQuitPlayerState()
+	state.NumEarlyQuits = 20
+	if err := StorableWrite(ctx, nk, targetID, state); err != nil {
+		t.Fatalf("seed player state: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name        string
+		level       int32
+		wantLockout int64 // expected seconds of lockout; 0 means "no lockout"
+	}{
+		{"level absent from ladder uses its own built-in duration, not level 3's 900s", 2, int64(GetLockoutDuration(2).Seconds())},
+		{"level present in ladder uses the ladder's duration for THAT level", 1, 777},
+		{"level 0 clears the lockout", 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			level := tc.level
+			payload, err := json.Marshal(EarlyQuitModifyRequest{
+				GroupID:      groupID,
+				TargetUserID: targetID,
+				Action:       "set_penalty",
+				PenaltyLevel: &level,
+			})
+			if err != nil {
+				t.Fatalf("marshal payload: %v", err)
+			}
+
+			before := time.Now().Unix()
+			out, err := EarlyQuitModifyRPC(ctx, NewRuntimeGoLogger(loggerForTest(t)), nil, nk, string(payload))
+			if err != nil {
+				t.Fatalf("EarlyQuitModifyRPC: %v", err)
+			}
+			after := time.Now().Unix()
+
+			var resp EarlyQuitModifyResponse
+			if err := json.Unmarshal([]byte(out), &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+			if resp.State.PenaltyLevel != tc.level {
+				t.Errorf("PenaltyLevel = %d, want %d", resp.State.PenaltyLevel, tc.level)
+			}
+
+			if tc.wantLockout == 0 {
+				if resp.State.PenaltyTimestamp != 0 {
+					t.Errorf("PenaltyTimestamp = %d, want 0 (no lockout for level %d)", resp.State.PenaltyTimestamp, tc.level)
+				}
+				return
+			}
+
+			gotLockout := resp.State.PenaltyTimestamp - before
+			if gotLockout < tc.wantLockout || resp.State.PenaltyTimestamp-after > tc.wantLockout {
+				t.Errorf("lockout for level %d = %ds (penalty_ts %d, set between %d and %d), want %ds",
+					tc.level, gotLockout, resp.State.PenaltyTimestamp, before, after, tc.wantLockout)
+			}
+		})
+	}
+}
+
+// TestEarlyQuit_ModeratorSanctionSurvivesASubsequentQuit is the headline case
+// for the sanction-wipe bug.
+//
+// resolveAndApplyPenaltyLockout overwrote PenaltyLevel/PenaltyTimestamp from the
+// quit count unconditionally, zeroing BOTH whenever the resolved level carries
+// no lockout. So a moderator sanction applied to a player with a clean record
+// was erased by that player's very next early quit: one quit maps to ladder
+// level 0, and level 0 takes the CLEAR branch.
+//
+// Correct behaviour: a moderator-applied sanction that has not yet expired is
+// not lowered or erased by ladder resolution.
+func TestEarlyQuit_ModeratorSanctionSurvivesASubsequentQuit(t *testing.T) {
+	nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+
+	// Default ladder: 0-2 quits => level 0 / no lockout; level 3 => 900s.
+	seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+	// A player with a completely clean record.
+	state := NewEarlyQuitPlayerState()
+	if err := StorableWrite(ctx, nk, targetID, state); err != nil {
+		t.Fatalf("seed player state: %v", err)
+	}
+
+	// --- a moderator applies a level 3 sanction ---
+	level := int32(3)
+	payload, err := json.Marshal(EarlyQuitModifyRequest{
+		GroupID:      groupID,
+		TargetUserID: targetID,
+		Action:       "set_penalty",
+		PenaltyLevel: &level,
+	})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	if _, err := EarlyQuitModifyRPC(ctx, logger, nil, nk, string(payload)); err != nil {
+		t.Fatalf("EarlyQuitModifyRPC: %v", err)
+	}
+
+	sanctioned := NewEarlyQuitPlayerState()
+	if err := StorableRead(ctx, nk, targetID, sanctioned, false); err != nil {
+		t.Fatalf("read sanctioned state: %v", err)
+	}
+	if sanctioned.PenaltyLevel != 3 || !sanctioned.IsPenaltyActive() {
+		t.Fatalf("precondition: expected an active level 3 sanction, got level %d ts %d",
+			sanctioned.PenaltyLevel, sanctioned.PenaltyTimestamp)
+	}
+	sanctionTS := sanctioned.PenaltyTimestamp
+
+	// --- the player then quits one match ---
+	sanctioned.IncrementEarlyQuit()
+	resolveAndApplyPenaltyLockout(ctx, nk, logger, sanctioned)
+
+	if sanctioned.PenaltyLevel != 3 {
+		t.Errorf("PenaltyLevel = %d after one early quit, want 3: an early quit must not erase a moderator sanction",
+			sanctioned.PenaltyLevel)
+	}
+	if sanctioned.PenaltyTimestamp != sanctionTS {
+		t.Errorf("PenaltyTimestamp = %d after one early quit, want %d (unchanged): an early quit must not shorten a moderator sanction",
+			sanctioned.PenaltyTimestamp, sanctionTS)
+	}
+	if !sanctioned.IsPenaltyActive() {
+		t.Errorf("IsPenaltyActive() = false after one early quit: the moderator sanction was erased")
+	}
+}
+
+// TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries covers the
+// edges around the sanction guard: it must not become permanent immunity, must
+// yield to a harsher ladder result, and must not stop an ordinary (ladder-set)
+// penalty from being lifted.
+func TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries(t *testing.T) {
+	logger := NewRuntimeGoLogger(loggerForTest(t))
+
+	// sanction applies a moderator penalty through the admin RPC and returns
+	// the resulting stored state.
+	sanction := func(t *testing.T, ctx context.Context, nk runtime.NakamaModule, groupID, targetID string, level int32) *EarlyQuitPlayerState {
+		t.Helper()
+		payload, err := json.Marshal(EarlyQuitModifyRequest{
+			GroupID:      groupID,
+			TargetUserID: targetID,
+			Action:       "set_penalty",
+			PenaltyLevel: &level,
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		if _, err := EarlyQuitModifyRPC(ctx, logger, nil, nk, string(payload)); err != nil {
+			t.Fatalf("EarlyQuitModifyRPC: %v", err)
+		}
+		state := NewEarlyQuitPlayerState()
+		if err := StorableRead(ctx, nk, targetID, state, false); err != nil {
+			t.Fatalf("read sanctioned state: %v", err)
+		}
+		return state
+	}
+
+	t.Run("expired sanction stops blocking the ladder", func(t *testing.T) {
+		nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+		seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+		state := sanction(t, ctx, nk, groupID, targetID, 3)
+		state.PenaltyTimestamp = time.Now().Unix() - 1 // sanction just lapsed
+		state.NumEarlyQuits = 1                        // ladder level 0
+
+		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+
+		if state.PenaltyLevel != 0 || state.PenaltyTimestamp != 0 {
+			t.Errorf("after the sanction expired, ladder resolution must apply: got level %d ts %d, want 0/0",
+				state.PenaltyLevel, state.PenaltyTimestamp)
+		}
+	})
+
+	t.Run("a harsher ladder result overrides a lighter sanction", func(t *testing.T) {
+		nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+		seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+		state := sanction(t, ctx, nk, groupID, targetID, 1)
+		state.NumEarlyQuits = 20 // ladder level 3 / 900s
+
+		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+
+		if state.PenaltyLevel != 3 {
+			t.Errorf("PenaltyLevel = %d, want 3: a harsher ladder result must override a lighter sanction", state.PenaltyLevel)
+		}
+	})
+
+	t.Run("an ordinary ladder penalty is still lifted when the count drops", func(t *testing.T) {
+		nk, ctx, _, _ := newEarlyQuitAdminHarness(t)
+		seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+		state := NewEarlyQuitPlayerState()
+		state.NumEarlyQuits = 3
+		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+		if state.PenaltyLevel != 1 || !state.IsPenaltyActive() {
+			t.Fatalf("precondition: expected an active level 1 ladder penalty, got level %d ts %d",
+				state.PenaltyLevel, state.PenaltyTimestamp)
+		}
+
+		// The quit is forgiven; the ladder now resolves to level 0.
+		state.ForgiveLastQuit()
+		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+
+		if state.PenaltyLevel != 0 || state.PenaltyTimestamp != 0 {
+			t.Errorf("ladder penalty was not lifted: got level %d ts %d, want 0/0", state.PenaltyLevel, state.PenaltyTimestamp)
+		}
+	})
+}

--- a/server/evr_earlyquit_moderator_penalty_test.go
+++ b/server/evr_earlyquit_moderator_penalty_test.go
@@ -445,3 +445,99 @@ func TestEarlyQuit_ResetLiftsAModeratorSanction(t *testing.T) {
 			after.PenaltyLevel, after.PenaltyTimestamp)
 	}
 }
+
+// TestEarlyQuit_ASanctionWithNoLockoutLeavesNoPhantomLevel pins the one
+// invariant every reader of PenaltyLevel depends on: a non-zero PenaltyLevel
+// always carries a non-zero PenaltyTimestamp.
+//
+// applyLadderPenalty already states the rule — "A level carrying no lockout is
+// no penalty at all" (evr_earlyquit.go), and it zeroes the level to enforce it.
+// ApplyModeratorPenalty assigned s.PenaltyLevel = level BEFORE branching, so the
+// no-lockout branch cleared the timestamp and the retained sanction but left the
+// level standing. Same ladder, same requested level, two different stored
+// states depending on which path last touched the record.
+//
+// The phantom level is not inert. Both match-completion paths
+// (evr_match.go MatchOver, EventRemoteLogSet.incrementCompletedMatches) read the
+// stored state and call UpdateTier WITHOUT re-resolving the level first, so the
+// phantom drives the player into the Tier 2 queue and fires the "Account
+// flagged for early quitting" DM — for a player IsPenaltyActive() says is not
+// penalized. Nothing on the completion path ever recomputes PenaltyLevel, so
+// "Complete full matches to restore Tier 1 status" cannot come true; only a
+// later early quit (which does re-resolve) clears it.
+func TestEarlyQuit_ASanctionWithNoLockoutLeavesNoPhantomLevel(t *testing.T) {
+	t.Run("the level is cleared with the lockout", func(t *testing.T) {
+		state := NewEarlyQuitPlayerState()
+		state.ApplyModeratorPenalty(2, 0)
+
+		if state.PenaltyLevel != 0 || state.PenaltyTimestamp != 0 {
+			t.Errorf("ApplyModeratorPenalty(2, 0) = level %d ts %d, want 0/0: a level with no lockout is no penalty at all",
+				state.PenaltyLevel, state.PenaltyTimestamp)
+		}
+		if state.PenaltyLevel > 0 && !state.IsPenaltyActive() {
+			t.Errorf("PenaltyLevel = %d while IsPenaltyActive() = false: readers that consult the level alone "+
+				"(UpdateTier, the client profile's EarlyQuitFeatures.PenaltyLevel) now disagree with the lockout",
+				state.PenaltyLevel)
+		}
+	})
+
+	// The reachable path: a ladder that configures a level with no matchmaking
+	// lockout (a coherent config — the level still carries SpawnLock/AutoReport),
+	// and a moderator setting that level through earlyquit/modify. The RPC reads
+	// the lockout straight off that ladder entry and hands 0 to
+	// ApplyModeratorPenalty.
+	t.Run("a moderator setting a lockout-less ladder level does not queue-degrade the player", func(t *testing.T) {
+		nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+		seedEarlyQuitLadder(t, ctx, nk, []evr.EarlyQuitPenaltyLevelConfig{
+			{PenaltyLevel: 0, MinEarlyQuits: 0, MaxEarlyQuits: 2, MMLockoutSec: 0},
+			// Level 2 punishes with a spawn lock and an auto-report, but no
+			// matchmaking lockout. validatePenaltyLevels bounds MMLockoutSec
+			// only from below, and the admin RPC's loader skips Validate
+			// entirely, so this ladder reaches the handler as written.
+			{PenaltyLevel: 2, MinEarlyQuits: 3, MaxEarlyQuits: 999, MMLockoutSec: 0, SpawnLock: 1, AutoReport: 1},
+		})
+
+		state := NewEarlyQuitPlayerState()
+		if err := StorableWrite(ctx, nk, targetID, state); err != nil {
+			t.Fatalf("seed player state: %v", err)
+		}
+
+		level := int32(2)
+		payload, err := json.Marshal(EarlyQuitModifyRequest{
+			GroupID:      groupID,
+			TargetUserID: targetID,
+			Action:       "set_penalty",
+			PenaltyLevel: &level,
+		})
+		if err != nil {
+			t.Fatalf("marshal payload: %v", err)
+		}
+		if _, err := EarlyQuitModifyRPC(ctx, NewRuntimeGoLogger(loggerForTest(t)), nil, nk, string(payload)); err != nil {
+			t.Fatalf("EarlyQuitModifyRPC: %v", err)
+		}
+
+		// Read it back exactly as the completion paths do.
+		stored := NewEarlyQuitPlayerState()
+		if err := StorableRead(ctx, nk, targetID, stored, false); err != nil {
+			t.Fatalf("read stored state: %v", err)
+		}
+		if stored.IsPenaltyActive() {
+			t.Fatalf("precondition: the stored penalty must be inactive (ts %d)", stored.PenaltyTimestamp)
+		}
+		if stored.PenaltyLevel != 0 {
+			t.Errorf("stored PenaltyLevel = %d with PenaltyTimestamp = %d: a phantom level no lockout backs",
+				stored.PenaltyLevel, stored.PenaltyTimestamp)
+		}
+
+		// evr_match.go's MatchOver handler: read, credit the completion, then
+		// UpdateTier — with no re-resolution of the level in between.
+		threshold := int32(0)
+		stored.IncrementCompletedMatches()
+		oldTier, newTier, changed := stored.UpdateTier(&threshold)
+		if newTier != MatchmakingTier1 {
+			t.Errorf("completing a match moved the player from tier %d to tier %d (changed=%v) "+
+				"while IsPenaltyActive() = false: an unpenalized player was degraded to the Tier 2 queue",
+				oldTier, newTier, changed)
+		}
+	})
+}

--- a/server/evr_earlyquit_moderator_penalty_test.go
+++ b/server/evr_earlyquit_moderator_penalty_test.go
@@ -230,9 +230,13 @@ func TestEarlyQuit_ModeratorSanctionSurvivesASubsequentQuit(t *testing.T) {
 }
 
 // TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries covers the
-// edges around the sanction guard: it must not become permanent immunity, must
-// yield to a harsher ladder result, and must not stop an ordinary (ladder-set)
-// penalty from being lifted.
+// edges around the sanction floor: it must hold both dimensions while it is in
+// force, must not become permanent immunity, must yield to a harsher ladder
+// result, and must not stop an ordinary (ladder-set) penalty from being lifted.
+//
+// Only the first subtest can fail from deleting the floor; the other three are
+// over-correction guards, and they pass with the feature removed entirely. Read
+// them as "the fix did not break the ordinary case", not as coverage of the fix.
 func TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries(t *testing.T) {
 	logger := NewRuntimeGoLogger(loggerForTest(t))
 
@@ -258,6 +262,34 @@ func TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries(t *testing.T)
 		}
 		return state
 	}
+
+	t.Run("an unexpired sanction floors both the level and the expiry", func(t *testing.T) {
+		nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)
+		seedEarlyQuitLadder(t, ctx, nk, evr.DefaultEarlyQuitLevels().PenaltyLevels)
+
+		state := sanction(t, ctx, nk, groupID, targetID, 3)
+		// A week-long sanction, the shape the Discord handler's
+		// duration-minutes option exists to produce.
+		weekOut := time.Now().Unix() + 7*24*60*60
+		state.PenaltyTimestamp = weekOut
+		state.ModeratorPenaltyUntil = weekOut
+		// The ladder on its own would say "no penalty at all" for this player.
+		state.NumEarlyQuits = 1
+
+		resolveAndApplyPenaltyLockout(ctx, nk, logger, state)
+
+		if state.PenaltyLevel != 3 {
+			t.Errorf("PenaltyLevel = %d, want 3: ladder resolution lowered a level the moderator set", state.PenaltyLevel)
+		}
+		if state.PenaltyTimestamp != weekOut {
+			t.Errorf("PenaltyTimestamp = %d, want %d (delta %ds): ladder resolution shortened a moderator sanction",
+				state.PenaltyTimestamp, weekOut, weekOut-state.PenaltyTimestamp)
+		}
+		if state.ModeratorPenaltyLevel != 3 || state.ModeratorPenaltyUntil != weekOut {
+			t.Errorf("retained sanction = level %d until %d, want 3 until %d: an unexpired sanction must survive resolution",
+				state.ModeratorPenaltyLevel, state.ModeratorPenaltyUntil, weekOut)
+		}
+	})
 
 	t.Run("expired sanction stops blocking the ladder", func(t *testing.T) {
 		nk, ctx, targetID, groupID := newEarlyQuitAdminHarness(t)

--- a/server/evr_latencyhistory_test.go
+++ b/server/evr_latencyhistory_test.go
@@ -113,6 +113,20 @@ func (m *occTestNakamaModule) StorageWrite(ctx context.Context, writes []*runtim
 	return acks, nil
 }
 
+// MultiUpdate models the entry point StorableWriteMany uses. Only the storage
+// writes are modelled: nothing in this package batches account, wallet or delete
+// operations through it, and a test that starts doing so should teach this
+// double what that means rather than have it silently no-op.
+//
+// CAUTION: Go embedding does not dispatch virtually, so this calls THIS type's
+// StorageWrite, not an override on a type that embeds it. A double that
+// overrides StorageWrite to inject a fault must override MultiUpdate too, or the
+// fault is silently bypassed on the batch path and the write appears to succeed.
+func (m *occTestNakamaModule) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	acks, err := m.StorageWrite(ctx, storageWrites)
+	return acks, nil, err
+}
+
 func (m *occTestNakamaModule) StorageRead(ctx context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1592,13 +1592,17 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 					continue
 				}
 
-				// Track completion in detailed history first; only credit the
-				// counter when this is the first time the match is reported
-				// (the post-match stats upload also reports it).
+				// Stage the completion in the detailed history; only credit
+				// the counter when this is the first time the match is
+				// reported (the post-match stats upload also reports it).
+				// The staged record is the dedupe marker, so it is committed
+				// together with the credit below — never on its own, which
+				// would make a failed counter write lose the credit for good.
 				// Warn, not Debug: this is the failure that costs the player
 				// match credit, so it must be at least as visible as the
 				// adjacent eqconfig write failure below.
-				if first, err := TrackMatchCompletion(ctx, logger, nk, presence.GetUserId(), state.ID, time.Now().UTC()); err != nil {
+				first, history, err := PrepareMatchCompletion(ctx, logger, nk, presence.GetUserId(), state.ID, time.Now().UTC())
+				if err != nil {
 					logger.WithField("error", err).Warn("Failed to track match completion in history")
 				} else if first {
 					eqconfig.IncrementCompletedMatches()
@@ -1615,8 +1619,14 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 					"eqconfig":     eqconfig,
 				}).Debug("Player completed match tier update.")
 
-				if err := StorableWrite(ctx, nk, presence.GetUserId(), eqconfig); err != nil {
-					logger.Warn("Failed to write early quitter config after completed match", zap.Error(err))
+				var writeErr error
+				if first && history != nil {
+					writeErr = StorableWriteMany(ctx, nk, presence.GetUserId(), eqconfig, history)
+				} else {
+					writeErr = StorableWrite(ctx, nk, presence.GetUserId(), eqconfig)
+				}
+				if writeErr != nil {
+					logger.Warn("Failed to write early quitter config after completed match", zap.Error(writeErr))
 				} else {
 					if sessions != nil {
 						if s := sessions.Get(uuid.FromStringOrNil(presence.GetSessionId())); s != nil {

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1598,13 +1598,11 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				// The staged record is the dedupe marker, so it is committed
 				// together with the credit below — never on its own, which
 				// would make a failed counter write lose the credit for good.
-				// Warn, not Debug: this is the failure that costs the player
-				// match credit, so it must be at least as visible as the
-				// adjacent eqconfig write failure below.
-				first, history, err := PrepareMatchCompletion(ctx, logger, nk, presence.GetUserId(), state.ID, time.Now().UTC())
-				if err != nil {
-					logger.WithField("error", err).Warn("Failed to track match completion in history")
-				} else if first {
+				// A history read failure no longer surfaces here:
+				// PrepareMatchCompletion self-heals an unreadable row and logs
+				// it at Warn itself.
+				first, history := PrepareMatchCompletion(ctx, logger, nk, presence.GetUserId(), state.ID, time.Now().UTC())
+				if first {
 					eqconfig.IncrementCompletedMatches()
 				}
 

--- a/server/evr_match_completion_credit_test.go
+++ b/server/evr_match_completion_credit_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// matchOverState builds the minimum MatchLabel that drives the MatchLoop
+// MatchOver branch: an arena public match that has started, still has the
+// player on the server, and whose game state reports the match is over.
+func matchOverState(player *EvrMatchPresence) *MatchLabel {
+	serverSession := uuid.Must(uuid.NewV4())
+	operatorID := uuid.Must(uuid.NewV4())
+	groupID := uuid.Must(uuid.NewV4())
+
+	state := &MatchLabel{
+		ID:        MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "test-node"},
+		CreatedAt: time.Now().UTC().Add(-time.Minute),
+		StartTime: time.Now().UTC().Add(-time.Minute),
+		Open:      true,
+		LobbyType: PublicLobby,
+		Mode:      evr.ModeArenaPublic,
+		Level:     evr.LevelArena,
+		MaxSize:   16,
+		GroupID:   &groupID,
+		GameServer: &GameServerPresence{
+			SessionID:  serverSession,
+			OperatorID: operatorID,
+			GroupIDs:   []uuid.UUID{groupID},
+		},
+		server: &Presence{
+			ID:     PresenceID{Node: "test-node", SessionID: serverSession},
+			UserID: operatorID,
+		},
+		GameState:             &GameState{MatchOver: true},
+		Players:               make([]PlayerInfo, 0, 16),
+		presenceMap:           make(map[string]*EvrMatchPresence, 16),
+		reservationMap:        make(map[string]*slotReservation),
+		reconnectReservations: make(map[string]*reconnectReservation),
+		presenceByEvrID:       make(map[evr.EvrId]*EvrMatchPresence, 16),
+		TeamAlignments:        make(map[string]int, 16),
+		joinTimestamps:        make(map[string]time.Time, 16),
+		joinTimeMilliseconds:  make(map[string]int64, 16),
+		participations:        make(map[string]*PlayerParticipation, 16),
+		tickRate:              10,
+	}
+	state.levelLoaded = true
+	state.presenceMap[player.GetSessionId()] = player
+	state.joinTimestamps[player.GetSessionId()] = time.Now()
+	state.rebuildCache()
+	return state
+}
+
+// TestMatchLoopCompletion_CreditSurvivesARejectedCounterWrite is the MatchLoop
+// half of the completion-credit ordering, the sibling of
+// TestMatchCompletion_CreditSurvivesARejectedCounterWrite (which drives the
+// post-match stats upload).
+//
+// Both reporters share one dedupe record — the player's completion history — so
+// each of them must commit that record and the credited counter together. The
+// MatchLoop MatchOver dispatch committed the record first and only Warn-logged a
+// failed counter write, so a counter write that lost an optimistic-concurrency
+// race left the match marked as counted but never counted. The stats upload
+// then saw the record, returned first=false, and the credit was gone for good.
+//
+// Correct behaviour: a rejected write leaves no dedupe record behind, so the
+// other reporter still finds an uncounted match and credits it exactly once.
+func TestMatchLoopCompletion_CreditSurvivesARejectedCounterWrite(t *testing.T) {
+	logger := reconnectTestLogger()
+	nk := newCompletionTestNK()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	player := reconnectTestPlayer("completion", evr.TeamBlue)
+	userID := player.GetUserId()
+	state := matchOverState(player)
+
+	// One concurrent writer wins the race against the counter row, exactly once.
+	rejected := false
+	nk.beforeWrite = func(writes []*runtime.StorageWrite) error {
+		if rejected {
+			return nil
+		}
+		for _, w := range writes {
+			if w.Collection == StorageCollectionEarlyQuit && w.Key == StorageKeyEarlyQuit && w.UserID == userID && w.Version != "" {
+				rejected = true
+				return runtime.ErrStorageRejectedVersion
+			}
+		}
+		return nil
+	}
+
+	// Reporter 1: the MatchLoop MatchOver dispatch. tick must be a multiple of
+	// 2*tickRate for the participation/summary block to run.
+	m := &EvrMatch{}
+	if out := m.MatchLoop(ctx, logger, nil, nk, &drainTestDispatcher{}, int64(2*state.tickRate), state, nil); out == nil {
+		t.Fatal("MatchLoop terminated the match")
+	}
+	if !state.matchSummarySent {
+		t.Fatal("precondition: the MatchOver branch never ran, so no completion was reported")
+	}
+	if !rejected {
+		t.Fatal("precondition: the injected rejection never fired; the counter write was not attempted")
+	}
+
+	// Reporter 2: the post-match stats upload for the same match.
+	s := &EventRemoteLogSet{}
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", state.ID); err != nil {
+		t.Fatalf("stats-upload report: %v", err)
+	}
+
+	stored, history := storedCompletionState(t, ctx, nk, userID)
+	if stored.TotalCompletedMatches != 1 {
+		t.Errorf("TotalCompletedMatches = %d, want 1: the completion was recorded but never credited",
+			stored.TotalCompletedMatches)
+	}
+	if got := countCompletionsFor(history, state.ID); got != 1 {
+		t.Errorf("completion records for the match = %d, want 1", got)
+	}
+}
+
+// TestMatchLoopCompletion_CreditedOnceAcrossBothReporters is the ordinary
+// no-fault path: the MatchLoop dispatch credits the match, and the post-match
+// stats upload for the same match must find the dedupe record and credit
+// nothing further.
+func TestMatchLoopCompletion_CreditedOnceAcrossBothReporters(t *testing.T) {
+	logger := reconnectTestLogger()
+	nk := newCompletionTestNK()
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	player := reconnectTestPlayer("completion-clean", evr.TeamOrange)
+	userID := player.GetUserId()
+	state := matchOverState(player)
+
+	m := &EvrMatch{}
+	if out := m.MatchLoop(ctx, logger, nil, nk, &drainTestDispatcher{}, int64(2*state.tickRate), state, nil); out == nil {
+		t.Fatal("MatchLoop terminated the match")
+	}
+	if !state.matchSummarySent {
+		t.Fatal("precondition: the MatchOver branch never ran, so no completion was reported")
+	}
+
+	stored, history := storedCompletionState(t, ctx, nk, userID)
+	if stored.TotalCompletedMatches != 1 {
+		t.Fatalf("after the MatchLoop report, TotalCompletedMatches = %d, want 1", stored.TotalCompletedMatches)
+	}
+	if got := countCompletionsFor(history, state.ID); got != 1 {
+		t.Fatalf("after the MatchLoop report, completion records = %d, want 1", got)
+	}
+
+	s := &EventRemoteLogSet{}
+	if err := s.incrementCompletedMatches(ctx, logger, nk, nil, &testSessionRegistry{}, userID, "", state.ID); err != nil {
+		t.Fatalf("stats-upload report: %v", err)
+	}
+
+	stored, history = storedCompletionState(t, ctx, nk, userID)
+	if stored.TotalCompletedMatches != 1 {
+		t.Errorf("TotalCompletedMatches = %d after the second reporter, want 1: the match was double-credited",
+			stored.TotalCompletedMatches)
+	}
+	if got := countCompletionsFor(history, state.ID); got != 1 {
+		t.Errorf("completion records for the match = %d, want 1: the dedupe record was duplicated", got)
+	}
+}

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -573,13 +573,17 @@ func (s *EventRemoteLogSet) incrementCompletedMatches(ctx context.Context, logge
 	if err := StorableRead(ctx, nk, userID, eqconfig, true); err != nil {
 		logger.WithField("error", err).Warn("Failed to load early quitter config")
 	} else {
-		// Track completion in detailed history first; only credit the counter
+		// Stage the completion in the detailed history; only credit the counter
 		// when this is the first time the match is reported (the MatchLoop
-		// MatchOver dispatch also reports it).
+		// MatchOver dispatch also reports it). The staged record is the dedupe
+		// marker, so it is committed together with the credit below — never on
+		// its own, which would make a failed counter write lose the credit for
+		// good.
 		// Warn, not Debug: this is the failure that costs the player match
 		// credit (no history write means no IncrementCompletedMatches), so it
 		// must be at least as visible as the adjacent eqconfig write failure.
-		if first, err := TrackMatchCompletion(ctx, logger, nk, userID, matchID, time.Now().UTC()); err != nil {
+		first, history, err := PrepareMatchCompletion(ctx, logger, nk, userID, matchID, time.Now().UTC())
+		if err != nil {
 			logger.WithField("error", err).Warn("Failed to track match completion in history")
 		} else if first {
 			eqconfig.IncrementCompletedMatches()
@@ -589,8 +593,14 @@ func (s *EventRemoteLogSet) incrementCompletedMatches(ctx context.Context, logge
 		serviceSettings := ServiceSettings()
 		oldTier, newTier, tierChanged := eqconfig.UpdateTier(serviceSettings.Matchmaking.EarlyQuitTier1Threshold)
 
-		if err := StorableWrite(ctx, nk, userID, eqconfig); err != nil {
-			logger.WithField("error", err).Warn("Failed to store early quitter config")
+		var writeErr error
+		if first && history != nil {
+			writeErr = StorableWriteMany(ctx, nk, userID, eqconfig, history)
+		} else {
+			writeErr = StorableWrite(ctx, nk, userID, eqconfig)
+		}
+		if writeErr != nil {
+			logger.WithField("error", writeErr).Warn("Failed to store early quitter config")
 		} else {
 			// Update session cache
 			if playerSession := sessionRegistry.Get(uuid.FromStringOrNil(sessionID)); playerSession != nil {

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -579,13 +579,10 @@ func (s *EventRemoteLogSet) incrementCompletedMatches(ctx context.Context, logge
 		// marker, so it is committed together with the credit below — never on
 		// its own, which would make a failed counter write lose the credit for
 		// good.
-		// Warn, not Debug: this is the failure that costs the player match
-		// credit (no history write means no IncrementCompletedMatches), so it
-		// must be at least as visible as the adjacent eqconfig write failure.
-		first, history, err := PrepareMatchCompletion(ctx, logger, nk, userID, matchID, time.Now().UTC())
-		if err != nil {
-			logger.WithField("error", err).Warn("Failed to track match completion in history")
-		} else if first {
+		// A history read failure no longer surfaces here: PrepareMatchCompletion
+		// self-heals an unreadable row and logs it at Warn itself.
+		first, history := PrepareMatchCompletion(ctx, logger, nk, userID, matchID, time.Now().UTC())
+		if first {
 			eqconfig.IncrementCompletedMatches()
 		}
 

--- a/server/evr_runtime_rpc_earlyquit_manage.go
+++ b/server/evr_runtime_rpc_earlyquit_manage.go
@@ -211,22 +211,19 @@ func EarlyQuitModifyRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		state.GuildOverrides[request.GroupID].PenaltyLevel = &level
 		state.GuildOverrides[request.GroupID].ModeratorNotes = request.ModeratorNotes
 
-		// Also update global penalty and lockout from config
-		state.PenaltyLevel = level
-		_, lockoutSec := ResolvePenaltyLevel(state.NumEarlyQuits, serviceConfig)
-		_ = lockoutSec // Use config lockout for the resolved level
-		// Find lockout for the SET level specifically
+		// Also update global penalty and lockout from config. The lockout must
+		// come from the level being SET: seeding it from the level the target's
+		// current quit count maps to made a level absent from the ladder borrow
+		// a different level's lockout. When the ladder does not configure the
+		// requested level, fall back to the built-in duration for that level.
+		lockoutSec := GetLockoutDurationSeconds(int(level))
 		for _, pl := range serviceConfig.PenaltyLevels {
 			if int32(pl.PenaltyLevel) == level {
-				lockoutSec = int32(pl.MMLockoutSec)
+				lockoutSec = clampLockoutSec(pl.MMLockoutSec)
 				break
 			}
 		}
-		if lockoutSec > 0 {
-			state.PenaltyTimestamp = time.Now().Unix() + int64(lockoutSec)
-		} else {
-			state.PenaltyTimestamp = 0
-		}
+		state.ApplyModeratorPenalty(level, lockoutSec)
 
 		message = fmt.Sprintf("Penalty level set to %d", level)
 
@@ -234,6 +231,9 @@ func EarlyQuitModifyRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		state.NumEarlyQuits = 0
 		state.NumSteadyEarlyQuits = 0
 		state.PenaltyTimestamp = 0
+		// A reset also lifts any moderator-applied sanction; leaving the marker
+		// set would block ladder resolution for the rest of the old lockout.
+		state.PenaltyIsManual = false
 
 		// Re-resolve penalty from config (should be level 0 with 0 quits)
 		level, _ := ResolvePenaltyLevel(0, serviceConfig)

--- a/server/evr_runtime_rpc_earlyquit_manage.go
+++ b/server/evr_runtime_rpc_earlyquit_manage.go
@@ -216,7 +216,7 @@ func EarlyQuitModifyRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		// current quit count maps to made a level absent from the ladder borrow
 		// a different level's lockout. When the ladder does not configure the
 		// requested level, fall back to the built-in duration for that level.
-		lockoutSec := GetLockoutDurationSeconds(int(level))
+		lockoutSec := int32(GetLockoutDuration(int(level)).Seconds())
 		for _, pl := range serviceConfig.PenaltyLevels {
 			if int32(pl.PenaltyLevel) == level {
 				lockoutSec = clampLockoutSec(pl.MMLockoutSec)

--- a/server/evr_runtime_rpc_earlyquit_manage.go
+++ b/server/evr_runtime_rpc_earlyquit_manage.go
@@ -231,9 +231,9 @@ func EarlyQuitModifyRPC(ctx context.Context, logger runtime.Logger, db *sql.DB, 
 		state.NumEarlyQuits = 0
 		state.NumSteadyEarlyQuits = 0
 		state.PenaltyTimestamp = 0
-		// A reset also lifts any moderator-applied sanction; leaving the marker
-		// set would block ladder resolution for the rest of the old lockout.
-		state.PenaltyIsManual = false
+		// A reset also lifts any moderator-applied sanction; leaving it retained
+		// would keep flooring ladder resolution for the rest of the old lockout.
+		state.ClearModeratorPenalty()
 
 		// Re-resolve penalty from config (should be level 0 with 0 quits)
 		level, _ := ResolvePenaltyLevel(0, serviceConfig)

--- a/server/evr_storable.go
+++ b/server/evr_storable.go
@@ -263,9 +263,10 @@ func storableCreate(ctx context.Context, nk runtime.NakamaModule, userID string,
 // conflict on this path look like a hard failure and defeat the retry loop in
 // SyncJournalAndProfileWithRetry.
 //
-// Acks come back in input order (storageWriteObjects assigns them by the
-// original index at core_storage.go:686), so versions are propagated back to
-// the matching source object.
+// Versions are propagated back to the source objects by applyStorageAcks, which
+// matches on collection/key rather than trusting ack order. Nakama's own
+// implementation does assign acks by the original index (storageWriteObjects,
+// core_storage.go:686), but the runtime API does not promise it.
 func StorableWriteMany(ctx context.Context, nk runtime.NakamaModule, userID string, srcs ...StorableAdapter) error {
 	if len(srcs) == 0 {
 		return nil
@@ -305,14 +306,7 @@ func StorableWriteMany(ctx context.Context, nk runtime.NakamaModule, userID stri
 			"atomic write of %d objects failed, none applied (%s): %w", len(ops), strings.Join(paths, ", "), err)
 	}
 
-	for i, ack := range acks {
-		if i >= len(srcs) {
-			break
-		}
-		meta := metas[i]
-		meta.Version = ack.GetVersion()
-		srcs[i].SetStorageMeta(meta)
-	}
+	applyStorageAcks(acks, metas, srcs)
 	return nil
 }
 

--- a/server/evr_storable.go
+++ b/server/evr_storable.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/heroiclabs/nakama-common/runtime"
 	"google.golang.org/grpc/codes"
@@ -296,14 +295,11 @@ func StorableWriteMany(ctx context.Context, nk runtime.NakamaModule, userID stri
 	// Storage writes only: no account updates, no deletes, no wallet updates.
 	acks, _, err := nk.MultiUpdate(ctx, nil, ops, nil, nil, false)
 	if err != nil {
-		// Name every object in the batch: the caller needs to know that NONE of
-		// them were applied, not just the one that happened to be rejected.
-		paths := make([]string, 0, len(metas))
-		for _, m := range metas {
-			paths = append(paths, m.String())
-		}
-		return storableErrorf(metas[0], codes.Internal,
-			"atomic write of %d objects failed, none applied (%s): %w", len(ops), strings.Join(paths, ", "), err)
+		// Attribute the failure to the batch, not to metas[0]: the caller needs
+		// to know that NONE of them were applied, and the storage layer does not
+		// tell us which object was actually rejected.
+		return storableBatchErrorf(metas, codes.Internal,
+			"atomic write of %d objects failed, none applied: %w", len(ops), err)
 	}
 
 	applyStorageAcks(acks, metas, srcs)

--- a/server/evr_storable_batch.go
+++ b/server/evr_storable_batch.go
@@ -1,8 +1,47 @@
 package server
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/heroiclabs/nakama-common/api"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// storableBatchErrorf reports a failure that belongs to a BATCH rather than to
+// any one object in it, naming every object the batch carried.
+//
+// A rejection on any single object aborts the whole transaction, and the
+// storage layer does not say which one it was: storageWriteObjects
+// (core_storage.go) holds the offending object when it rejects but returns a
+// bare runtime.ErrStorageRejectedVersion / ErrStorageRejectedPermission, and
+// StorageWriteObjects passes that sentinel up unadorned. Blaming one member of
+// the batch would assert an identity we do not have — and under contention it
+// is the wrong one, since the first object listed is not the likeliest loser of
+// the race.
+//
+// Like storableErrorf, the format string is evaluated with fmt.Errorf so a `%w`
+// verb keeps the underlying storage error reachable through errors.Is. That is
+// load-bearing, not cosmetic: isVersionConflictError is errors.Is-based, so
+// formatting the cause away here would make every version conflict on this path
+// look like a hard failure and defeat the retry loop in
+// SyncJournalAndProfileWithRetry.
+//
+// It keeps storableErrorf's "storable error on …" prefix so existing log
+// searches still find it.
+func storableBatchErrorf(metas []StorableMetadata, c codes.Code, format string, a ...any) error {
+	ids := make([]string, 0, len(metas))
+	for _, m := range metas {
+		ids = append(ids, fmt.Sprintf("%s/%s/%s/%s", m.UserID, m.Collection, m.Key, m.Version))
+	}
+	cause := fmt.Errorf(format, a...)
+	return &storableError{
+		code: c,
+		msg:  fmt.Sprintf("storable error on one of batch [%s]: %v", strings.Join(ids, ", "), status.Error(c, cause.Error())),
+		err:  cause,
+	}
+}
 
 // applyStorageAcks stamps the versions returned by a batch write back onto the
 // source storables.

--- a/server/evr_storable_batch.go
+++ b/server/evr_storable_batch.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"github.com/heroiclabs/nakama-common/api"
+)
+
+// applyStorageAcks stamps the versions returned by a batch write back onto the
+// source storables.
+//
+// Nakama's own implementation returns acks in request order, but the runtime API
+// does not promise it. Match on collection/key so a reordering implementation
+// cannot silently stamp the wrong version onto a storable — a wrong version is
+// not a cosmetic error, it is an optimistic-concurrency check that will now pass
+// when it should have failed.
+//
+// An ack with no matching meta is ignored rather than treated as an error: the
+// caller has already been told the write succeeded, and there is no source
+// object to attribute it to.
+func applyStorageAcks(acks []*api.StorageObjectAck, metas []StorableMetadata, srcs []StorableAdapter) {
+	for _, ack := range acks {
+		for i, meta := range metas {
+			if i >= len(srcs) {
+				break
+			}
+			if ack.GetCollection() == meta.Collection && ack.GetKey() == meta.Key {
+				meta.Version = ack.GetVersion()
+				srcs[i].SetStorageMeta(meta)
+				break
+			}
+		}
+	}
+}

--- a/server/evr_storable_batch_test.go
+++ b/server/evr_storable_batch_test.go
@@ -1,0 +1,77 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// rejectSecondWriteNakamaModule rejects a batch on a version conflict against
+// the SECOND object in it, and reports it the way the real storage layer does:
+// a bare runtime.ErrStorageRejectedVersion carrying no object identity at all.
+//
+// That fidelity is the point of the test. storageWriteObjects (core_storage.go)
+// has the offending object in hand when it rejects, but returns the sentinel
+// without it; StorageWriteObjects then wraps the sentinel and returns it
+// unadorned. So a caller of nk.StorageWrite genuinely cannot learn which object
+// of the batch was rejected.
+type rejectSecondWriteNakamaModule struct {
+	runtime.NakamaModule
+	seen [][]*runtime.StorageWrite
+}
+
+func (m *rejectSecondWriteNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	m.seen = append(m.seen, writes)
+	return nil, runtime.ErrStorageRejectedVersion
+}
+
+// TestStorableWriteMany_BatchErrorDoesNotBlameTheWrongObject pins what a failed
+// batch write is allowed to claim.
+//
+// StorableWriteMany wrapped the failure with metas[0], so the message asserted a
+// specific object — "storable error on <user>/EarlyQuit/statistics/..." — that
+// the storage layer never named. In the batch the completion path actually
+// writes (StorableWriteMany(ctx, nk, userID, eqconfig, history) in
+// evr_match.go), metas[0] is always the early-quit state row, so a version
+// conflict on the HISTORY row was reported against the state row. Under
+// contention that sends whoever reads the log at the wrong record.
+//
+// The storage layer does not say which object it rejected, so neither may we:
+// name every object in the batch. This is a reporting fix only — the error is
+// still returned, unretried, for the caller to resolve ("errors are okay,
+// retries are picking a winner in a race").
+func TestStorableWriteMany_BatchErrorDoesNotBlameTheWrongObject(t *testing.T) {
+	t.Parallel()
+
+	nk := &rejectSecondWriteNakamaModule{}
+	userID := occTestUserID
+
+	state := NewEarlyQuitPlayerState()
+	history := NewEarlyQuitHistory(userID)
+
+	err := StorableWriteMany(context.Background(), nk, userID, state, history)
+	if err == nil {
+		t.Fatal("StorableWriteMany returned nil on a rejected batch write")
+	}
+
+	// Both objects must be identifiable from the message; the conflict could
+	// have been on either and the storage layer did not tell us.
+	for _, src := range []StorableAdapter{state, history} {
+		meta := src.StorageMeta()
+		if !strings.Contains(err.Error(), meta.Collection) || !strings.Contains(err.Error(), meta.Key) {
+			t.Errorf("batch error does not identify %s/%s, so a conflict on it is reported against another object.\n"+
+				"got: %v", meta.Collection, meta.Key, err)
+		}
+	}
+
+	// The user and the underlying cause must survive the rewording.
+	if !strings.Contains(err.Error(), userID) {
+		t.Errorf("batch error dropped the user ID %s: %v", userID, err)
+	}
+	if !strings.Contains(err.Error(), runtime.ErrStorageRejectedVersion.Error()) {
+		t.Errorf("batch error dropped the underlying cause %q: %v", runtime.ErrStorageRejectedVersion, err)
+	}
+}

--- a/server/evr_storable_batch_test.go
+++ b/server/evr_storable_batch_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -26,6 +27,13 @@ type rejectSecondWriteNakamaModule struct {
 func (m *rejectSecondWriteNakamaModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
 	m.seen = append(m.seen, writes)
 	return nil, runtime.ErrStorageRejectedVersion
+}
+
+// MultiUpdate is the entry point StorableWriteMany actually calls; this path
+// only ever carries storage writes, so it rejects the same way.
+func (m *rejectSecondWriteNakamaModule) MultiUpdate(ctx context.Context, accountUpdates []*runtime.AccountUpdate, storageWrites []*runtime.StorageWrite, storageDeletes []*runtime.StorageDelete, walletUpdates []*runtime.WalletUpdate, updateLedger bool) ([]*api.StorageObjectAck, []*runtime.WalletUpdateResult, error) {
+	acks, err := m.StorageWrite(ctx, storageWrites)
+	return acks, nil, err
 }
 
 // TestStorableWriteMany_BatchErrorDoesNotBlameTheWrongObject pins what a failed
@@ -73,5 +81,15 @@ func TestStorableWriteMany_BatchErrorDoesNotBlameTheWrongObject(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), runtime.ErrStorageRejectedVersion.Error()) {
 		t.Errorf("batch error dropped the underlying cause %q: %v", runtime.ErrStorageRejectedVersion, err)
+	}
+
+	// The sentinel must survive in the CHAIN, not just in the text.
+	// isVersionConflictError is errors.Is-based, so formatting the cause away
+	// here (a %v where a %w belongs) would make every version conflict on this
+	// path read as a hard failure and silently stop the retry loop in
+	// SyncJournalAndProfileWithRetry.
+	if !errors.Is(err, runtime.ErrStorageRejectedVersion) {
+		t.Errorf("batch error broke the errors.Is chain to ErrStorageRejectedVersion, "+
+			"so isVersionConflictError can no longer see a version conflict: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes seven defects in early-quit penalty state and match-completion tracking. All are in `server/evr_earlyquit*.go` plus the two completion-credit call sites.

**Pinned SHA for review: `3bfd5f695`.** This branch moved during the adversarial review (the reviewer was handed `585306cb1`, and `841bffc67` / `5436d281b` landed mid-review). Every citation below is verified against `3bfd5f695` for both SHA and line number.

---

## Summary

| # | Scenario | Class | Gated behind | Frequency |
|---|---|---|---|---|
| 1 | Quit count in a ladder gap, or below the ladder's floor, got the **maximum** penalty | FIX | operator ladder config only | unreachable on the default ladder — see §1 |
| 2 | `MMLockoutSec` ≥ 2^31 wrapped and **silently disabled** the lockout | FIX | operator ladder config only | unreachable on the default ladder — see §2 |
| 3 | A player's early quit **erased a moderator sanction** | FIX | always on | unquantified |
| 4 | Quitting **more** shortened a long moderator sanction | FIX | always on | unquantified |
| 5 | A forgiven logout-quit kept serving the **full lockout**, and the tier never recovered | FIX | always on | every voluntary quit followed by a logout within 5 min |
| 6 | Match completion credit lost for good on a contended write | FIX | always on | unquantified (needs concurrency) |
| 7 | A corrupt history row was a permanent **completion-credit blackhole** | FIX | always on | unquantified (needs a corrupt row) |
| 8 | Tier-restored Discord DM on logout forgiveness | NEW (newly reachable) | `enable_early_quit_penalty` && !`silent_early_quit_system` | once per tier restoration |

---

## 1. Ladder resolution is total instead of falling through to max penalty  [FIX]

**What was tried:** An operator configures a penalty ladder whose first band starts above 0 (e.g. levels at 3–5 and 6–999, nothing for 0–2), or one with a gap (0–2, then 5–10 — nothing for 3 and 4). A player with 1 early quit matchmakes.
**What they expected:** 1 quit is below every configured band, so no penalty.
**What happened BEFORE this PR:** The loop found no containing band and fell through to `cfg.PenaltyLevels[len-1]` — the **last** configured level, i.e. the harshest lockout in the ladder. A player with fewer quits than the ladder's floor got the maximum penalty. Same for a count landing in a gap.
**Estimated frequency:** Unreachable on the default ladder, which is contiguous 0-2/3-5/6-10/11-999 (`server/evr/login_earlyquitconfig.go:112-115 @ 3bfd5f695`) and covers every count including >999 identically before and after. Reachable only for an operator-supplied ladder with a gap or a non-zero floor. `validatePenaltyLevels` only ever *raises* `MinEarlyQuits` to close overlaps (`server/evr/login_earlyquitconfig.go:170-178 @ 3bfd5f695`) — it never lowers one to close a gap and never forces a floor at 0, so both shapes survive validation.
**What happens AFTER this PR:** Resolution is total. A count outside every band resolves to the band with the highest floor among those it has cleared **entirely** (ceiling already passed), and to no penalty at all when it has cleared none. Only a count above every band gets the top level.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none — silent.
**How to verify in production logs:** Not observable in logs; this path emits nothing. Observe it instead through the penalty level in the existing tier-update record — `grep 'Early quitter tier update' /home/echovrce/deployment/logs/nakama.log` (Debug level, `server/evr_match.go:1064 @ 3bfd5f695`) — and read the embedded `eqconfig`'s `penalty_level` against the guild's configured ladder.
**Citation:** `server/evr_earlyquit.go:179-205 @ 3bfd5f695`. Base behaviour: `git show d3e7e5549:server/evr_earlyquit.go` lines 128-132, `// If no level matches (quit count above all ranges), use the highest level`. Test: `TestResolvePenaltyLevel_UnderRangeAndGapDoNotGiveMaxPenalty`, 12 subtests.

## 2. Config lockout saturates instead of wrapping to a disabled penalty  [FIX]

**What was tried:** An operator sets `mm_lockout_sec` to a very large value — 2147483648 (2^31) or 4294967296 (2^32) — intending a very long lockout.
**What they expected:** A very long lockout.
**What happened BEFORE this PR:** `int32(pl.MMLockoutSec)` wrapped. 2^31 became `-2147483648`; 2^32 became exactly `0`. Every caller gates on `lockoutSec > 0`, so both took the **CLEAR** branch: the config value that asked for a longer lockout silently disabled the penalty entirely.
**Estimated frequency:** Unreachable on the default ladder (max `mm_lockout_sec` is 900). Requires an operator-supplied out-of-range value. Validation does not catch it: `LoadEarlyQuitServiceConfig` *does* call `config.Validate()` on the read-success path (`server/evr_early_quit_message_trigger.go:122 @ 3bfd5f695`), but `validatePenaltyLevels` bounds `MMLockoutSec` only from below — `if level.MMLockoutSec < 0 { level.MMLockoutSec = 0 }` (`server/evr/login_earlyquitconfig.go:157-158 @ 3bfd5f695`) — and imposes no upper bound anywhere. The admin RPC's own loader `loadEarlyQuitServiceConfigOrDefault` skips `Validate` altogether (`server/evr_runtime_rpc_earlyquit_manage.go:321-328 @ 3bfd5f695`).
**What happens AFTER this PR:** `clampLockoutSec` saturates at `math.MaxInt32`. An absurdly long lockout is still a lockout.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none — silent.
**How to verify in production logs:** Not observable in logs. Check the stored config instead: the `EarlyQuit|config` storage row under `SystemUserID`; any `mm_lockout_sec` above 2147483647 was previously being silently zeroed at resolution time.
**Citation:** `server/evr_earlyquit.go:150-158 @ 3bfd5f695`. Test: `TestResolvePenaltyLevel_LockoutSaturatesInsteadOfWrapping`. Verified RED against the base raw cast: `ResolvePenaltyLevel lockout = -2147483648, want 2147483647 (config asked for 2147483648)` and `lockout = 0, want 2147483647 (config asked for 4294967296)`.

## 3. A player's early quit can no longer erase a moderator sanction  [FIX]

**What was tried:** A moderator runs `/early-quit … penalty-level 3` on a player. The player then early-quits one match.
**What they expected:** The sanction stands.
**What happened BEFORE this PR:** The quit called `IncrementEarlyQuit()` then re-resolved `PenaltyLevel`/`PenaltyTimestamp` purely from the quit-count ladder, overwriting the moderator's value. A player with a low quit count who had just been sanctioned to level 3 was re-resolved down to level 0 — the sanction was **erased by quitting**.
**Estimated frequency:** Unquantified. Requires a moderator sanction followed by an early quit by that player; both are ordinary operations.
**What happens AFTER this PR:** A sanction is recorded in dedicated `ModeratorPenaltyLevel`/`ModeratorPenaltyUntil` fields and applied as a **floor** in both dimensions while unexpired: the ladder may raise the level or extend the expiry, never lower or shorten either. An expired sanction is dropped and stops blocking the ladder. An admin `reset` clears it explicitly.
**Log signature BEFORE:** none for the erasure itself — silent. The surrounding `Early quitter tier update.` (Debug) still fired.
**Log signature AFTER:** none — silent. No new log statement was added.
**How to verify in production logs:** `grep 'Early quitter tier update' /home/echovrce/deployment/logs/nakama.log | grep -o '"penalty_level":[0-9]*'` — a sanctioned player's level should no longer drop below the sanctioned value on a subsequent quit. Note this line is **Debug** level (`server/evr_match.go:1064 @ 3bfd5f695`), so it only appears when the server runs at debug verbosity. The authoritative check is the player's `EarlyQuit|state` storage row, where an unexpired sanction is now visible as `moderator_penalty_level` / `moderator_penalty_until` (`server/evr_earlyquit.go:76-77 @ 3bfd5f695`).
**Citation:** `server/evr_earlyquit.go:271-284 @ 3bfd5f695` (the floor), `server/evr_earlyquit.go:212-225` (`ApplyModeratorPenalty`), `server/evr_discord_appbot.go:2843` and `server/evr_runtime_rpc_earlyquit_manage.go:226` (the two sanction entry points). Tests: `TestEarlyQuit_ModeratorSanctionSurvivesASubsequentQuit`, `TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries`, `TestEarlyQuit_ResetLiftsAModeratorSanction`.

## 4. Quitting more can no longer shorten a long moderator sanction  [FIX]

**What was tried:** A moderator uses the `duration-minutes` option — which exists precisely for long bans (`server/evr_discord_appbot.go:2830-2835 @ 3bfd5f695`) — to hand out a deliberately **light but long** sanction: level 1 for 7 days. The player quits more matches.
**What they expected:** The 7-day expiry stands; more quitting cannot help them.
**What happened BEFORE this PR:** The intermediate guard compared **level only**. A player whose quit count resolved to a harsher ladder level (say 3) fell through the guard, and the ladder's much **shorter** lockout (900s) came with it. A 7-day sanction became 15 minutes. The direction was perverse: quitting more was the way out.
**Estimated frequency:** Unquantified. Requires a moderator sanction longer than the ladder's own lockout for the resolved level.
**What happens AFTER this PR:** The floor is applied in **both** dimensions independently — level and expiry. A harsher ladder level raises the level while the sanction's longer expiry is preserved.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none — silent.
**How to verify in production logs:** Not directly loggable; inspect the player's `EarlyQuit|state` storage row — `moderator_penalty_until` (`server/evr_earlyquit.go:77 @ 3bfd5f695`) should be preserved as the floor on the effective `penalty_ts`.
**Citation:** `server/evr_earlyquit.go:271-284 @ 3bfd5f695`. Test: `TestEarlyQuit_QuittingMoreCannotShortenAModeratorSanction`, plus the new discriminating subtest `TestResolveAndApplyPenaltyLockout_ModeratorSanctionBoundaries/an_unexpired_sanction_floors_both_the_level_and_the_expiry`. Verified RED with the floor deleted: `PenaltyTimestamp = 0, want 1786579610 (delta 1786579610s): ladder resolution shortened a moderator sanction`.

## 5. Forgiving a logout-quit now actually releases the lockout  [FIX]

**What was tried:** A player voluntarily leaves a match, then closes the game entirely within 5 minutes. This is the crash/quit-flow case the forgiveness path exists to handle.
**What they expected:** The quit is forgiven, so the lockout it caused is lifted and their matchmaking tier recovers.
**What happened BEFORE this PR:** `CheckAndStrikeEarlyQuitIfLoggedOut` called `ForgiveLastQuit()` — whose own doc comment says *"PenaltyLevel and PenaltyTimestamp are re-resolved by the caller"* — and then never re-resolved them. Its sibling `CheckAndApplyEarlyQuitIfStillOnline` **did** call `resolveAndApplyPenaltyLockout`. So the decremented quit count was persisted while the stale `PenaltyLevel`/`PenaltyTimestamp` rode along untouched: **the forgiven player served the full original lockout anyway**, and because `UpdateTier` reads that same stale `PenaltyLevel`, `tierChanged` was always false and the tier never recovered.
**Estimated frequency:** Every voluntary early quit followed by a full logout within the 5-minute grace window — i.e. every time the forgiveness feature was supposed to fire. The forgiveness was recorded in the counters but had no effect on the penalty the player actually served.
**What happens AFTER this PR:** The lockout is re-resolved from the reduced quit count. 3 quits → forgive → 2 quits → level 0, lockout cleared, tier restored to Tier 1.
**Log signature BEFORE:** `Reduced early quit penalty: player logged out after early quit` (Info, `server/evr_earlyquit.go:618 @ 3bfd5f695`) — already emitted, but its `new_penalty_level` and `tier_changed` fields were **wrong**: `new_penalty_level` equalled `old_penalty_level` and `tier_changed` was always `false`.
**Log signature AFTER:** Same message, same level, same emission frequency. The **field values** change: `new_penalty_level` now differs from `old_penalty_level` when the forgiveness takes effect, and `tier_changed` can now be `true`.
**How to verify in production logs:** `grep 'Reduced early quit penalty' /home/echovrce/deployment/logs/nakama.log | grep '"tier_changed":true'` — this returns **zero** matches before this PR and non-zero after. That is the cleanest single signal that the fix is live.
**Citation:** `server/evr_earlyquit.go:596 @ 3bfd5f695` (the added `resolveAndApplyPenaltyLockout` call). Test: `TestCheckAndStrikeEarlyQuitIfLoggedOut_ForgivenessLiftsTheLockout`, 3 subtests. Verified RED with the call removed: `PenaltyLevel = 1, want 0: the penalty was not re-resolved after forgiveness`; `IsPenaltyActive() = true after forgiveness: the lockout was never lifted`; `MatchmakingTier = 2, want 1`.

## 6. Completion credit and its dedupe marker commit atomically  [FIX]

**What was tried:** A player finishes a match. Both reporters fire for it — the post-match stats upload (`incrementCompletedMatches`) and the `MatchLoop` `MatchOver` dispatch. Meanwhile something else writes the player's state row (another quit, the tier scheduler), bumping its version.
**What they expected:** The completed match is credited exactly once.
**What happened BEFORE this PR:** `TrackMatchCompletion` wrote the history record **first**, in its own `StorableWrite`, then the counter was written separately. The history record **is** the dedupe marker. If the history write succeeded and the counter write was then rejected on version, the match was permanently marked as already-counted while `TotalCompletedMatches` was never incremented. The other reporter then returned `first=false`. **The credit could never be re-earned.**
**Estimated frequency:** Unquantified — requires a concurrent write to the player's state row between the two writes. Both writes are on the hot post-match path.
**What happens AFTER this PR:** `PrepareMatchCompletion` **stages** the history without writing it; the call site commits the staged history and the credited counter in one `StorableWriteMany`. Nakama runs a multi-object storage write inside a single transaction (`StorageWriteObjects` at `server/core_storage.go:583` wraps `storageWriteObjects` in `ExecuteInTxPgx` at `:587`), and a version rejection on any object aborts the whole transaction — so either both land or neither does. The worse state (recorded-but-uncredited) is now impossible.
**Log signature BEFORE:** `Failed to track match completion in history` (**Debug**) at `evr_match.go:1517` and `evr_runtime_event_remotelogset.go:579` @ `d3e7e5549`, plus `Failed to write completion to early quit history` (**Warn**) at `evr_earlyquit_detailed.go:371` @ `d3e7e5549`.
**Log signature AFTER:** **All three of those messages are removed** — `TrackMatchCompletion` no longer exists. The same failure now surfaces on the retained, unchanged message at the call site: `Failed to write early quitter config after completed match` (Warn, `server/evr_match.go:1544 @ 3bfd5f695`) and `Failed to store early quitter config` (Warn, `server/evr_runtime_event_remotelogset.go:598 @ 3bfd5f695`). Those two Warns may therefore appear **slightly more often**, because they now also carry history-write failures that used to be reported separately. Message strings and levels are unchanged.
**How to verify in production logs:** Expect these to stop appearing entirely — `grep -c 'Failed to track match completion in history\|Failed to write completion to early quit history' /home/echovrce/deployment/logs/nakama.log` should go to 0 for log lines written after deploy. Their replacement: `grep 'Failed to write early quitter config after completed match\|Failed to store early quitter config' /home/echovrce/deployment/logs/nakama.log`.
**Citation:** `server/evr_earlyquit_detailed.go:362 @ 3bfd5f695` (`PrepareMatchCompletion`), `server/evr_storable_batch.go:23` (`StorableWriteMany`), call sites `server/evr_match.go:1521,1539` and `server/evr_runtime_event_remotelogset.go:582,593` (the only two `evr_match.go` hunks in this PR). Tests: `TestMatchCompletion_CreditSurvivesARejectedCounterWrite`, `TestMatchLoopCompletion_CreditSurvivesARejectedCounterWrite`, `TestMatchLoopCompletion_CreditedOnceAcrossBothReporters`, `TestMatchCompletion_FirstEverCompletionDoesNotClobberAConcurrentOne`. Verified RED committing the history separately: `TotalCompletedMatches = 0, want 1` on both reporters.

## 7. A corrupt history row is no longer a permanent credit blackhole  [FIX]

**What was tried:** A player's `EarlyQuitHistory` row exists but does not unmarshal (truncated or malformed JSON). They complete matches.
**What they expected:** Completions credited; the bad row repaired.
**What happened BEFORE this PR:** Inside the batch fix, `StorableRead(create=false)` returns `codes.Internal` — **not** `NotFound` — when a row exists but fails to unmarshal. Staging version `"*"` on every error meant the batch was rejected against the still-present row, on every completion, **forever**. And because the credit now rides the same transaction, the credit was rolled back with it. Nothing on this path repaired the row.
**Estimated frequency:** Unquantified — requires an already-corrupt row.
**What happens AFTER this PR:** Only a genuinely absent row (`codes.NotFound`) stages `"*"`. Any other read error falls back to the unconditional write this path used before the batch existed, which self-heals the corrupt row — the same recovery shape the quit-record path already uses.
**Log signature BEFORE:** `Failed to load early quit history for completion tracking, proceeding with new history` (Warn) — same message at base.
**Log signature AFTER:** Same message, same level, same file (`server/evr_earlyquit_detailed.go:382 @ 3bfd5f695`), same emission condition (non-`NotFound` read error). **No change.**
**How to verify in production logs:** `grep 'Failed to load early quit history for completion tracking' /home/echovrce/deployment/logs/nakama.log` — a player whose ID repeats here indefinitely had a stuck row before; after deploy the row self-heals and the repeats stop.
**Citation:** `server/evr_earlyquit_detailed.go:362-396 @ 3bfd5f695`. Test: `TestMatchCompletion_CorruptHistoryRowStillCreditsTheCompletion`. Verified RED re-staging `"*"` on the non-NotFound path: `TotalCompletedMatches = 0, want 1: an unreadable history row rolled back the credit`.

## 8. The tier-restored notification block becomes reachable  [NEW]

**What was tried:** A player quits, logs out within 5 minutes, gets forgiven, and their forgiveness drops their penalty level to 0 — restoring them to Tier 1.
**What they expected:** To be told their standing recovered.
**What happened BEFORE this PR:** Nothing. `tierChanged` was permanently `false` for the reason in §5, so the entire notification block — `SendEarlyQuitUpdateNotification`, `GetDiscordIDByUserID`, and the tier-restored Discord DM — was **dead code**. It had never executed in production.
**Estimated frequency:** Once per tier restoration via logout forgiveness. Gated on `enable_early_quit_penalty` being true and `silent_early_quit_system` being false.
**What happens AFTER this PR:** The block executes. Players who recover to Tier 1 through logout forgiveness receive `TierRestoredMessage` as a Discord DM.
**Log signature BEFORE:** none — the block never ran.
**Log signature AFTER:** Two **existing** Warn statements in that block can now emit for the first time: `Failed to get Discord ID for tier notification after logout` (`server/evr_earlyquit.go:631 @ 3bfd5f695`) and `Failed to send tier change notification after logout` (`server/evr_earlyquit.go:646`). **Operators should not read a first appearance of these as a new fault** — they are pre-existing statements on a path that only just became live. Their volume is bounded by the tier-restoration rate.
**How to verify in production logs:** `grep 'tier change notification after logout\|Discord ID for tier notification after logout' /home/echovrce/deployment/logs/nakama.log` — zero matches before deploy, possibly non-zero after.
**Citation:** `server/evr_earlyquit.go:621-649 @ 3bfd5f695`. Test: `TestCheckAndStrikeEarlyQuitIfLoggedOut_TierRestoredNotificationIsReachable` — drives the block with a `*sql.DB` whose connections always fail, asserting the database is actually touched (which cannot happen unless `tierChanged` became true) and that an unusable database does not cost the player their lockout release. Verified RED without the §5 fix: `the database was never touched (opens 0 -> 0): the tier-change notification block was not reached`.

---

## What does NOT change

- **Cross-guild matchmaking is not enabled.** `git diff d3e7e5549..HEAD | grep -F 'uuid.Nil' | grep '^+' | wc -l` → **`0`**. Every added `GroupID` line is in a test fixture (`evr_earlyquit_moderator_penalty_test.go`, `evr_match_completion_credit_test.go`); no matchmaking-path `GroupID` is touched.
- **`server/evr_storable.go` is byte-identical to base.** `git diff d3e7e5549..HEAD -- server/evr_storable.go | wc -l` → **`0`**. `StorableWriteMany` lives in a new file, `server/evr_storable_batch.go`, specifically so it has zero conflict surface with `fix/storage-occ-retry`.
- **The default penalty ladder behaves identically.** Old and new `ResolvePenaltyLevel` agree for every quit count on the contiguous 0-2/3-5/6-10/11-999 default, including counts above 999.
- **The early-quit exemption gate is untouched.** `earlyQuitEnforcementEnabled` and `IsExempt` are unchanged. (But see follow-up #2 — the gate has a pre-existing hole this PR amplifies.)
- **`MatchJoinAttempt` and the join refusal gate are untouched.** `evr_match.go` has **exactly two hunks**, both inside `MatchLoop`'s match-completion handling — `git diff d3e7e5549..HEAD -- server/evr_match.go | grep '^@@'` returns only `@@ -1512,12 +1512,14 @@ func (m *EvrMatch) MatchLoop` and `@@ -1532,8 +1534,14 @@ func (m *EvrMatch) MatchLoop`. The `resolveAndApplyPenaltyLockout` calls in `MatchLeave` (`:1041`, `:1414`) are **pre-existing at base** (`git show d3e7e5549:server/evr_match.go | grep -c resolveAndApplyPenaltyLockout` → `2`), not added here.
- **Dedupe semantics are unchanged.** A match already present in the history still returns `first=false` and credits nothing; `TestTrackMatchCompletion_DedupeSameMatchID` (a base-owned test, unmodified) still passes.

## Production log impact — summary

Checked by grepping the non-test diff for changed string literals: `git diff d3e7e5549..HEAD -- 'server/*.go' ':(exclude)server/*_test.go' | grep -E '^[+-]' | grep -oE '"[^"]{15,}"' | sort -u`.

| Message | Level | Change |
|---|---|---|
| `Failed to track match completion in history` | Debug | **REMOVED** (2 call sites) |
| `Failed to write completion to early quit history` | Warn | **REMOVED** |
| `Failed to write early quitter config after completed match` | Warn | unchanged string/level; **slightly higher volume** (now also carries history-write failures) |
| `Failed to store early quitter config` | Warn | unchanged string/level; **slightly higher volume** (same reason) |
| `Failed to load early quit history for completion tracking, proceeding with new history` | Warn | unchanged in every respect |
| `No early quit history found for completion tracking, starting new history` | Debug | unchanged in every respect |
| `Reduced early quit penalty: player logged out after early quit` | Info | unchanged string/level/frequency; **field values `new_penalty_level` and `tier_changed` are now correct** (§5) |
| `Failed to get Discord ID for tier notification after logout` | Warn | unchanged string/level; **newly reachable** (§8) |
| `Failed to send tier change notification after logout` | Warn | unchanged string/level; **newly reachable** (§8) |

No other production log statement in any touched path had its message string, level, or emission condition changed. The two new strings in `evr_storable_batch.go` (`"failed to marshal: %v"`, `"failed to write batch: %v"`) are error-wrapping text, not log messages.

## Findings from the adversarial review that were NOT real bugs in the code

**The review's own justification for §1/§2 was wrong, and I had baked the false claim into production comments.** The report and the resulting doc comments asserted that *"stored configs are not re-validated on read"*. **That is false.** `LoadEarlyQuitServiceConfig` **does** call `config.Validate()` on the read-success path — `server/evr_early_quit_message_trigger.go:122 @ 3bfd5f695` — with a mutation-detection write-back immediately after.

The fixes themselves stand, for a different and correct reason: `validatePenaltyLevels` bounds `MMLockoutSec` only from below (`server/evr/login_earlyquitconfig.go:157-158`), never from above; it only *raises* `MinEarlyQuits` to close overlaps (`:170-178`), so gaps survive and no floor-at-0 is forced; and the admin RPC's `loadEarlyQuitServiceConfigOrDefault` (`server/evr_runtime_rpc_earlyquit_manage.go:321-328`) skips `Validate` entirely. Commit `3bfd5f695` corrects both comments to say that, with real citations. **The earlier out-of-scope report item claiming "`LoadEarlyQuitServiceConfig` does not validate on read" is retracted — do not open a ticket for it.**

## Known follow-ups (not fixed here — deliberately out of scope)

1. **A transient history *read* failure destroys the player's quit records.** `PrepareMatchCompletion` falls back to an unconditional write on *any* non-`NotFound` error, and `StorableRead` returns the same error shape for "corrupt JSON" and "storage read blew up" (`storableErrorf` wraps with `fmt.Errorf` + `%v`, so `status.Code()` is `Unknown` either way). Corrupt → repair is right; transient → clobber is data loss. **This is pre-existing at `d3e7e5549`** — base did an unconditional `StorableWrite` on any read error too (`git show d3e7e5549:server/evr_earlyquit_detailed.go` lines 351-370). Restoring base behaviour is not a new regression. The correct shape is a trichotomy (absent → `"*"`; unreadable → unconditional; read-failed → abort), which requires `StorableRead` to distinguish them — that is **`fix/storage-occ-retry`'s territory**.
2. **An exempt player's logout lifts their *global* lockout.** The `CheckAndStrikeEarlyQuitIfLoggedOut` goroutine launch (`server/evr_match.go:1119-1127 @ 3bfd5f695`) is gated on `leaveReason`, **not** on `eqconfig.IsExempt(groupID)` — the exemption branch is a sibling `if` higher up (`server/evr_match.go:1028 @ 3bfd5f695`). Exemption is per-guild but the counters and lockout are global. Pre-fix, an exempt player's logout only decremented `NumEarlyQuits`; with §5 it now also re-resolves and can lift a lockout accrued in **another** guild. This is an **amplification of a pre-existing gate bug**, not a new one. The exemption gate is out of scope for this PR (it overlaps `fix/match-lifecycle`); flagging only.
3. **`StorableWriteMany` has no OCC retry.** §6 guarantees the *worse* state (recorded-but-uncredited) is impossible, but under sustained contention both reporters can still lose and the credit is silently lost — both call sites only `Warn`-log. This is a narrowing of the window, not its elimination. Do not read §6 as a stronger guarantee than that.
4. **`storableErrorf` uses `%v`, so `errors.Is(err, runtime.ErrStorageRejectedVersion)` fails for batch writes** (`server/evr_storable_batch.go:34,50 @ 3bfd5f695`). No functional impact today — both call sites only log. Switch to `%w` once `fix/storage-occ-retry`'s `storableError`/`Unwrap` lands. Not fixed here because the fix belongs in `server/evr_storable.go`, which this PR keeps byte-identical on purpose.
5. **Gapped operator ladders now under-penalize.** Counts in a gap resolve to the band *below*, where they previously got the ladder's max. Correct per §1's intent, but it is an enforcement **weakening** for any operator config with a gap. Nothing in the codebase pins operator intent here. No change for the default ladder.
6. **`TestTrackMatchCompletion_DedupeSameMatchID` is now misnamed** — `TrackMatchCompletion` no longer exists; the test drives `incrementCompletedMatches`. It still passes. Left alone as a base-owned file to avoid conflict surface.

## Concurrent Tier-1 PRs touching the same files

| Branch | Overlap with this PR |
|---|---|
| `fix/storage-occ-retry` | **`server/evr_storable.go`** — deliberately kept byte-identical here; `StorableWriteMany` isolated in the new `server/evr_storable_batch.go`. Follow-ups #1 and #4 above are that branch's to fix. |
| `fix/match-lifecycle` | **`server/evr_match.go`** — this PR has four hunks, all in `MatchLoop`/`MatchLeave` early-quit handling (`:1041`, `:1414`, `:1521`, `:1539`). Follow-up #2 (the exemption gate) is likely that branch's territory. |
| `fix/security-join-gates` | `server/evr_match.go` — no overlap; `MatchJoinAttempt` and the refusal gate are untouched here. |
| `fix/concurrency-locking` | Possible overlap on `EarlyQuitPlayerState` locking. This PR adds `applyLadderPenalty`, which takes the state's own lock, and two new fields. |
| `fix/discord-prune-safety` | `server/evr_discord_appbot.go` — this PR has one hunk, in the `/early-quit` set-penalty handler (`:2843`). |
| `fix/assorted-one-offs` | Unknown; flagging `server/evr_runtime_rpc_earlyquit_manage.go` and `server/evr_runtime_event_remotelogset.go` as touched here. |

## Verification (real output, at `3bfd5f695`)

```
$ GOWORK=off go build ./server/...
BUILD_OK
$ GOWORK=off go vet ./server/...
VET_OK

$ TZ=UTC GOWORK=off go test ./server/... -count=1
EXIT=0
ok  	github.com/heroiclabs/nakama/v3/server	126.712s
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.020s
?   	github.com/heroiclabs/nakama/v3/server/evr/gen_cosmetic_hashes	[no test files]
?   	github.com/heroiclabs/nakama/v3/server/evr/wire	[no test files]
?   	github.com/heroiclabs/nakama/v3/server/socialauth	[no test files]

$ GOWORK=off go test -race ./server/ -run 'EarlyQuit|Penalty|Ladder|Forgive|MatchCompletion|MatchLoopCompletion|TrackMatchCompletion|Sanction|Moderator|TierRestored' -count=1
ok  	github.com/heroiclabs/nakama/v3/server	1.464s

$ gofmt -l <every touched file>
(no output — clean)

$ GOWORK=off GOOS=linux GOARCH=386 go vet ./server/
(no output — the package now builds on 32-bit; it did not at 841bffc67)
```

### One pre-existing flake, not caused by this PR

An unqualified `go test ./server/...` under `TZ=America/Chicago` after 19:00 local fails one subtest:

```
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
```

This is a **latent local-vs-UTC bug in a file this PR never touches**. The implementation formats `time.Now().UTC()` (`server/evr/core_account_statistics.go:47`) while the test expects `time.Now()` in local time (`server/evr/core_account_statistics_test.go:23`). It fires whenever the local date and the UTC date differ. Proof it is unrelated:

```
$ git diff --name-only d3e7e5549..HEAD | grep -c core_account_statistics
0
$ TZ=UTC GOWORK=off go test ./server/evr/ -run TestStatisticsGroup_MarshalText -count=1
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.004s
$ git log --oneline -1 d3e7e5549 -- server/evr/core_account_statistics_test.go server/evr/core_account_statistics.go
4e5a48d2e feat: rolling win-rate from last 100 games via MongoDB
```

Last touched by a commit that predates this branch's base. Not fixed here (out of scope); worth a one-line ticket.

### Every new test verified genuinely RED against pre-fix code

Each was run against a `/tmp` copy of the tree with the production fix reverted. Quoted failures appear inline in §1–§8 above. The perturbation copies have been deleted, and `git grep -c PERTURBED HEAD -- server` returns nothing.
