### PR TITLE
fix(concurrency): lock the latency-history storage path and the discordgo state reads on the prune ticker

### DIFF
--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -551,7 +551,7 @@ func (d *DiscordIntegrator) guildSync(ctx context.Context, logger *zap.Logger, g
 	logger = logger.With(zap.String("guild_id", guild.ID), zap.String("guild_name", guild.Name))
 
 	var err error
-	botUserID := d.DiscordIDToUserID(d.dg.State.User.ID)
+	botUserID := d.DiscordIDToUserID(botDiscordIDFromState(d.dg.State))
 	if botUserID == "" {
 		return fmt.Errorf("failed to get bot user ID from state")
 	}

--- a/server/evr_discord_integrator_prune_wiring_test.go
+++ b/server/evr_discord_integrator_prune_wiring_test.go
@@ -1,0 +1,339 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"go.uber.org/zap"
+)
+
+// The tests in this file exist because snapshotStateGuilds is only a fix if
+// pruneGuildGroups actually CALLS it. The snapshot contract tests in
+// evr_discord_integrator_state_race_test.go all invoke snapshotStateGuilds
+// directly, so every one of them would keep passing if the read site at
+// evr_discord_integrator_pruning.go reverted to `d.dg.State.Guilds` and the
+// snapshot became dead code. These tests drive pruneGuildGroups itself.
+//
+// TestPruneGuildGroups_UsesSnapshotNotLiveState is deliberately deterministic
+// rather than -race-dependent: CI runs `just test` (justfile:70-71 —
+// `go test ./server/... -count=1`) with NO -race flag, so a race-only test
+// would not gate a revert.
+
+// prunePhaseLogger records the field maps that pruneGuildGroups attaches to its
+// log lines, so a test can inspect the *discordgo.Guild values the prune path
+// actually operated on.
+type prunePhaseLogger struct {
+	mu     *sync.Mutex
+	events *[]pruneLogEvent
+	fields map[string]any
+}
+
+type pruneLogEvent struct {
+	level  string
+	msg    string
+	fields map[string]any
+}
+
+func newPrunePhaseLogger() *prunePhaseLogger {
+	return &prunePhaseLogger{
+		mu:     &sync.Mutex{},
+		events: &[]pruneLogEvent{},
+		fields: map[string]any{},
+	}
+}
+
+func (l *prunePhaseLogger) record(level, format string, v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	msg := format
+	if len(v) > 0 {
+		msg = fmt.Sprintf(format, v...)
+	}
+	*l.events = append(*l.events, pruneLogEvent{level: level, msg: msg, fields: l.fields})
+}
+
+func (l *prunePhaseLogger) Debug(format string, v ...interface{}) { l.record("debug", format, v...) }
+func (l *prunePhaseLogger) Info(format string, v ...interface{})  { l.record("info", format, v...) }
+func (l *prunePhaseLogger) Warn(format string, v ...interface{})  { l.record("warn", format, v...) }
+func (l *prunePhaseLogger) Error(format string, v ...interface{}) { l.record("error", format, v...) }
+
+func (l *prunePhaseLogger) WithField(key string, value interface{}) runtime.Logger {
+	return l.WithFields(map[string]interface{}{key: value})
+}
+
+func (l *prunePhaseLogger) WithFields(fields map[string]interface{}) runtime.Logger {
+	merged := make(map[string]any, len(l.fields)+len(fields))
+	for k, v := range l.fields {
+		merged[k] = v
+	}
+	for k, v := range fields {
+		merged[k] = v
+	}
+	return &prunePhaseLogger{mu: l.mu, events: l.events, fields: merged}
+}
+
+func (l *prunePhaseLogger) Fields() map[string]interface{} { return l.fields }
+
+// orphanGuildsLogged returns the guild slice pruneGuildGroups attached to its
+// mass-leave safety abort.
+func (l *prunePhaseLogger) orphanGuildsLogged(t *testing.T) []*discordgo.Guild {
+	t.Helper()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, e := range *l.events {
+		if v, ok := e.fields["orphan_guilds"]; ok {
+			guilds, ok := v.([]*discordgo.Guild)
+			if !ok {
+				t.Fatalf("orphan_guilds logged as %T, want []*discordgo.Guild", v)
+			}
+			return guilds
+		}
+	}
+	t.Fatalf("pruneGuildGroups never logged orphan_guilds; events=%+v", *l.events)
+	return nil
+}
+
+// emptyGroupsNakamaModule reports that Nakama has no guild groups at all, so
+// every guild in the discordgo state becomes an orphan candidate. Every other
+// NakamaModule method is nil: if pruneGuildGroups reaches one, the test panics
+// rather than silently hitting a database.
+type emptyGroupsNakamaModule struct {
+	runtime.NakamaModule
+}
+
+func (m *emptyGroupsNakamaModule) GroupsList(ctx context.Context, name, langTag string, members *int, open *bool, limit int, cursor string) ([]*api.Group, string, error) {
+	return nil, "", nil
+}
+
+// newPruneTestIntegrator builds the minimum DiscordIntegrator pruneGuildGroups
+// needs. db is deliberately nil: no code path exercised here may touch it.
+//
+// idcache is primed so DiscordIDToUserID short-circuits on the bot lookup and
+// returns "". That makes guildSync fail at its first check ("failed to get bot
+// user ID from state", evr_discord_integrator.go) and return immediately,
+// which is what keeps reconcileOrphanGuilds from making network calls while
+// still leaving the guild in the orphan set the safety check logs.
+func newPruneTestIntegrator(t *testing.T, state *discordgo.State) *DiscordIntegrator {
+	t.Helper()
+	idcache := &MapOf[string, string]{}
+	idcache.Store(botDiscordIDForPruneTest, "")
+	return &DiscordIntegrator{
+		ctx:     context.Background(),
+		logger:  zap.NewNop(),
+		nk:      &emptyGroupsNakamaModule{},
+		dg:      &discordgo.Session{State: state},
+		idcache: idcache,
+	}
+}
+
+const botDiscordIDForPruneTest = "bot-discord-id"
+
+// TestPruneGuildGroups_UsesSnapshotNotLiveState is the wiring pin: it drives
+// pruneGuildGroups end to end and proves the *discordgo.Guild values it works
+// with came from snapshotStateGuilds, not from d.dg.State.Guilds.
+//
+// It fails deterministically (no -race needed) if the read site reverts to live
+// state, because the live guild carries a populated Roles slice that
+// copyStateGuild clears, and the live *Guild / *Channel pointers are the ones
+// the gateway overwrites in place.
+func TestPruneGuildGroups_UsesSnapshotNotLiveState(t *testing.T) {
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: botDiscordIDForPruneTest}
+	if err := state.GuildAdd(&discordgo.Guild{
+		ID:      "guild-orphan",
+		Name:    "Orphan",
+		OwnerID: "owner-1",
+		// Cleared by copyStateGuild; still present on the live object.
+		Roles:   []*discordgo.Role{{ID: "role-1"}},
+		Members: []*discordgo.Member{{User: &discordgo.User{ID: "u1"}}},
+		Channels: []*discordgo.Channel{
+			{ID: "c1", GuildID: "guild-orphan", Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "be nice"},
+		},
+	}); err != nil {
+		t.Fatalf("GuildAdd: %v", err)
+	}
+	// A nil entry in State.Guilds: snapshotStateGuilds skips it, an unguarded
+	// live read panics on g.ID.
+	state.Guilds = append(state.Guilds, nil)
+
+	live, err := state.Guild("guild-orphan")
+	if err != nil {
+		t.Fatalf("Guild: %v", err)
+	}
+	liveChannel := live.Channels[0]
+
+	d := newPruneTestIntegrator(t, state)
+	logger := newPrunePhaseLogger()
+
+	// pruneSafetyThreshold 0 with one orphan guild trips the mass-leave abort,
+	// which logs the orphan guilds and returns before any GuildLeave or
+	// GroupDelete call. doGuildLeaves/doGroupDeletes are false as well.
+	err = d.pruneGuildGroups(context.Background(), logger, false, false, 0)
+	if err == nil {
+		t.Fatal("expected the mass-leave safety abort to return an error")
+	}
+
+	got := logger.orphanGuildsLogged(t)
+	if len(got) != 1 {
+		t.Fatalf("got %d orphan guilds, want 1 (the nil State.Guilds entry must be skipped)", len(got))
+	}
+	g := got[0]
+
+	if g == live {
+		t.Error("pruneGuildGroups operated on the LIVE *Guild from discordgo state; it must use snapshotStateGuilds, whose copies the gateway cannot overwrite in place")
+	}
+	if len(g.Roles) != 0 {
+		t.Error("pruneGuildGroups' guild still carries Roles; copyStateGuild clears them, so this guild came from live state")
+	}
+	if len(g.Members) != 0 {
+		t.Error("pruneGuildGroups' guild still carries Members; copyStateGuild clears them, so this guild came from live state")
+	}
+	if len(g.Channels) != 1 {
+		t.Fatalf("got %d channels, want 1", len(g.Channels))
+	}
+	if g.Channels[0] == liveChannel {
+		t.Error("pruneGuildGroups' guild aliases the LIVE *Channel pointers; ChannelAdd overwrites them in place under State.Lock()")
+	}
+	// The scalars the prune path and guildSync read must survive the copy.
+	if g.ID != "guild-orphan" || g.Name != "Orphan" || g.OwnerID != "owner-1" {
+		t.Errorf("snapshot dropped scalars the prune path reads: %+v", g)
+	}
+}
+
+// TestPruneGuildGroups_SafeAgainstGatewayMutation drives pruneGuildGroups
+// concurrently with the gateway mutations discordgo performs under State.Lock()
+// (GuildAdd append + in-place overwrite, ChannelAdd, ChannelRemove, and the
+// READY assignment of State.User). It is the -race companion to the
+// deterministic wiring test above: it catches ANY unlocked read of live state
+// on the prune path, including ones a copy-shaped but unlocked implementation
+// would still perform.
+//
+// Because nk reports no groups, every state guild is an orphan, so this also
+// drives reconcileOrphanGuilds -> guildSync — pinning the bot-ID read at its
+// real production call site rather than only through the accessor's own test.
+func TestPruneGuildGroups_SafeAgainstGatewayMutation(t *testing.T) {
+	const guilds = 4
+	state := newTestDiscordState(t, guilds)
+	state.User = &discordgo.User{ID: botDiscordIDForPruneTest}
+
+	d := newPruneTestIntegrator(t, state)
+	logger := newPrunePhaseLogger()
+
+	stop := make(chan struct{})
+	gatewayDone := make(chan struct{})
+	go func() {
+		defer close(gatewayDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			guildID := fmt.Sprintf("guild-%d", i%guilds)
+			_ = state.GuildAdd(&discordgo.Guild{
+				ID:      guildID,
+				Name:    fmt.Sprintf("Guild %d rev %d", i%guilds, i),
+				OwnerID: fmt.Sprintf("owner-%d", i),
+				Icon:    fmt.Sprintf("icon-%d", i),
+				Channels: []*discordgo.Channel{
+					{ID: guildID + "-rules", GuildID: guildID, Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "rev"},
+				},
+			})
+			ch := &discordgo.Channel{
+				ID:      guildID + "-churn",
+				GuildID: guildID,
+				Type:    discordgo.ChannelTypeGuildText,
+				Name:    "rules",
+				Topic:   "churn",
+			}
+			_ = state.ChannelAdd(ch)
+			_ = state.ChannelRemove(ch)
+
+			// The READY write, narrowed to the one word that matters. onReady
+			// assigns the whole embedded Ready struct (`s.Ready = *r`) under
+			// State.Lock(), which rewrites the User pointer; assigning
+			// State.User directly hits the same word without also clearing
+			// State.Guilds (State embeds Ready, so State.Guilds IS
+			// Ready.Guilds). The ID is held constant so the integrator's
+			// idcache still short-circuits and no database lookup is reached.
+			state.Lock()
+			state.User = &discordgo.User{ID: botDiscordIDForPruneTest}
+			state.Unlock()
+		}
+	}()
+
+	// A threshold above the guild count keeps the safety abort quiet, so the
+	// full prune body runs. doGuildLeaves/doGroupDeletes stay false, so no
+	// GuildLeave/GroupDelete call is ever made.
+	for i := 0; i < 200; i++ {
+		if err := d.pruneGuildGroups(context.Background(), logger, false, false, 1000); err != nil {
+			close(stop)
+			<-gatewayDone
+			t.Fatalf("pruneGuildGroups: %v", err)
+		}
+	}
+
+	close(stop)
+	<-gatewayDone
+}
+
+// TestBotDiscordIDFromState covers the accessor that replaced the unlocked
+// `d.dg.State.User.ID` read in guildSync.
+func TestBotDiscordIDFromState(t *testing.T) {
+	if got := botDiscordIDFromState(nil); got != "" {
+		t.Errorf("nil state: got %q, want %q", got, "")
+	}
+
+	// Pre-READY: State.User is nil. The old expression panicked here.
+	if got := botDiscordIDFromState(discordgo.NewState()); got != "" {
+		t.Errorf("nil State.User: got %q, want %q", got, "")
+	}
+
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-42"}
+	if got := botDiscordIDFromState(state); got != "bot-42" {
+		t.Errorf("got %q, want %q", got, "bot-42")
+	}
+}
+
+// TestBotDiscordIDFromState_ConcurrentWithReady proves the read is serialized
+// against the gateway's READY handling, which assigns the whole embedded Ready
+// struct (`s.Ready = *r`) under State.Lock() and so writes the User pointer
+// word itself. Fails under -race without the lock.
+func TestBotDiscordIDFromState_ConcurrentWithReady(t *testing.T) {
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-0"}
+
+	stop := make(chan struct{})
+	gatewayDone := make(chan struct{})
+	go func() {
+		defer close(gatewayDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Exactly what State.onReady does on every gateway reconnect.
+			state.Lock()
+			state.Ready = discordgo.Ready{User: &discordgo.User{ID: fmt.Sprintf("bot-%d", i)}}
+			state.Unlock()
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		if got := botDiscordIDFromState(state); got == "" {
+			close(stop)
+			<-gatewayDone
+			t.Fatal("read an empty bot ID; guildSync would fail every orphan reconciliation")
+		}
+	}
+
+	close(stop)
+	<-gatewayDone
+}

--- a/server/evr_discord_integrator_pruning.go
+++ b/server/evr_discord_integrator_pruning.go
@@ -105,6 +105,12 @@ func copyStateGuild(g *discordgo.Guild) *discordgo.Guild {
 		chCopy.Members = nil
 		chCopy.AvailableTags = nil
 		chCopy.AppliedTags = nil
+		// Pointer fields nothing here reads. ChannelAdd replaces the pointer
+		// (`*c = *channel`) rather than writing through it, so aliasing them
+		// would not actually race — but "cleared unless copied" has to hold
+		// for every reference-typed field or the contract is unenforceable.
+		chCopy.LastPinTimestamp = nil
+		chCopy.DefaultSortOrder = nil
 		c.Channels = append(c.Channels, &chCopy)
 	}
 	c.Features = slices.Clone(g.Features)

--- a/server/evr_discord_integrator_pruning.go
+++ b/server/evr_discord_integrator_pruning.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/heroiclabs/nakama-common/api"
@@ -41,6 +42,86 @@ func reconcileOrphanGuilds(logger runtime.Logger, orphanGuilds []*discordgo.Guil
 	return remaining
 }
 
+// snapshotStateGuilds returns a copy of the guilds the bot is a member of,
+// taken under the discordgo state's read lock.
+//
+// discordgo owns Session.State and mutates it from the gateway goroutine under
+// State.Lock(): GuildAdd appends to State.Guilds and overwrites an existing
+// *Guild in place (`*g = *guild`), ChannelAdd appends to guild.Channels and
+// overwrites an existing *Channel in place, and ChannelRemove compacts
+// guild.Channels. pruneGuildGroups runs on the prune ticker goroutine, not the
+// gateway goroutine, so reading State.Guilds unlocked and passing the LIVE
+// *Guild pointers on to a deep reader — guildSync ranges guild.Channels, and
+// the leave path logs the whole guild, which zap reflect-walks it — races the
+// gateway. In production that surfaces as a torn slice header (index out of
+// range) or a read of an already-removed channel.
+//
+// The copy goes exactly as deep as the consumers read: the Guild struct and its
+// Channels. Every other reference-typed field is CLEARED rather than left
+// aliasing live state, so a future deep read cannot silently reach back into
+// gateway-mutated memory; a caller that needs one of them must extend the
+// copy here.
+func snapshotStateGuilds(state *discordgo.State) []*discordgo.Guild {
+	if state == nil {
+		return nil
+	}
+
+	state.RLock()
+	defer state.RUnlock()
+
+	guilds := make([]*discordgo.Guild, 0, len(state.Guilds))
+	for _, g := range state.Guilds {
+		if g == nil {
+			continue
+		}
+		guilds = append(guilds, copyStateGuild(g))
+	}
+	return guilds
+}
+
+// copyStateGuild copies a guild out of the discordgo state. It must be called
+// with the state's read lock held. See snapshotStateGuilds for why.
+func copyStateGuild(g *discordgo.Guild) *discordgo.Guild {
+	// discordgo.Guild carries no lock, so the struct copy is safe; it takes the
+	// scalar fields guildSync reads (ID, Name, OwnerID, Description, Icon).
+	c := *g
+
+	// Channels is the one collection read deeply: guildSync scans it for the
+	// #rules channel, and ChannelAdd overwrites *Channel values in place.
+	c.Channels = make([]*discordgo.Channel, 0, len(g.Channels))
+	for _, ch := range g.Channels {
+		if ch == nil {
+			continue
+		}
+		chCopy := *ch
+		// The channel's own collections still alias live state (MessageAdd
+		// appends to Channel.Messages under State.Lock()). Nothing reads them
+		// here, so drop them rather than hand out an aliased header.
+		chCopy.Recipients = nil
+		chCopy.Messages = nil
+		chCopy.PermissionOverwrites = nil
+		chCopy.ThreadMetadata = nil
+		chCopy.Member = nil
+		chCopy.Members = nil
+		chCopy.AvailableTags = nil
+		chCopy.AppliedTags = nil
+		c.Channels = append(c.Channels, &chCopy)
+	}
+	c.Features = slices.Clone(g.Features)
+
+	// Collections no consumer of this snapshot reads. Cleared, not aliased.
+	c.Roles = nil
+	c.Emojis = nil
+	c.Stickers = nil
+	c.Members = nil
+	c.Presences = nil
+	c.Threads = nil
+	c.VoiceStates = nil
+	c.StageInstances = nil
+
+	return &c
+}
+
 func (d *DiscordIntegrator) pruneGuildGroups(ctx context.Context, logger runtime.Logger, doGuildLeaves, doGroupDeletes bool, pruneSafetyThreshold int) error {
 	var (
 		groupByGuildID = make(map[string]*api.Group)
@@ -76,13 +157,14 @@ func (d *DiscordIntegrator) pruneGuildGroups(ctx context.Context, logger runtime
 		}
 	}
 
-	if len(d.dg.State.Guilds) == 0 {
+	stateGuilds := snapshotStateGuilds(d.dg.State)
+	if len(stateGuilds) == 0 {
 		logger.Warn("No guilds found in Discord state, skipping pruning operation")
 		return nil
 	}
 	// Get the guilds where the bot is a member
-	botGuildMap := make(map[string]*discordgo.Guild)
-	for _, g := range d.dg.State.Guilds {
+	botGuildMap := make(map[string]*discordgo.Guild, len(stateGuilds))
+	for _, g := range stateGuilds {
 		botGuildMap[g.ID] = g
 	}
 

--- a/server/evr_discord_integrator_state_race_test.go
+++ b/server/evr_discord_integrator_state_race_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -11,12 +12,13 @@ import (
 // discordgo owns Session.State and mutates it from the gateway goroutine under
 // State.Lock():
 //
-//   - GuildAdd (state.go:89) appends to State.Guilds (state.go:142) and, for a
-//     guild already in the cache, overwrites the existing *Guild IN PLACE
-//     (`*g = *guild`, state.go:141).
-//   - ChannelAdd (state.go:482) appends to guild.Channels and overwrites an
-//     existing *Channel in place (`*c = *channel`).
-//   - ChannelRemove (state.go:529) compacts guild.Channels.
+// (all line numbers are discordgo v0.29.0's state.go)
+//
+//   - GuildAdd (:89) appends to State.Guilds (:146) and, for a guild already in
+//     the cache, overwrites the existing *Guild IN PLACE (`*g = *guild`, :142).
+//   - ChannelAdd (:482) appends to guild.Channels (:520) and overwrites an
+//     existing *Channel in place (`*c = *channel`, :502).
+//   - ChannelRemove (:529) compacts guild.Channels.
 //
 // pruneGuildGroups runs on the 15-minute prune ticker goroutine
 // (evr_discord_integrator.go:189), NOT the gateway goroutine. It read
@@ -158,13 +160,17 @@ func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
 	sortOrder := discordgo.ForumSortOrderLatestActivity
 	state := discordgo.NewState()
 	if err := state.GuildAdd(&discordgo.Guild{
-		ID:      "guild-x",
-		Name:    "X",
-		OwnerID: "owner-x",
-		Roles:   []*discordgo.Role{{ID: "role-1"}},
-		Emojis:  []*discordgo.Emoji{{ID: "emoji-1"}},
-		Members: []*discordgo.Member{{User: &discordgo.User{ID: "u1"}}},
-		Threads: []*discordgo.Channel{{ID: "thread-1", GuildID: "guild-x"}},
+		ID:             "guild-x",
+		Name:           "X",
+		OwnerID:        "owner-x",
+		Roles:          []*discordgo.Role{{ID: "role-1"}},
+		Emojis:         []*discordgo.Emoji{{ID: "emoji-1"}},
+		Stickers:       []*discordgo.Sticker{{ID: "sticker-1"}},
+		Members:        []*discordgo.Member{{User: &discordgo.User{ID: "u1"}}},
+		Presences:      []*discordgo.Presence{{User: &discordgo.User{ID: "u1"}}},
+		VoiceStates:    []*discordgo.VoiceState{{UserID: "u1"}},
+		StageInstances: []*discordgo.StageInstance{{ID: "stage-1"}},
+		Threads:        []*discordgo.Channel{{ID: "thread-1", GuildID: "guild-x"}},
 		Channels: []*discordgo.Channel{
 			{ID: "c1", GuildID: "guild-x", Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "t",
 				Messages:             []*discordgo.Message{{ID: "m1"}},
@@ -188,11 +194,18 @@ func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
 	}
 	g := snap[0]
 
+	// The eight Guild collections copyStateGuild clears. Channels is deep-copied
+	// and Features cloned; together that is all ten of discordgo.Guild's
+	// reference-typed fields.
 	for name, v := range map[string]int{
-		"Roles":   len(g.Roles),
-		"Emojis":  len(g.Emojis),
-		"Members": len(g.Members),
-		"Threads": len(g.Threads),
+		"Roles":          len(g.Roles),
+		"Emojis":         len(g.Emojis),
+		"Stickers":       len(g.Stickers),
+		"Members":        len(g.Members),
+		"Presences":      len(g.Presences),
+		"VoiceStates":    len(g.VoiceStates),
+		"StageInstances": len(g.StageInstances),
+		"Threads":        len(g.Threads),
 	} {
 		if v != 0 {
 			t.Errorf("snapshot still carries %s (%d entries); it aliases gateway-mutated state", name, v)
@@ -231,6 +244,111 @@ func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
 	if ch.ID != "c1" || ch.Name != "rules" || ch.Topic != "t" || ch.Type != discordgo.ChannelTypeGuildText {
 		t.Errorf("snapshot dropped the channel scalars guildSync reads: %+v", ch)
 	}
+}
+
+// populateNilReferenceFields fills every nil reference-typed field on a struct
+// with a non-nil value. It is what makes the aliasing guard below survive a
+// discordgo upgrade: a field added by a future version is populated here by
+// reflection, without this test knowing its name, so copyStateGuild's shallow
+// `c := *g` cannot silently start aliasing it.
+func populateNilReferenceFields(t *testing.T, v reflect.Value) {
+	t.Helper()
+	typ := v.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		if !typ.Field(i).IsExported() {
+			continue
+		}
+		fv := v.Field(i)
+		switch fv.Kind() {
+		case reflect.Slice:
+			if fv.IsNil() {
+				fv.Set(reflect.MakeSlice(fv.Type(), 1, 1))
+			}
+		case reflect.Map:
+			if fv.IsNil() {
+				fv.Set(reflect.MakeMap(fv.Type()))
+			}
+		case reflect.Pointer:
+			if fv.IsNil() {
+				fv.Set(reflect.New(fv.Type().Elem()))
+			}
+		}
+	}
+}
+
+// assertNoLiveAliasing checks the contract copyStateGuild documents: every
+// reference-typed field is either CLEARED (nil) or deep-copied. Sharing backing
+// memory with the live object is the one thing it must never do, because the
+// gateway goroutine mutates that memory under State.Lock().
+func assertNoLiveAliasing(t *testing.T, label string, snap, live reflect.Value) {
+	t.Helper()
+	typ := snap.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		sv, lv := snap.Field(i), live.Field(i)
+		switch sv.Kind() {
+		case reflect.Slice, reflect.Map, reflect.Pointer, reflect.Chan, reflect.Func:
+		default:
+			continue
+		}
+		if sv.IsNil() || lv.IsNil() {
+			continue // cleared, or nothing to alias
+		}
+		if sv.Kind() == reflect.Slice && (sv.Len() == 0 || lv.Len() == 0) {
+			continue // no backing array to share
+		}
+		if sv.Pointer() == lv.Pointer() {
+			t.Errorf("%s.%s aliases live discordgo state (both %#x); copyStateGuild must deep-copy it or clear it",
+				label, f.Name, sv.Pointer())
+		}
+	}
+}
+
+// TestSnapshotStateGuilds_NoFieldAliasesLiveState is the self-enforcing version
+// of the copy contract. The table-driven test above names the fields it knows;
+// this one reflects over EVERY exported reference-typed field of Guild and
+// Channel, so a discordgo upgrade that adds one fails here instead of silently
+// handing gateway-mutated memory to the prune-leave path's zap reflect-walk.
+func TestSnapshotStateGuilds_NoFieldAliasesLiveState(t *testing.T) {
+	ch := &discordgo.Channel{
+		ID: "c1", GuildID: "guild-a", Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "t",
+	}
+	populateNilReferenceFields(t, reflect.ValueOf(ch).Elem())
+
+	g := &discordgo.Guild{
+		ID: "guild-a", Name: "A", OwnerID: "owner-a",
+		Channels: []*discordgo.Channel{ch},
+	}
+	populateNilReferenceFields(t, reflect.ValueOf(g).Elem())
+
+	// State.Guilds is set directly rather than via GuildAdd: the reflective
+	// fixture leaves nil elements inside the pointer slices it fills, and
+	// GuildAdd dereferences guild.Threads[i] (state.go:103-105 @ v0.29.0) and,
+	// via createMemberMap, guild.Members[i].User (state.go:108-109). Only the
+	// slice headers matter
+	// for aliasing, and snapshotStateGuilds reads State.Guilds directly.
+	state := discordgo.NewState()
+	state.Guilds = []*discordgo.Guild{g}
+	live := g
+
+	snap := snapshotStateGuilds(state)
+	if len(snap) != 1 {
+		t.Fatalf("got %d guilds, want 1", len(snap))
+	}
+	got := snap[0]
+
+	assertNoLiveAliasing(t, "Guild", reflect.ValueOf(got).Elem(), reflect.ValueOf(live).Elem())
+
+	if len(got.Channels) != 1 || len(live.Channels) != 1 {
+		t.Fatalf("channels not carried: snapshot=%d live=%d", len(got.Channels), len(live.Channels))
+	}
+	if got.Channels[0] == live.Channels[0] {
+		t.Fatal("snapshot reused the live *Channel pointer")
+	}
+	assertNoLiveAliasing(t, "Channel", reflect.ValueOf(got.Channels[0]).Elem(), reflect.ValueOf(live.Channels[0]).Elem())
 }
 
 // TestSnapshotStateGuilds_SafeAgainstGatewayChannelMutation proves the guilds

--- a/server/evr_discord_integrator_state_race_test.go
+++ b/server/evr_discord_integrator_state_race_test.go
@@ -1,0 +1,351 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// discordgo owns Session.State and mutates it from the gateway goroutine under
+// State.Lock():
+//
+//   - GuildAdd (state.go:89) appends to State.Guilds (state.go:142) and, for a
+//     guild already in the cache, overwrites the existing *Guild IN PLACE
+//     (`*g = *guild`, state.go:141).
+//   - ChannelAdd (state.go:482) appends to guild.Channels and overwrites an
+//     existing *Channel in place (`*c = *channel`).
+//   - ChannelRemove (state.go:529) compacts guild.Channels.
+//
+// pruneGuildGroups runs on the 15-minute prune ticker goroutine
+// (evr_discord_integrator.go:189), NOT the gateway goroutine. It read
+// d.dg.State.Guilds with no lock held and handed the LIVE *Guild pointers on to
+// deep readers: guildSync (evr_discord_integrator.go:550) ranges guild.Channels
+// looking for #rules, and the prune-leave path logs `"guild_metadata": guild`,
+// which zap reflect-walks the whole struct.
+//
+// Before PR #514, guildSync only ever received the event-owned e.Guild from a
+// Guild Create/Update, which is fresh and unshared; the orphan reconciliation
+// added in #514 is what wired live state objects into a deep read.
+//
+// The copy-semantics tests below fail deterministically without the fix; the
+// concurrency tests fail under -race.
+
+// guildSyncStyleRead performs the same reads on a guild that guildSync does:
+// the scalar fields it copies into the Nakama group, and the #rules channel
+// scan over guild.Channels.
+func guildSyncStyleRead(g *discordgo.Guild) string {
+	rules := ""
+	_ = g.ID
+	_ = g.Name
+	_ = g.OwnerID
+	_ = g.Description
+	_ = g.IconURL("512")
+	for _, channel := range g.Channels {
+		if channel == nil {
+			continue
+		}
+		if channel.Type == discordgo.ChannelTypeGuildText && channel.Name == "rules" {
+			rules = channel.Topic
+			break
+		}
+	}
+	return rules
+}
+
+// newTestDiscordState builds a state with n guilds, each carrying a #rules
+// channel, as the gateway would after a Ready + Guild Create burst.
+func newTestDiscordState(t *testing.T, n int) *discordgo.State {
+	t.Helper()
+	state := discordgo.NewState()
+	for i := 0; i < n; i++ {
+		guildID := fmt.Sprintf("guild-%d", i)
+		g := &discordgo.Guild{
+			ID:          guildID,
+			Name:        fmt.Sprintf("Guild %d", i),
+			OwnerID:     fmt.Sprintf("owner-%d", i),
+			Description: "a guild",
+			Icon:        "icon-hash",
+			Channels: []*discordgo.Channel{
+				{ID: guildID + "-rules", GuildID: guildID, Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "be nice"},
+				{ID: guildID + "-general", GuildID: guildID, Type: discordgo.ChannelTypeGuildText, Name: "general"},
+			},
+		}
+		if err := state.GuildAdd(g); err != nil {
+			t.Fatalf("GuildAdd: %v", err)
+		}
+	}
+	return state
+}
+
+// TestSnapshotStateGuilds_ReturnsCopiesNotLiveGuilds is the deterministic core
+// of the fix: the snapshot must not alias the *Guild objects that the gateway
+// goroutine overwrites in place. It fails without -race.
+func TestSnapshotStateGuilds_ReturnsCopiesNotLiveGuilds(t *testing.T) {
+	state := newTestDiscordState(t, 2)
+
+	live, err := state.Guild("guild-0")
+	if err != nil {
+		t.Fatalf("Guild: %v", err)
+	}
+
+	snap := snapshotStateGuilds(state)
+	var got *discordgo.Guild
+	for _, g := range snap {
+		if g.ID == "guild-0" {
+			got = g
+		}
+	}
+	if got == nil {
+		t.Fatalf("guild-0 missing from snapshot")
+	}
+
+	if got == live {
+		t.Fatal("snapshot returned the LIVE *Guild from discordgo state; the gateway goroutine overwrites it in place under State.Lock()")
+	}
+	if len(got.Channels) > 0 && len(live.Channels) > 0 && got.Channels[0] == live.Channels[0] {
+		t.Fatal("snapshot returned the LIVE *Channel pointers; ChannelAdd overwrites them in place under State.Lock()")
+	}
+}
+
+// TestSnapshotStateGuilds_SnapshotIsStableAcrossStateMutation pins the whole
+// point of copying: once taken, the snapshot the prune path iterates must not
+// change underneath it when the gateway mutates state. Deterministic.
+func TestSnapshotStateGuilds_SnapshotIsStableAcrossStateMutation(t *testing.T) {
+	state := newTestDiscordState(t, 1)
+
+	snap := snapshotStateGuilds(state)
+	if len(snap) != 1 {
+		t.Fatalf("got %d guilds, want 1", len(snap))
+	}
+	if rules := guildSyncStyleRead(snap[0]); rules != "be nice" {
+		t.Fatalf("rules topic = %q, want %q", rules, "be nice")
+	}
+
+	// The gateway re-delivers the guild (in-place *g = *guild), renames it,
+	// and drops the #rules channel.
+	if err := state.GuildAdd(&discordgo.Guild{
+		ID:          "guild-0",
+		Name:        "Renamed",
+		OwnerID:     "someone-else",
+		Description: "changed",
+		Channels: []*discordgo.Channel{
+			{ID: "guild-0-general", GuildID: "guild-0", Type: discordgo.ChannelTypeGuildText, Name: "general"},
+		},
+	}); err != nil {
+		t.Fatalf("GuildAdd: %v", err)
+	}
+
+	if snap[0].Name != "Guild 0" {
+		t.Errorf("snapshot guild name changed to %q after a state mutation; it aliases live state", snap[0].Name)
+	}
+	if snap[0].OwnerID != "owner-0" {
+		t.Errorf("snapshot guild owner changed to %q after a state mutation; it aliases live state", snap[0].OwnerID)
+	}
+	if rules := guildSyncStyleRead(snap[0]); rules != "be nice" {
+		t.Errorf("snapshot rules topic changed to %q after a state mutation; it aliases live state", rules)
+	}
+}
+
+// TestSnapshotStateGuilds_DropsUncopiedLiveCollections pins the safety
+// contract: reference-typed fields that the snapshot does not deep-copy must be
+// cleared, not aliased. Otherwise the prune-leave path's
+// `"guild_metadata": guild` zap reflect-walk reaches straight back into
+// gateway-mutated slices.
+func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
+	state := discordgo.NewState()
+	if err := state.GuildAdd(&discordgo.Guild{
+		ID:      "guild-x",
+		Name:    "X",
+		OwnerID: "owner-x",
+		Roles:   []*discordgo.Role{{ID: "role-1"}},
+		Emojis:  []*discordgo.Emoji{{ID: "emoji-1"}},
+		Members: []*discordgo.Member{{User: &discordgo.User{ID: "u1"}}},
+		Threads: []*discordgo.Channel{{ID: "thread-1", GuildID: "guild-x"}},
+		Channels: []*discordgo.Channel{
+			{ID: "c1", GuildID: "guild-x", Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "t",
+				Messages: []*discordgo.Message{{ID: "m1"}}},
+		},
+	}); err != nil {
+		t.Fatalf("GuildAdd: %v", err)
+	}
+
+	snap := snapshotStateGuilds(state)
+	if len(snap) != 1 {
+		t.Fatalf("got %d guilds, want 1", len(snap))
+	}
+	g := snap[0]
+
+	for name, v := range map[string]int{
+		"Roles":   len(g.Roles),
+		"Emojis":  len(g.Emojis),
+		"Members": len(g.Members),
+		"Threads": len(g.Threads),
+	} {
+		if v != 0 {
+			t.Errorf("snapshot still carries %s (%d entries); it aliases gateway-mutated state", name, v)
+		}
+	}
+	if len(g.Channels) != 1 {
+		t.Fatalf("snapshot lost the channels the prune path reads: %+v", g.Channels)
+	}
+	if len(g.Channels[0].Messages) != 0 {
+		t.Errorf("snapshot channel still carries Messages; MessageAdd appends to it under State.Lock()")
+	}
+}
+
+// TestSnapshotStateGuilds_SafeAgainstGatewayChannelMutation proves the guilds
+// handed to a deep reader are not the live objects the gateway mutates via
+// ChannelAdd / ChannelRemove. Fails under -race without the fix.
+func TestSnapshotStateGuilds_SafeAgainstGatewayChannelMutation(t *testing.T) {
+	const guilds = 4
+	state := newTestDiscordState(t, guilds)
+
+	stop := make(chan struct{})
+	gatewayDone := make(chan struct{})
+	go func() {
+		defer close(gatewayDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			guildID := fmt.Sprintf("guild-%d", i%guilds)
+			// A bounded churn set: the same channel is added and removed, so
+			// guild.Channels is appended to and compacted repeatedly without
+			// the state growing without bound.
+			ch := &discordgo.Channel{
+				ID:      fmt.Sprintf("%s-churn", guildID),
+				GuildID: guildID,
+				Type:    discordgo.ChannelTypeGuildText,
+				Name:    "rules",
+				Topic:   "churn",
+			}
+			_ = state.ChannelAdd(ch)
+			_ = state.ChannelRemove(ch)
+		}
+	}()
+
+	for i := 0; i < 500; i++ {
+		for _, g := range snapshotStateGuilds(state) {
+			_ = guildSyncStyleRead(g)
+		}
+	}
+
+	close(stop)
+	<-gatewayDone
+}
+
+// TestSnapshotStateGuilds_SafeAgainstGatewayGuildMutation covers the other two
+// live-state mutations GuildAdd performs under State.Lock(): appending to
+// State.Guilds and overwriting an existing *Guild in place. Fails under -race
+// without the fix.
+func TestSnapshotStateGuilds_SafeAgainstGatewayGuildMutation(t *testing.T) {
+	const guilds = 4
+	state := newTestDiscordState(t, guilds)
+
+	stop := make(chan struct{})
+	gatewayDone := make(chan struct{})
+	go func() {
+		defer close(gatewayDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Re-deliver an existing guild (in-place *g = *guild overwrite)...
+			existingID := fmt.Sprintf("guild-%d", i%guilds)
+			_ = state.GuildAdd(&discordgo.Guild{
+				ID:          existingID,
+				Name:        fmt.Sprintf("Guild %d rev %d", i%guilds, i),
+				OwnerID:     fmt.Sprintf("owner-%d", i),
+				Description: "updated",
+				Icon:        fmt.Sprintf("icon-%d", i),
+				Channels: []*discordgo.Channel{
+					{ID: existingID + "-rules", GuildID: existingID, Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "rev"},
+				},
+			})
+			// ...and join a guild from a bounded pool, which appends to
+			// State.Guilds the first time each ID is seen. Bounded so the
+			// snapshot cost stays constant instead of growing quadratically.
+			newID := fmt.Sprintf("guild-new-%d", i%guilds)
+			_ = state.GuildAdd(&discordgo.Guild{ID: newID, Name: newID, OwnerID: "owner-new"})
+		}
+	}()
+
+	for i := 0; i < 500; i++ {
+		for _, g := range snapshotStateGuilds(state) {
+			_ = guildSyncStyleRead(g)
+		}
+	}
+
+	close(stop)
+	<-gatewayDone
+}
+
+// TestSnapshotStateGuilds_Contents pins what the snapshot must contain: every
+// guild, with the fields the prune path and guildSync read.
+func TestSnapshotStateGuilds_Contents(t *testing.T) {
+	state := newTestDiscordState(t, 3)
+
+	got := snapshotStateGuilds(state)
+	if len(got) != 3 {
+		t.Fatalf("got %d guilds, want 3", len(got))
+	}
+
+	byID := make(map[string]*discordgo.Guild, len(got))
+	for _, g := range got {
+		byID[g.ID] = g
+	}
+	g, ok := byID["guild-1"]
+	if !ok {
+		t.Fatalf("guild-1 missing from snapshot: %v", byID)
+	}
+	if g.Name != "Guild 1" || g.OwnerID != "owner-1" || g.Description != "a guild" {
+		t.Errorf("guild-1 fields not carried over: %+v", g)
+	}
+	if g.IconURL("512") == "" {
+		t.Errorf("guild-1 icon not carried over; guildSync passes IconURL to GroupCreate/GroupUpdate")
+	}
+	if len(g.Channels) != 2 {
+		t.Fatalf("guild-1 channels not carried over: %+v", g.Channels)
+	}
+	if rules := guildSyncStyleRead(g); rules != "be nice" {
+		t.Errorf("rules topic = %q, want %q", rules, "be nice")
+	}
+}
+
+// TestSnapshotStateGuilds_NilState covers the defensive path: a session with no
+// state must not panic the prune job.
+func TestSnapshotStateGuilds_NilState(t *testing.T) {
+	if got := snapshotStateGuilds(nil); got != nil {
+		t.Fatalf("got %v, want nil", got)
+	}
+}
+
+// TestSnapshotStateGuilds_EmptyState pins the signal pruneGuildGroups relies on
+// to abort: an empty state yields an empty snapshot.
+func TestSnapshotStateGuilds_EmptyState(t *testing.T) {
+	if got := snapshotStateGuilds(discordgo.NewState()); len(got) != 0 {
+		t.Fatalf("got %d guilds, want 0", len(got))
+	}
+}
+
+// TestSnapshotStateGuilds_SkipsNilGuild covers a defensive path: a nil entry in
+// State.Guilds must not panic the prune job.
+func TestSnapshotStateGuilds_SkipsNilGuild(t *testing.T) {
+	state := newTestDiscordState(t, 1)
+	state.Guilds = append(state.Guilds, nil)
+
+	got := snapshotStateGuilds(state)
+	for _, g := range got {
+		if g == nil {
+			t.Fatal("snapshot carried a nil *Guild through to the prune path")
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d guilds, want 1", len(got))
+	}
+}

--- a/server/evr_discord_integrator_state_race_test.go
+++ b/server/evr_discord_integrator_state_race_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -153,6 +154,8 @@ func TestSnapshotStateGuilds_SnapshotIsStableAcrossStateMutation(t *testing.T) {
 // `"guild_metadata": guild` zap reflect-walk reaches straight back into
 // gateway-mutated slices.
 func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
+	pinnedAt := time.Now()
+	sortOrder := discordgo.ForumSortOrderLatestActivity
 	state := discordgo.NewState()
 	if err := state.GuildAdd(&discordgo.Guild{
 		ID:      "guild-x",
@@ -164,7 +167,16 @@ func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
 		Threads: []*discordgo.Channel{{ID: "thread-1", GuildID: "guild-x"}},
 		Channels: []*discordgo.Channel{
 			{ID: "c1", GuildID: "guild-x", Type: discordgo.ChannelTypeGuildText, Name: "rules", Topic: "t",
-				Messages: []*discordgo.Message{{ID: "m1"}}},
+				Messages:             []*discordgo.Message{{ID: "m1"}},
+				Recipients:           []*discordgo.User{{ID: "u1"}},
+				PermissionOverwrites: []*discordgo.PermissionOverwrite{{ID: "po1"}},
+				ThreadMetadata:       &discordgo.ThreadMetadata{Archived: true},
+				Member:               &discordgo.ThreadMember{ID: "tm1"},
+				Members:              []*discordgo.ThreadMember{{ID: "tm2"}},
+				AvailableTags:        []discordgo.ForumTag{{ID: "tag1"}},
+				AppliedTags:          []string{"tag1"},
+				LastPinTimestamp:     &pinnedAt,
+				DefaultSortOrder:     &sortOrder},
 		},
 	}); err != nil {
 		t.Fatalf("GuildAdd: %v", err)
@@ -189,8 +201,35 @@ func TestSnapshotStateGuilds_DropsUncopiedLiveCollections(t *testing.T) {
 	if len(g.Channels) != 1 {
 		t.Fatalf("snapshot lost the channels the prune path reads: %+v", g.Channels)
 	}
-	if len(g.Channels[0].Messages) != 0 {
-		t.Errorf("snapshot channel still carries Messages; MessageAdd appends to it under State.Lock()")
+	// Every reference-typed field on discordgo.Channel must be either
+	// deep-copied or cleared. `go doc discordgo.Channel` enumerates exactly
+	// these ten; none is read through the snapshot, so all ten are cleared.
+	ch := g.Channels[0]
+	for name, v := range map[string]int{
+		"Messages":             len(ch.Messages),
+		"Recipients":           len(ch.Recipients),
+		"PermissionOverwrites": len(ch.PermissionOverwrites),
+		"Members":              len(ch.Members),
+		"AvailableTags":        len(ch.AvailableTags),
+		"AppliedTags":          len(ch.AppliedTags),
+	} {
+		if v != 0 {
+			t.Errorf("snapshot channel still carries %s (%d entries); it aliases gateway-mutated state", name, v)
+		}
+	}
+	for name, ptr := range map[string]bool{
+		"ThreadMetadata":   ch.ThreadMetadata != nil,
+		"Member":           ch.Member != nil,
+		"LastPinTimestamp": ch.LastPinTimestamp != nil,
+		"DefaultSortOrder": ch.DefaultSortOrder != nil,
+	} {
+		if ptr {
+			t.Errorf("snapshot channel still aliases %s; clear it or deep-copy it", name)
+		}
+	}
+	// The scalar fields guildSync actually reads must survive.
+	if ch.ID != "c1" || ch.Name != "rules" || ch.Topic != "t" || ch.Type != discordgo.ChannelTypeGuildText {
+		t.Errorf("snapshot dropped the channel scalars guildSync reads: %+v", ch)
 	}
 }
 

--- a/server/evr_discord_state_access.go
+++ b/server/evr_discord_state_access.go
@@ -1,0 +1,38 @@
+package server
+
+import "github.com/bwmarrin/discordgo"
+
+// botDiscordIDFromState returns the bot's own Discord user ID, read under the
+// discordgo state's read lock.
+//
+// discordgo.State embeds Ready (state.go:36-38 @ v0.29.0), so State.User is
+// Ready.User — a *User that discordgo REPLACES wholesale on every gateway
+// READY: State.onReady takes State.Lock() and assigns `s.Ready = *r`
+// (state.go:911, :916, :935 @ v0.29.0), which writes the User pointer word
+// itself, not just the pointee.
+//
+// guildSync reads the bot ID on the 15-minute prune-ticker goroutine
+// (pruneGuildGroups -> reconcileOrphanGuilds -> guildSync), not the gateway
+// goroutine, so an unlocked `d.dg.State.User.ID` is a plain data race against a
+// gateway reconnect. A torn/stale read yields "" and turns every orphan guild
+// into a prune-leave candidate.
+//
+// It also removes a nil dereference: before the first READY, State.User is nil
+// and the unlocked expression `State.User.ID` panicked. Returning "" instead
+// lets guildSync fail with its existing "failed to get bot user ID from state"
+// error, which the prune path already handles as "guild stays an orphan
+// candidate" rather than crashing the integrator goroutine.
+//
+// The lock is released before the caller's DiscordIDToUserID lookup, so the
+// discordgo state lock is never held across a database call.
+func botDiscordIDFromState(state *discordgo.State) string {
+	if state == nil {
+		return ""
+	}
+	state.RLock()
+	defer state.RUnlock()
+	if state.User == nil {
+		return ""
+	}
+	return state.User.ID
+}

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -45,6 +45,8 @@ func NewLatencyHistory() *LatencyHistory {
 }
 
 func (h *LatencyHistory) StorageMeta() StorableMetadata {
+	h.RLock()
+	defer h.RUnlock()
 	return StorableMetadata{
 		Collection:      LatencyHistoryStorageCollection,
 		Key:             LatencyHistoryStorageKey,
@@ -119,9 +121,59 @@ func (h *LatencyHistory) writeWithRetry(ctx context.Context, nk runtime.NakamaMo
 	return fmt.Errorf("LatencyHistory.writeWithRetry: exhausted %d attempts: %w", latencyRetryMaxAttempts, lastErr)
 }
 
-func (h *LatencyHistory) String() string {
+// latencyHistoryData is the wire form of LatencyHistory. It exists so that
+// MarshalJSON/UnmarshalJSON can serialize the exported state without copying
+// the embedded RWMutex (a `type Alias LatencyHistory` conversion would copy the
+// lock). Any exported field added to LatencyHistory must be mirrored here or it
+// will silently stop being persisted.
+type latencyHistoryData struct {
+	GameServerLatencies map[string][]LatencyHistoryItem `json:"game_server_latencies"`
+}
+
+// MarshalJSON serializes the history under the read lock.
+//
+// A *LatencyHistory is shared across a session's goroutines via
+// sessionParameters.latencyHistory, and StorableWrite marshals the live object,
+// so the encoder walks the same map that Add mutates. Without this the encode
+// is an unsynchronized map read racing a locked map write.
+func (h *LatencyHistory) MarshalJSON() ([]byte, error) {
 	h.RLock()
 	defer h.RUnlock()
+	return json.Marshal(latencyHistoryData{GameServerLatencies: h.GameServerLatencies})
+}
+
+// UnmarshalJSON deserializes the history under the write lock.
+//
+// StorableRead decodes straight into the live, session-shared object (see
+// writeWithRetry's re-read after a version conflict), so the decode is a map
+// write that must be serialized against the locked readers on other goroutines.
+// Unsynchronized, it surfaces as "fatal error: concurrent map read and map
+// write" — a runtime throw that kills the process rather than a recoverable
+// panic.
+//
+// Merge semantics match what encoding/json did for the plain struct: keys from
+// the decoded record are adopted, and keys present only in the receiver are
+// preserved.
+func (h *LatencyHistory) UnmarshalJSON(data []byte) error {
+	var decoded latencyHistoryData
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	h.Lock()
+	defer h.Unlock()
+	if h.GameServerLatencies == nil {
+		h.GameServerLatencies = make(map[string][]LatencyHistoryItem, len(decoded.GameServerLatencies))
+	}
+	for extIP, history := range decoded.GameServerLatencies {
+		h.GameServerLatencies[extIP] = history
+	}
+	return nil
+}
+
+func (h *LatencyHistory) String() string {
+	// json.Marshal dispatches to MarshalJSON, which takes the read lock. Taking
+	// it here as well would be a recursive RLock and can deadlock against a
+	// waiting writer.
 	data, err := json.Marshal(h)
 	if err != nil {
 		return ""
@@ -359,6 +411,10 @@ func (h *LatencyHistory) HasRecentEntry(ipKey string, cutoff time.Time) bool {
 	return false
 }
 
+// Get returns a copy of the recorded history for an external IP. The copy is
+// required: Add mutates the stored slice in place (append into spare capacity,
+// slices.Delete compaction), so handing out the live slice lets the caller read
+// it after the lock is released, racing the next Add.
 func (h *LatencyHistory) Get(extIP string) ([]LatencyHistoryItem, bool) {
 	h.RLock()
 	defer h.RUnlock()
@@ -366,7 +422,7 @@ func (h *LatencyHistory) Get(extIP string) ([]LatencyHistoryItem, bool) {
 	if !ok || len(history) == 0 {
 		return nil, false
 	}
-	return history, true
+	return slices.Clone(history), true
 }
 
 func sortPingCandidatesByLatencyHistory(hostIPs []string, latencyHistory *LatencyHistory) {

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -151,9 +151,19 @@ func (h *LatencyHistory) MarshalJSON() ([]byte, error) {
 // write" — a runtime throw that kills the process rather than a recoverable
 // panic.
 //
-// Merge semantics match what encoding/json did for the plain struct: keys from
-// the decoded record are adopted, and keys present only in the receiver are
-// preserved.
+// Merge semantics match what encoding/json did for the plain struct in every
+// case except one: keys from the decoded record are adopted, and keys present
+// only in the receiver are preserved.
+//
+// The one divergence is a JSON null for the map. Reflection-decoding
+// `{"game_server_latencies":null}` set the field to a nil map, discarding
+// whatever the receiver already held; this implementation leaves the receiver's
+// entries in place. That document is reachable in production — StorableWrite on
+// a `&LatencyHistory{}` with a nil map (constructed at evr_pipeline_login.go,
+// evr_runtime_rpc.go and evr_runtime_rpc_match.go) persists exactly that — and
+// the divergence is strictly the safer direction: writeWithRetry's re-read no
+// longer silently drops the caller's pending samples when the concurrent winner
+// stored a null map. Pinned by TestLatencyHistory_UnmarshalNullMapPreservesExisting.
 func (h *LatencyHistory) UnmarshalJSON(data []byte) error {
 	var decoded latencyHistoryData
 	if err := json.Unmarshal(data, &decoded); err != nil {

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -164,6 +164,16 @@ func (h *LatencyHistory) MarshalJSON() ([]byte, error) {
 // the divergence is strictly the safer direction: writeWithRetry's re-read no
 // longer silently drops the caller's pending samples when the concurrent winner
 // stored a null map. Pinned by TestLatencyHistory_UnmarshalNullMapPreservesExisting.
+//
+// Decoding is also all-or-nothing where the reflection decode salvaged whatever
+// it had already parsed: a record whose map holds one malformed value now
+// contributes NOTHING to the receiver instead of contributing its valid keys.
+// Both versions return the same error, and StorableRead's corrupt-record path
+// (evr_storable.go) deletes and recreates the record from the in-memory object
+// either way, so the only delta is that partially-salvaged keys are no longer
+// folded into that rewrite. Atomic is the intended semantic: a half-applied
+// decode leaves the session's live object in a state no stored record ever had.
+// Pinned by TestLatencyHistory_UnmarshalErrorLeavesReceiverUntouched.
 func (h *LatencyHistory) UnmarshalJSON(data []byte) error {
 	var decoded latencyHistoryData
 	if err := json.Unmarshal(data, &decoded); err != nil {

--- a/server/evr_latencyhistory.go
+++ b/server/evr_latencyhistory.go
@@ -155,15 +155,27 @@ func (h *LatencyHistory) MarshalJSON() ([]byte, error) {
 // case except one: keys from the decoded record are adopted, and keys present
 // only in the receiver are preserved.
 //
-// The one divergence is a JSON null for the map. Reflection-decoding
-// `{"game_server_latencies":null}` set the field to a nil map, discarding
-// whatever the receiver already held; this implementation leaves the receiver's
-// entries in place. That document is reachable in production — StorableWrite on
-// a `&LatencyHistory{}` with a nil map (constructed at evr_pipeline_login.go,
-// evr_runtime_rpc.go and evr_runtime_rpc_match.go) persists exactly that — and
-// the divergence is strictly the safer direction: writeWithRetry's re-read no
-// longer silently drops the caller's pending samples when the concurrent winner
-// stored a null map. Pinned by TestLatencyHistory_UnmarshalNullMapPreservesExisting.
+// The one divergence is a JSON null (or an absent key) for the map.
+// Reflection-decoding `{"game_server_latencies":null}` set the field to a nil
+// map, discarding whatever the receiver already held; this implementation
+// leaves the receiver exactly as it found it. That document is reachable in
+// production — StorableWrite on a `&LatencyHistory{}` with a nil map
+// (constructed at evr_pipeline_login.go, evr_runtime_rpc.go and
+// evr_runtime_rpc_match.go) persists exactly that — and the divergence is
+// strictly the safer direction: writeWithRetry's re-read no longer silently
+// drops the caller's pending samples when the concurrent winner stored a null
+// map. Pinned by TestLatencyHistory_UnmarshalNullMapPreservesExisting.
+//
+// "Leaves the receiver as it found it" includes leaving a nil map NIL. The
+// null case returns before allocating, because whether the map is nil is
+// persisted state, not an implementation detail: a nil map marshals to `null`
+// and an allocated empty one to `{}`, so allocating here would make the
+// StorableRead -> StorableWrite round trip rewrite a stored null record into
+// `{}` without a single sample having changed. An explicit
+// `{"game_server_latencies":{}}` is NOT null and still allocates, matching
+// encoding/json. Pinned by TestLatencyHistory_UnmarshalNullMapIntoNilReceiverStaysNil,
+// TestLatencyHistory_NullMapRecordRoundTrips and
+// TestLatencyHistory_UnmarshalEmptyObjectMapStillAllocates.
 //
 // Decoding is also all-or-nothing where the reflection decode salvaged whatever
 // it had already parsed: a record whose map holds one malformed value now
@@ -178,6 +190,12 @@ func (h *LatencyHistory) UnmarshalJSON(data []byte) error {
 	var decoded latencyHistoryData
 	if err := json.Unmarshal(data, &decoded); err != nil {
 		return err
+	}
+	if decoded.GameServerLatencies == nil {
+		// Null or absent: there is nothing to merge and nothing to allocate, so
+		// this is a no-op on the receiver and needs no lock — same as the decode
+		// error above, which also returns before locking.
+		return nil
 	}
 	h.Lock()
 	defer h.Unlock()

--- a/server/evr_latencyhistory_nullmap_test.go
+++ b/server/evr_latencyhistory_nullmap_test.go
@@ -1,0 +1,152 @@
+package server
+
+// Characterization tests for LatencyHistory.UnmarshalJSON's handling of a
+// null/absent map, measured against the reflection decode it replaced.
+//
+// The explicit UnmarshalJSON is allowed exactly two documented divergences from
+// stock encoding/json (see the comment on UnmarshalJSON): a null map preserves
+// the receiver's existing entries, and a failed decode is all-or-nothing.
+// "Whether the map is nil" is NOT on that list, and it is observable: a nil map
+// marshals to `null` and an empty non-nil map marshals to `{}`, so allocating on
+// a null decode rewrites a stored record's shape on the next write.
+//
+// stockDecodeMap is the reference implementation: latencyHistoryData is the
+// exact struct the reflection decode operated on, so decoding into it IS what
+// encoding/json used to do to the receiver's field.
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+)
+
+// stockDecodeMap reports what plain encoding/json does to the map field for a
+// given document, starting from the given receiver map.
+func stockDecodeMap(t *testing.T, doc string, receiver map[string][]LatencyHistoryItem) map[string][]LatencyHistoryItem {
+	t.Helper()
+	stock := latencyHistoryData{GameServerLatencies: receiver}
+	if err := json.Unmarshal([]byte(doc), &stock); err != nil {
+		t.Fatalf("stock decode of %s: %v", doc, err)
+	}
+	return stock.GameServerLatencies
+}
+
+// TestLatencyHistory_UnmarshalNullMapIntoNilReceiverStaysNil is the case
+// Copilot flagged. A fresh &LatencyHistory{} is what every StorableRead decodes
+// into, and `{"game_server_latencies":null}` is a document that is genuinely
+// stored (a nil-map history serializes to exactly that). Allocating an empty map
+// here is an undocumented third divergence, and unlike the other two it is
+// visible in the persisted record.
+func TestLatencyHistory_UnmarshalNullMapIntoNilReceiverStaysNil(t *testing.T) {
+	const doc = `{"game_server_latencies":null}`
+
+	// The reference: stock encoding/json leaves a nil receiver map nil.
+	if got := stockDecodeMap(t, doc, nil); got != nil {
+		t.Fatalf("premise broken: stock encoding/json produced %#v for a null map into a nil receiver, want nil", got)
+	}
+
+	h := &LatencyHistory{}
+	if err := json.Unmarshal([]byte(doc), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.GameServerLatencies != nil {
+		t.Errorf("decoding %s into a nil-map receiver produced a non-nil map (%#v); stock encoding/json leaves it nil, and the difference is persisted: a nil map marshals to `null`, an allocated one to `{}`",
+			doc, h.GameServerLatencies)
+	}
+}
+
+// TestLatencyHistory_UnmarshalAbsentMapIntoNilReceiverStaysNil covers the same
+// divergence reached through an absent key rather than an explicit null.
+func TestLatencyHistory_UnmarshalAbsentMapIntoNilReceiverStaysNil(t *testing.T) {
+	const doc = `{}`
+
+	if got := stockDecodeMap(t, doc, nil); got != nil {
+		t.Fatalf("premise broken: stock encoding/json produced %#v for an absent map, want nil", got)
+	}
+
+	h := &LatencyHistory{}
+	if err := json.Unmarshal([]byte(doc), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.GameServerLatencies != nil {
+		t.Errorf("decoding %s into a nil-map receiver produced a non-nil map (%#v); stock encoding/json leaves it nil", doc, h.GameServerLatencies)
+	}
+}
+
+// TestLatencyHistory_NullMapRecordRoundTrips is the consequence Copilot named:
+// a stored `{"game_server_latencies":null}` record, read and written back
+// unchanged, must still be `null`. This is the read-modify-write StorableRead ->
+// StorableWrite performs, and a shape change here rewrites every such record in
+// storage the first time it is touched.
+func TestLatencyHistory_NullMapRecordRoundTrips(t *testing.T) {
+	const stored = `{"game_server_latencies":null}`
+
+	h := &LatencyHistory{}
+	if err := json.Unmarshal([]byte(stored), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	out, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != stored {
+		t.Errorf("a stored null-map record round-tripped to %s, want %s; reading a record and writing it back unchanged must not rewrite its shape", out, stored)
+	}
+}
+
+// TestLatencyHistory_UnmarshalEmptyObjectMapStillAllocates is the guard on the
+// other side of the fix: `{}` for the map is NOT null, and stock encoding/json
+// allocates for it. An early return keyed on "decoded map is nil" must not
+// swallow this case, or an explicitly-empty stored record would read back as nil
+// and marshal to `null`.
+func TestLatencyHistory_UnmarshalEmptyObjectMapStillAllocates(t *testing.T) {
+	const doc = `{"game_server_latencies":{}}`
+
+	if got := stockDecodeMap(t, doc, nil); got == nil {
+		t.Fatal("premise broken: stock encoding/json left the map nil for an explicit empty object")
+	}
+
+	h := &LatencyHistory{}
+	if err := json.Unmarshal([]byte(doc), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.GameServerLatencies == nil {
+		t.Error("an explicitly empty map decoded to a nil map; it must allocate, as stock encoding/json does, so the record round-trips as `{}` and not `null`")
+	}
+	out, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(out) != doc {
+		t.Errorf("an empty-object record round-tripped to %s, want %s", out, doc)
+	}
+}
+
+// TestLatencyHistory_UnmarshalNullMapStillPreservesPopulatedReceiver re-pins the
+// ONE divergence that is intended, so the fix above cannot be implemented by
+// simply restoring stock behavior. A null map must still not wipe a receiver
+// that holds pending samples — that is what protects writeWithRetry's OCC
+// re-read.
+func TestLatencyHistory_UnmarshalNullMapStillPreservesPopulatedReceiver(t *testing.T) {
+	const doc = `{"game_server_latencies":null}`
+
+	// The reference behavior this one deliberately does NOT follow.
+	seed := map[string][]LatencyHistoryItem{"10.0.0.2": {{RTT: 99, Timestamp: time.Time{}}}}
+	if got := stockDecodeMap(t, doc, seed); got != nil {
+		t.Fatalf("premise broken: stock encoding/json produced %#v for a null map into a populated receiver, want nil", got)
+	}
+
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("10.0.0.2"), 99, 25, time.Time{})
+
+	if err := json.Unmarshal([]byte(doc), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.GameServerLatencies == nil {
+		t.Fatal("a null map nil'd a populated receiver; pending samples would be lost on the OCC re-read")
+	}
+	if _, ok := h.GameServerLatencies["10.0.0.2"]; !ok {
+		t.Errorf("a null map dropped the receiver's own key: %#v", h.GameServerLatencies)
+	}
+}

--- a/server/evr_latencyhistory_race_test.go
+++ b/server/evr_latencyhistory_race_test.go
@@ -414,3 +414,33 @@ func TestLatencyHistory_UnmarshalRejectsGarbage(t *testing.T) {
 		t.Fatal("expected an error unmarshalling a malformed record, got nil")
 	}
 }
+
+// TestLatencyHistory_UnmarshalErrorLeavesReceiverUntouched pins the second
+// deliberate divergence from the reflection decode: decoding is all-or-nothing.
+//
+// Reflection decoded into the receiver key by key and kept whatever it had
+// parsed before hitting the malformed value, so a partially-corrupt record
+// contributed its valid keys AND wiped nothing. This implementation decodes
+// into a scratch value and returns before taking the lock, so a failed decode
+// contributes nothing and — critically — cannot leave the live, session-shared
+// object holding a half-applied merge of a record that never existed.
+func TestLatencyHistory_UnmarshalErrorLeavesReceiverUntouched(t *testing.T) {
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("10.0.0.9"), 7, 25, time.Time{})
+
+	// One valid entry, one malformed: the reflection decode salvaged 1.1.1.1.
+	const partial = `{"game_server_latencies":{"1.1.1.1":[{"timestamp":"2024-01-01T00:00:00Z","rtt":1000000}],"2.2.2.2":"bad"}}`
+	if err := json.Unmarshal([]byte(partial), h); err == nil {
+		t.Fatal("expected an error unmarshalling a partially malformed record, got nil")
+	}
+
+	if _, ok := h.GameServerLatencies["1.1.1.1"]; ok {
+		t.Error("a failed decode contributed a key to the receiver; decoding must be all-or-nothing")
+	}
+	if _, ok := h.GameServerLatencies["2.2.2.2"]; ok {
+		t.Error("a failed decode contributed the malformed key to the receiver")
+	}
+	if _, ok := h.GameServerLatencies["10.0.0.9"]; !ok {
+		t.Errorf("a failed decode dropped the receiver's own entries: %#v", h.GameServerLatencies)
+	}
+}

--- a/server/evr_latencyhistory_race_test.go
+++ b/server/evr_latencyhistory_race_test.go
@@ -117,6 +117,47 @@ func TestLatencyHistory_StorableRead_UnmarshalIsLocked(t *testing.T) {
 	<-readersDone
 }
 
+// TestLatencyHistory_StorageMeta_IsLocked pins the locking contract on the
+// version field: SetStorageMeta writes h.version under the write lock (it is
+// called by both StorableRead and StorableWrite), so StorageMeta must read it
+// under the read lock.
+//
+// Unlike the marshal/unmarshal races above, no confirmed production
+// interleaving reaches this today: the two StorableRead call sites that touch a
+// LatencyHistory (evr_pipeline_login.go:721 and the appbot handlers) all read
+// into an object that is not yet published to params.latencyHistory. This test
+// pins the type's contract rather than a reproduced production failure — every
+// other accessor on LatencyHistory locks, and an unlocked version read is a
+// trap for the next caller that does a storage op on the shared object.
+func TestLatencyHistory_StorageMeta_IsLocked(t *testing.T) {
+	h := seedLatencyHistory(2)
+
+	stop := make(chan struct{})
+	started := make(chan struct{})
+	writersDone := make(chan struct{})
+	go func() {
+		defer close(writersDone)
+		h.SetStorageMeta(StorableMetadata{Version: "v0"})
+		close(started) // Guarantee the two loops actually overlap.
+		for i := 1; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h.SetStorageMeta(StorableMetadata{Version: fmt.Sprintf("v%d", i)})
+		}
+	}()
+
+	<-started
+	for i := 0; i < 200000; i++ {
+		_ = h.StorageMeta().Version
+	}
+
+	close(stop)
+	<-writersDone
+}
+
 // TestLatencyHistory_StorableWrite_MarshalIsLocked proves the marshal inside
 // StorableWrite does not race with a concurrent locked mutation (Add) of the
 // same session-shared history.

--- a/server/evr_latencyhistory_race_test.go
+++ b/server/evr_latencyhistory_race_test.go
@@ -216,7 +216,10 @@ func TestLatencyHistory_String_ConcurrentWithAdd(t *testing.T) {
 		defer close(finished)
 		for i := 0; i < 500; i++ {
 			if s := h.String(); s == "" {
-				panic("String() returned empty; marshal failed")
+				// t.Fatal is illegal off the test goroutine, and panicking
+				// here would abort the whole ./server/ test binary.
+				t.Errorf("String() returned empty; marshal failed")
+				return
 			}
 		}
 	}()
@@ -358,6 +361,35 @@ func TestLatencyHistory_UnmarshalMergesIntoExisting(t *testing.T) {
 	}
 	if _, ok := local.GameServerLatencies["10.0.0.2"]; !ok {
 		t.Errorf("local-only key was dropped: %#v", local.GameServerLatencies)
+	}
+}
+
+// TestLatencyHistory_UnmarshalNullMapPreservesExisting pins the ONE case where
+// the explicit UnmarshalJSON diverges from the reflection decode it replaced.
+//
+// A `&LatencyHistory{}` with a nil map (evr_pipeline_login.go:720,
+// evr_runtime_rpc.go:1950, evr_runtime_rpc_match.go:168) marshals to
+// `{"game_server_latencies":null}`, so this document is genuinely stored.
+// Reflection-decoding it set the receiver's map to nil, discarding the caller's
+// pending samples during writeWithRetry's re-read; the merge keeps them. The
+// divergence is deliberate and strictly the safer direction.
+func TestLatencyHistory_UnmarshalNullMapPreservesExisting(t *testing.T) {
+	// The document really is what a nil-map history serializes to.
+	if got := (&LatencyHistory{}).String(); got != `{"game_server_latencies":null}` {
+		t.Fatalf("nil-map history serialized to %s; the null case may no longer be reachable", got)
+	}
+
+	h := NewLatencyHistory()
+	h.Add(net.ParseIP("10.0.0.2"), 99, 25, time.Time{})
+
+	if err := json.Unmarshal([]byte(`{"game_server_latencies":null}`), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if h.GameServerLatencies == nil {
+		t.Fatal("null map nil'd the receiver's map; pending samples would be lost on the OCC re-read")
+	}
+	if _, ok := h.GameServerLatencies["10.0.0.2"]; !ok {
+		t.Errorf("null map dropped the local-only key: %#v", h.GameServerLatencies)
 	}
 }
 

--- a/server/evr_latencyhistory_race_test.go
+++ b/server/evr_latencyhistory_race_test.go
@@ -1,0 +1,343 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// A *LatencyHistory is shared across a session's goroutines: it lives in
+// sessionParameters.latencyHistory (*atomic.Pointer[LatencyHistory]) and is
+// loaded by lobbyPingResponse (inbound pipeline goroutine) while the
+// lobbySessionRequest goroutine reads it via CheckServerPing ->
+// HasRecentEntry / sortPingCandidatesByLatencyHistory and via
+// NewLobbyParametersFromRequest -> AverageRTTs.
+//
+// Every accessor on the type takes the embedded RWMutex, but the storage path
+// did not: StorableWrite json.Marshal'd the live object and StorableRead
+// json.Unmarshal'd into it with no lock held. The unmarshal is a map WRITE, so
+// it races with the locked readers on the other goroutine — Go reports that as
+// "fatal error: concurrent map read and map write", a runtime throw that takes
+// the whole process down rather than a recoverable panic.
+//
+// These tests pin the storage path to the same locking discipline as the rest
+// of the type. They only fail under -race (or, nondeterministically, with the
+// map fatal error).
+
+// conflictAlternatingModule rejects every other StorageWrite with a version
+// conflict so that each writeWithRetry call exercises BOTH the marshal path
+// (StorableWrite) and the re-read/unmarshal path (StorableRead) before it
+// finally succeeds.
+type conflictAlternatingModule struct {
+	*occTestNakamaModule
+	callMu sync.Mutex
+	calls  int
+}
+
+func (m *conflictAlternatingModule) StorageWrite(ctx context.Context, writes []*runtime.StorageWrite) ([]*api.StorageObjectAck, error) {
+	m.callMu.Lock()
+	m.calls++
+	conflict := m.calls%2 == 1
+	m.callMu.Unlock()
+	if conflict {
+		return nil, runtime.ErrStorageRejectedVersion
+	}
+	return m.occTestNakamaModule.StorageWrite(ctx, writes)
+}
+
+// seedLatencyHistory returns a history populated with n game server entries.
+func seedLatencyHistory(n int) *LatencyHistory {
+	h := NewLatencyHistory()
+	for i := 0; i < n; i++ {
+		h.Add(net.ParseIP(fmt.Sprintf("10.0.0.%d", i+1)), 20+i, 25, time.Time{})
+	}
+	return h
+}
+
+// hammerReaders runs the locked read accessors that the lobby-find goroutine
+// uses, until stop is closed.
+func hammerReaders(h *LatencyHistory, stop <-chan struct{}, done chan<- struct{}) {
+	defer close(done)
+	cutoff := time.Now().Add(-time.Hour)
+	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+		_ = h.AverageRTTs(false)
+		_ = h.LatestRTTs()
+		_ = h.HasRecentEntry("10.0.0.1", cutoff)
+		_ = h.AverageRTT("10.0.0.2", true)
+		_, _, _ = h.BestAddress("10.0.0.1", "10.0.0.2")
+		ips := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+		sortPingCandidatesByLatencyHistory(ips, h)
+	}
+}
+
+// TestLatencyHistory_StorableRead_UnmarshalIsLocked proves the re-read after a
+// version conflict (StorableRead -> json.Unmarshal into the live object) does
+// not race with the locked readers on another goroutine.
+func TestLatencyHistory_StorableRead_UnmarshalIsLocked(t *testing.T) {
+	ctx := context.Background()
+
+	base := newOCCTestNakamaModule()
+	base.seedObject(occTestUserID, LatencyHistoryStorageCollection, LatencyHistoryStorageKey, seedLatencyHistory(16).String())
+	nk := &conflictAlternatingModule{occTestNakamaModule: base}
+
+	// The session-shared history, as loaded from params.latencyHistory.
+	h := seedLatencyHistory(4)
+
+	stop := make(chan struct{})
+	readersDone := make(chan struct{})
+	go hammerReaders(h, stop, readersDone)
+
+	expiry := time.Now().Add(-14 * 24 * time.Hour)
+	reapply := func() error {
+		h.Add(net.ParseIP("10.0.0.99"), 42, 25, expiry)
+		return nil
+	}
+	for i := 0; i < 20; i++ {
+		if err := reapply(); err != nil {
+			t.Fatalf("reapply: %v", err)
+		}
+		if err := h.writeWithRetry(ctx, nk, occTestUserID, reapply); err != nil {
+			t.Fatalf("writeWithRetry iteration %d: %v", i, err)
+		}
+	}
+
+	close(stop)
+	<-readersDone
+}
+
+// TestLatencyHistory_StorableWrite_MarshalIsLocked proves the marshal inside
+// StorableWrite does not race with a concurrent locked mutation (Add) of the
+// same session-shared history.
+func TestLatencyHistory_StorableWrite_MarshalIsLocked(t *testing.T) {
+	ctx := context.Background()
+
+	nk := newOCCTestNakamaModule()
+	h := seedLatencyHistory(8)
+
+	stop := make(chan struct{})
+	addersDone := make(chan struct{})
+	go func() {
+		defer close(addersDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h.Add(net.ParseIP(fmt.Sprintf("10.1.0.%d", i%32)), 10+i%50, 25, time.Time{})
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		if err := StorableWrite(ctx, nk, occTestUserID, h); err != nil {
+			t.Fatalf("StorableWrite iteration %d: %v", i, err)
+		}
+	}
+
+	close(stop)
+	<-addersDone
+}
+
+// TestLatencyHistory_String_ConcurrentWithAdd proves String() (which marshals)
+// is safe against a concurrent locked mutation, and that adding a locking
+// MarshalJSON did not reintroduce a recursive read-lock deadlock in String().
+func TestLatencyHistory_String_ConcurrentWithAdd(t *testing.T) {
+	h := seedLatencyHistory(4)
+
+	stop := make(chan struct{})
+	addersDone := make(chan struct{})
+	go func() {
+		defer close(addersDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h.Add(net.ParseIP(fmt.Sprintf("10.2.0.%d", i%16)), 10+i%40, 25, time.Time{})
+		}
+	}()
+
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		for i := 0; i < 500; i++ {
+			if s := h.String(); s == "" {
+				panic("String() returned empty; marshal failed")
+			}
+		}
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(30 * time.Second):
+		close(stop)
+		t.Fatal("String() deadlocked (recursive read lock?)")
+	}
+
+	close(stop)
+	<-addersDone
+}
+
+// TestLatencyHistory_Get_DoesNotEscapeLiveSlice proves Get hands back memory the
+// caller can safely read after the lock is released.
+//
+// sortPingCandidatesByLatencyHistory (the lobby-find goroutine) calls Get and
+// then reads history[len(history)-1] with no lock held. Add compacts the stored
+// slice in place via slices.Delete, which both shifts and zeroes elements the
+// escaped slice still spans. A stored record containing a zero-RTT entry is
+// enough to reach that path: Add strips zeroes it appends, but a record decoded
+// from storage (written by another session, or legacy data) can carry an
+// interior zero entry that the next Add then deletes in place.
+func TestLatencyHistory_Get_DoesNotEscapeLiveSlice(t *testing.T) {
+	const extIP = "10.5.0.1"
+
+	// decodedRecord builds a record carrying an interior zero-RTT entry, as
+	// StorableRead can produce. Generous capacity so Add compacts the slice in
+	// place instead of reallocating.
+	decodedRecord := func() []LatencyHistoryItem {
+		items := make([]LatencyHistoryItem, 0, 64)
+		for i := 0; i < 12; i++ {
+			rtt := time.Duration(20+i) * time.Millisecond
+			if i == 4 {
+				rtt = 0
+			}
+			items = append(items, LatencyHistoryItem{Timestamp: time.Now(), RTT: rtt})
+		}
+		return items
+	}
+
+	h := NewLatencyHistory()
+	h.GameServerLatencies[extIP] = decodedRecord()
+
+	stop := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Exactly what sortPingCandidatesByLatencyHistory does: read the
+			// returned entries after Get's lock has been released.
+			if history, ok := h.Get(extIP); ok {
+				for i := range history {
+					_ = history[i].RTT
+					_ = history[i].Timestamp
+				}
+			}
+		}
+	}()
+
+	for i := 0; i < 2000; i++ {
+		// Install a freshly decoded record (its own backing array, never touched
+		// by this goroutine again) so the next Add hits the in-place delete path.
+		// All in-place mutation of reader-visible memory is therefore done by
+		// production code, not by the test.
+		h.Lock()
+		h.GameServerLatencies[extIP] = decodedRecord()
+		h.Unlock()
+		h.Add(net.ParseIP(extIP), 30, 25, time.Time{})
+	}
+
+	close(stop)
+	<-readerDone
+}
+
+// TestLatencyHistory_JSONRoundTrip pins the wire format so that locking the
+// marshal/unmarshal path cannot silently change what is persisted. A regression
+// here would orphan every stored LatencyHistory record.
+func TestLatencyHistory_JSONRoundTrip(t *testing.T) {
+	ts := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	h := NewLatencyHistory()
+	h.GameServerLatencies = map[string][]LatencyHistoryItem{
+		"10.0.0.1": {{Timestamp: ts, RTT: 42 * time.Millisecond}},
+	}
+
+	data, err := json.Marshal(h)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("unmarshal into raw: %v", err)
+	}
+	if _, ok := raw["game_server_latencies"]; !ok {
+		t.Fatalf("marshalled form lost the game_server_latencies key: %s", data)
+	}
+	if len(raw) != 1 {
+		t.Fatalf("marshalled form has unexpected keys: %s", data)
+	}
+
+	got := NewLatencyHistory()
+	if err := json.Unmarshal(data, got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	items, ok := got.GameServerLatencies["10.0.0.1"]
+	if !ok || len(items) != 1 {
+		t.Fatalf("round trip lost entries: %#v", got.GameServerLatencies)
+	}
+	if !items[0].Timestamp.Equal(ts) || items[0].RTT != 42*time.Millisecond {
+		t.Fatalf("round trip corrupted entry: %#v", items[0])
+	}
+}
+
+// TestLatencyHistory_UnmarshalMergesIntoExisting pins the pre-existing
+// encoding/json map semantics that writeWithRetry's re-read relies on: keys
+// present only in the in-memory object survive the re-read, and keys present in
+// the stored object are adopted.
+func TestLatencyHistory_UnmarshalMergesIntoExisting(t *testing.T) {
+	local := NewLatencyHistory()
+	local.Add(net.ParseIP("10.0.0.2"), 99, 25, time.Time{})
+
+	stored := NewLatencyHistory()
+	stored.Add(net.ParseIP("10.0.0.1"), 42, 25, time.Time{})
+
+	if err := json.Unmarshal([]byte(stored.String()), local); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if _, ok := local.GameServerLatencies["10.0.0.1"]; !ok {
+		t.Errorf("stored key was not adopted: %#v", local.GameServerLatencies)
+	}
+	if _, ok := local.GameServerLatencies["10.0.0.2"]; !ok {
+		t.Errorf("local-only key was dropped: %#v", local.GameServerLatencies)
+	}
+}
+
+// TestLatencyHistory_UnmarshalIntoNilMap covers the fresh-object path used by
+// every StorableRead into a zero-valued LatencyHistory.
+func TestLatencyHistory_UnmarshalIntoNilMap(t *testing.T) {
+	h := &LatencyHistory{}
+	if err := json.Unmarshal([]byte(seedLatencyHistory(3).String()), h); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(h.GameServerLatencies) != 3 {
+		t.Fatalf("expected 3 entries, got %#v", h.GameServerLatencies)
+	}
+}
+
+// TestLatencyHistory_UnmarshalRejectsGarbage ensures a decode failure is still
+// reported (StorableRead depends on the error to trigger its corrupt-record
+// recovery path).
+func TestLatencyHistory_UnmarshalRejectsGarbage(t *testing.T) {
+	h := NewLatencyHistory()
+	if err := json.Unmarshal([]byte(`{"game_server_latencies":"not-a-map"}`), h); err == nil {
+		t.Fatal("expected an error unmarshalling a malformed record, got nil")
+	}
+}


### PR DESCRIPTION
Two data races that can kill the process, plus the storage-path locking contract around them. Base: `d3e7e5549`. Head: `536ea6f39`.

Both races were widened by recent work rather than being ancient: the latency-history one by the OCC re-read (`writeWithRetry`, `server/evr_latencyhistory.go:86 @ 536ea6f39`) decoding straight into the session-shared object, and the discordgo one by PR #514's orphan reconciliation wiring live gateway state into a deep reader.

## Summary

| # | Scenario | Class | Gated behind | Frequency |
|---|---|---|---|---|
| 1 | `StorableRead` decodes into the live, session-shared `*LatencyHistory` while lobby-find reads it → `fatal error: concurrent map read and map write` | FIX | nothing — always on | Unquantified. Requires an OCC conflict on a user's latency record concurrent with a lobby-find read. Two sessions for one user (headset + spectator, or a reconnect) is the trigger. |
| 2 | `StorableWrite` marshals the live `*LatencyHistory` while `Add` mutates it | FIX | nothing | Unquantified; same shape as #1, and reachable without any OCC conflict. |
| 3 | `Get` handed out the live slice; `sortPingCandidatesByLatencyHistory` read `history[len-1]` after the lock was released | FIX | nothing | Unquantified. `Add` compacts in place via `slices.Delete`. |
| 4 | `pruneGuildGroups` read `d.dg.State.Guilds` unlocked and passed LIVE `*discordgo.Guild` pointers to a deep reader | FIX | prune ticker (every 15 min, `evr_discord_integrator.go:180-189`) | Every prune cycle is a candidate; it races only when a gateway event lands in the same window. |
| 5 | `guildSync` read `d.dg.State.User.ID` unlocked, and nil-dereferenced it before the first READY | FIX | same prune ticker + orphan guilds present | Same window as #4. The nil deref is bounded to the pre-READY interval. |
| 6 | `String()` no longer takes its own read lock (`MarshalJSON` does) | NEUTRAL | nothing | Always. Required — the alternative deadlocks. |
| 7 | `UnmarshalJSON` on `{"game_server_latencies":null}` preserves the receiver's entries instead of nil'ing the map | NEUTRAL (safer) | nothing | Reachable: a nil-map history serializes to exactly that document. |
| 8 | `UnmarshalJSON` on a partially-malformed record contributes nothing instead of its salvageable keys | NEUTRAL (safer) | nothing | Only on a corrupt record; `StorableRead`'s corrupt-record path rewrites it either way. |

---

## Behavior changes

### 1. Latency-history re-read after an OCC conflict no longer races the lobby-find goroutine  [FIX]

**What was tried:** A player runs two sessions for the same Nakama user (headset plus a spectator client, or a reconnect before the old session drains) and both finish a ping cycle. Session A's `writeWithRetry` loses the version check, re-reads the stored record, and decodes it into the same `*LatencyHistory` that session B's lobby-find goroutine is reading.
**What they expected:** Both sessions' latency samples merge; matchmaking continues.
**What happened BEFORE this PR:** `StorableRead` → `json.Unmarshal` reflection-wrote the map with no lock held, while `AverageRTTs` / `LatestRTTs` / `HasRecentEntry` / `sortPingCandidatesByLatencyHistory` read it under `RLock`. Go's map guard reports that as `fatal error: concurrent map read and map write` — a runtime throw, not a recoverable panic, so the whole Nakama process dies and every connected player is dropped.
**Estimated frequency:** Unquantified. The window is one `json.Unmarshal` of a per-user record; it needs a same-user concurrent session and an OCC conflict. Not synthesizable from logs — see "How to verify" below.
**What happens AFTER this PR:** `UnmarshalJSON` (`server/evr_latencyhistory.go:189 @ 536ea6f39`) takes `h.Lock()`; `MarshalJSON` (`:139`) takes `h.RLock()`. The decode is serialized against every existing locked accessor.
**Log signature BEFORE:** none — silent until the process throws. The throw itself is not a Nakama log line; it is `fatal error: concurrent map read and map write` on stderr followed by a goroutine dump.
**Log signature AFTER:** none.
**How to verify in production logs:** `grep -n 'concurrent map read and map write' /home/echovrce/deployment/logs/nakama.log` — this must return nothing after the deploy. Also `grep -c 'failed to load latency history' /home/echovrce/deployment/logs/nakama.log` (`server/evr_pipeline_login.go:723`) should be unchanged; this PR does not alter that path's error rate.
**Citation:** `TestLatencyHistory_StorableRead_UnmarshalIsLocked` (`server/evr_latencyhistory_race_test.go:88`). Reverting `server/evr_latencyhistory.go` to `d3e7e5549` via `go test -overlay` reproduces the production stack:
```
WARNING: DATA RACE
Write at 0x00c000784960 by goroutine 50:
  reflect.Value.SetMapIndex() ... encoding/json.(*decodeState).object()
  server.StorableRead()   server/evr_storable.go:86
  server.(*LatencyHistory).writeWithRetry()   server/evr_latencyhistory.go:100
```

### 2. Marshalling the history for storage no longer races `Add`  [FIX]

**What was tried:** A player's ping results arrive (`lobbyPingResponse` → `Add`) while the matchmaker goroutine persists the same history (`writeWithRetry` → `StorableWrite` → `json.Marshal`, `server/evr_pipeline_matchmaker.go:181`).
**What they expected:** The sample is recorded and the record is written.
**What happened BEFORE this PR:** `json.Marshal` reflection-walked the live map with no lock held while `Add` (which does hold the write lock) mutated it. Same `fatal error` class as #1, and this one needs no OCC conflict at all.
**Estimated frequency:** Unquantified. Reachable on any session that pings and matchmakes concurrently.
**What happens AFTER this PR:** `MarshalJSON` holds `h.RLock()` for the encode.
**Log signature BEFORE:** none — silent.
**Log signature AFTER:** none.
**How to verify in production logs:** same grep as #1.
**Citation:** `TestLatencyHistory_StorableWrite_MarshalIsLocked` (`server/evr_latencyhistory_race_test.go:164`) — FAILs under `-race` against the base file, with the race pinned at `Add`'s `slices.Delete` line versus the marshal.

### 3. `Get` returns a clone, so the ping-candidate sort cannot read a slice `Add` is compacting  [FIX]

**What was tried:** `sortPingCandidatesByLatencyHistory` (lobby-find goroutine) calls `latencyHistory.Get(hostIP)` and then reads `history[len(history)-1]` (`server/evr_latencyhistory.go:488-490 @ 536ea6f39`) with no lock held.
**What they expected:** Candidates sorted by last-seen RTT.
**What happened BEFORE this PR:** `Get` returned the stored slice header. `Add` compacts that same backing array in place via `slices.Delete` (`server/evr_latencyhistory.go:250 @ 536ea6f39`) and appends into spare capacity, so the reader could observe a shifted/zeroed element — a silently wrong sort order, or a torn `LatencyHistoryItem`.
**Estimated frequency:** Unquantified.
**What happens AFTER this PR:** `Get` returns `slices.Clone(history)` (`server/evr_latencyhistory.go:463 @ 536ea6f39`).
**Log signature BEFORE:** none — silent; a wrong sort order is invisible.
**Log signature AFTER:** none.
**How to verify in production logs:** not observable in logs. Behavioural check only: ping-candidate ordering is unchanged for a quiescent history — `TestLatencyHistorySortOrder` and `TestLatencyHistorySort_UncachedFirst` (pre-existing, unmodified) still pass.
**Citation:** `TestLatencyHistory_Get_DoesNotEscapeLiveSlice` (`server/evr_latencyhistory_race_test.go:248`) — FAILs under `-race` without the clone.

### 4. Guild pruning snapshots discordgo state under its read lock  [FIX]

**What was tried:** The prune ticker fires (`server/evr_discord_integrator.go:180`, `pruneTicker.Reset(time.Minute * 15)` at `:183`) while the bot is receiving gateway traffic — a Guild Create, a channel rename, a channel delete.
**What they expected:** Orphaned guild groups are reconciled or pruned.
**What happened BEFORE this PR:** `pruneGuildGroups` read `d.dg.State.Guilds` with no lock and handed the LIVE `*discordgo.Guild` pointers to deep readers: `guildSync` ranges `guild.Channels` looking for `#rules`, and the prune-leave path logs `"guild_metadata": guild` (`server/evr_discord_integrator_pruning.go:218 @ 3ab7a49c5`), which zap reflect-walks the whole struct. discordgo mutates that memory from the gateway goroutine under `State.Lock()`: `GuildAdd` appends to `State.Guilds` (`state.go:146 @ discordgo v0.29.0`) and overwrites an existing `*Guild` in place (`*g = *guild`, `:142`); `ChannelAdd` overwrites a `*Channel` in place (`:502`) and appends to `guild.Channels` (`:520`); `ChannelRemove` (`:529`) compacts it. In production that surfaces as a torn slice header (index out of range) or a read of an already-removed channel, on the integrator goroutine.
**Estimated frequency:** Unquantified. Every 15-minute prune cycle is a candidate; it only races when a gateway event lands in the same window. Widened by PR #514 — before it, `guildSync` only ever received the event-owned `e.Guild` from a Guild Create/Update, which is fresh and unshared.
**What happens AFTER this PR:** `snapshotStateGuilds` (`server/evr_discord_integrator_pruning.go:64 @ 3ab7a49c5`) takes `state.RLock()` (`:69`) and deep-copies each guild plus its channels; the prune path works on the copies (`:166`). Every reference-typed field is either deep-copied or explicitly cleared.
**Log signature BEFORE:** none — silent, then a panic/goroutine dump. Existing prune log lines are unchanged.
**Log signature AFTER:** none.
**How to verify in production logs:** `grep -n 'index out of range\|Error pruning guild groups' /home/echovrce/deployment/logs/nakama.log`. The `Error pruning guild groups` line (`server/evr_discord_integrator.go:190`) is pre-existing and its message string is unchanged; a *drop* in its rate is the expected signal. `grep -c 'No guilds found in Discord state' …` (`server/evr_discord_integrator_pruning.go:168`) must be unchanged — the condition now tests the snapshot length rather than the live length, which is the same number.
**Citation:** `TestSnapshotStateGuilds_SafeAgainstGatewayChannelMutation` and `_SafeAgainstGatewayGuildMutation` (`server/evr_discord_integrator_state_race_test.go`); `TestPruneGuildGroups_SafeAgainstGatewayMutation` (`server/evr_discord_integrator_prune_wiring_test.go:219`) drives the real `pruneGuildGroups`. Reverting only `state.RLock()` while keeping the deep copy still fails both `_SafeAgainst*` tests with 17 races — the lock is load-bearing independently of the copy.

### 5. The bot's own Discord ID is read under the state lock, and no longer nil-dereferences before READY  [FIX]

**What was tried:** Same prune cycle as #4, with at least one orphan guild, so `reconcileOrphanGuilds` → `guildSync` runs. Concurrently the gateway reconnects and re-sends READY.
**What they expected:** The orphan guild is reconciled into a Nakama group.
**What happened BEFORE this PR:** `guildSync`'s first statement was `d.DiscordIDToUserID(d.dg.State.User.ID)`. `discordgo.State` embeds `Ready` (`state.go:36-38 @ v0.29.0`), so `State.User` IS `Ready.User`, and `onReady` (`:911`) takes `State.Lock()` (`:916`) and assigns `s.Ready = *r` (`:935`) — rewriting the `User` pointer word itself, not just the pointee. The prune-ticker read was unsynchronized. Separately, before the first READY `State.User` is nil and the expression panicked on the integrator goroutine.
**Estimated frequency:** Unquantified for the race (same window as #4). The nil deref is bounded to the interval between integrator start and the first READY.
**What happens AFTER this PR:** `botDiscordIDFromState` (`server/evr_discord_state_access.go:28 @ 3ab7a49c5`) takes `state.RLock()`, returns `""` for a nil state or nil `State.User`, and releases the lock before the caller's `DiscordIDToUserID` lookup — so the discordgo state lock is never held across a database call. `guildSync` (`server/evr_discord_integrator.go:554`) then hits its pre-existing `""` guard.
**Log signature BEFORE:** none for the race. For the nil deref: a Go panic + goroutine dump, no Nakama log line.
**Log signature AFTER:** `Error pruning guild groups` (`server/evr_discord_integrator.go:190`, level `error`, message string UNCHANGED) wrapping the pre-existing `failed to get bot user ID from state` (`server/evr_discord_integrator.go:556`). This error string already existed and is not new; what is new is that the pre-READY case now reaches it instead of panicking. **Operators: a burst of `failed to get bot user ID from state` right after a restart is the nil-READY case degrading gracefully, not a new fault.** It is self-clearing on the next prune cycle after READY.
**How to verify in production logs:** `grep -n 'failed to get bot user ID from state' /home/echovrce/deployment/logs/nakama.log` — expect zero or a short burst confined to the first minutes after a restart.
**Citation:** `TestBotDiscordIDFromState` and `TestBotDiscordIDFromState_ConcurrentWithReady` (`server/evr_discord_integrator_prune_wiring_test.go:287`, `:308`). RED reproduction — reverting only that one call site via `go test -overlay`:
```
WARNING: DATA RACE
  server.(*DiscordIntegrator).guildSync()
      server/evr_discord_integrator.go:554
      server/evr_discord_integrator_pruning.go:200
      server/evr_discord_integrator_pruning.go:35
      server/evr_discord_integrator_pruning.go:199
--- FAIL: TestPruneGuildGroups_SafeAgainstGatewayMutation (0.07s)
```

### 6. `String()` no longer takes its own read lock  [NEUTRAL]

**What was tried:** Anything that logs or debug-prints a `*LatencyHistory`.
**What they expected:** The JSON form.
**What happened BEFORE this PR:** `String()` marshalled without any lock (there was no `MarshalJSON`).
**Estimated frequency:** Always, wherever `String()` is called.
**What happens AFTER this PR:** `String()` still calls `json.Marshal(h)`, which now dispatches to the locking `MarshalJSON`. Taking `RLock` in `String()` as well would be a recursive read lock, which Go's `RWMutex` deadlocks when a writer is queued between the two acquisitions. Output is byte-identical.
**Log signature BEFORE / AFTER:** none — no production log statement was added, removed, or reworded.
**How to verify in production logs:** not applicable; output format unchanged.
**Citation:** `TestLatencyHistory_String_ConcurrentWithAdd` (`server/evr_latencyhistory_race_test.go:197`) has a 30-second deadlock guard. Re-adding `h.RLock()` to `String()` produces:
```
--- FAIL: TestLatencyHistory_String_ConcurrentWithAdd (30.00s)
    evr_latencyhistory_race_test.go:231: String() deadlocked (recursive read lock?)
```
`TestLatencyHistory_JSONRoundTrip` (`:308`) pins the wire format.

### 7. A stored `{"game_server_latencies":null}` no longer wipes the in-memory history  [NEUTRAL — strictly safer]

**What was tried:** A session's `writeWithRetry` loses a version check against a record written by a `&LatencyHistory{}` with a nil map (constructed at `server/evr_pipeline_login.go:720`, `server/evr_runtime_rpc.go:1950`, `server/evr_runtime_rpc_match.go:168`), then re-reads it.
**What they expected:** Its pending samples survive the merge.
**What happened BEFORE this PR:** reflection-decoding a JSON `null` for a map field set the field to `nil`, discarding whatever the receiver held. Empirically confirmed against `encoding/json`:
```
doc={"game_server_latencies":null}   OLD map=map[] nil=true  | NEW map=map[a:[{1}]] nil=false
doc=null                             OLD map=map[a:[{1}]]    | NEW map=map[a:[{1}]]
doc={}                               OLD map=map[a:[{1}]]    | NEW map=map[a:[{1}]]
```
**Estimated frequency:** Unquantified, but the document is genuinely stored — `(&LatencyHistory{}).String()` is exactly `{"game_server_latencies":null}`, asserted in the test.
**What happens AFTER this PR:** the merge preserves the receiver's keys. `Add` re-created a nil map anyway, so the only delta is that the caller's not-yet-persisted samples are no longer dropped.
**Log signature BEFORE / AFTER:** none.
**How to verify in production logs:** not observable.
**Citation:** `TestLatencyHistory_UnmarshalNullMapPreservesExisting` (`server/evr_latencyhistory_race_test.go:376`). It FAILs against `git show d3e7e5549:server/evr_latencyhistory.go` under `-overlay`:
```
--- FAIL: TestLatencyHistory_UnmarshalNullMapPreservesExisting (0.00s)
    evr_latencyhistory_race_test.go:389: null map nil'd the receiver's map; pending samples would be lost on the OCC re-read
```

### 8. Decoding a partially-malformed record is now all-or-nothing  [NEUTRAL — strictly safer]

**What was tried:** `StorableRead` hits a stored latency record whose map holds one malformed value.
**What they expected:** An error.
**What happened BEFORE this PR:** the reflection decode returned an error *and* left the keys it had already parsed in the receiver.
**Estimated frequency:** Only on a corrupt record; unquantified.
**What happens AFTER this PR:** the decode happens into a scratch `latencyHistoryData` before the lock is taken, so a failure contributes nothing. Both versions return the same error and `StorableRead`'s corrupt-record path deletes and recreates the record from the in-memory object either way — the only delta is that partially-salvaged keys are no longer folded into that rewrite. Atomicity is the point: a half-applied decode leaves the session-shared object in a state no stored record ever had.
**Log signature BEFORE / AFTER:** none — `StorableRead`'s existing corrupt-record logging is untouched.
**How to verify in production logs:** not observable.
**Citation:** `TestLatencyHistory_UnmarshalErrorLeavesReceiverUntouched` (`server/evr_latencyhistory_race_test.go:427`); `TestLatencyHistory_UnmarshalRejectsGarbage` (`:411`) pins that the error is still returned, which `StorableRead`'s recovery path depends on.

---

## Production log impact

No production log message string, level, or emission frequency changed. Verified mechanically:

```
$ git diff d3e7e5549...HEAD -- server/evr_latencyhistory.go server/evr_discord_integrator_pruning.go \
    server/evr_discord_integrator.go server/evr_discord_state_access.go \
  | grep -E '^[+-]' | grep -vE '^[+-][+-]' \
  | grep -E 'logger\.|\.Info\(|\.Warn\(|\.Error\(|\.Debug\(|LogServiceAuditMessage'
none
```

The one nuance worth an operator's attention is in change #5: `failed to get bot user ID from state` (`server/evr_discord_integrator.go:556`) is a **pre-existing** message that a pre-READY prune cycle now reaches instead of panicking. Its volume can rise from zero to a short post-restart burst. That is the fix working, not a fault.

## What does NOT change

- **Matchmaking.** Nothing in the diff goes near it. `git diff d3e7e5549...HEAD | grep -E 'uuid\.Nil|GroupID'` → no matches. The cross-guild invariant is untouched.
- **The stored wire format.** `latencyHistoryData` mirrors the single exported field with the same `json:"game_server_latencies"` tag; `TestLatencyHistory_JSONRoundTrip` pins it. Records written by this build are readable by the old one and vice versa.
- **Ping-candidate ordering.** `Get` returns a clone with identical contents. Pre-existing `TestLatencyHistorySortOrder` / `TestLatencyHistorySort_UncachedFirst` still pass unmodified.
- **Which guilds get pruned or left.** `snapshotStateGuilds` preserves every scalar the prune path and `guildSync` read (ID, Name, OwnerID, Description, Icon) and deep-copies `Channels` including `Type`/`Name`/`Topic`. `TestSnapshotStateGuilds_Contents` and `TestPruneGuildGroups_UsesSnapshotNotLiveState` assert it. The `len(...) == 0` early-return now measures the snapshot, which has the same length as the live slice minus nil entries.
- **`Add` semantics.** Limit, zero-RTT removal, and expiry logic are byte-identical to `d3e7e5549`.
- **Lock ordering.** The discordgo `State` read lock is never held across a database or network call: `snapshotStateGuilds` releases it before returning, and `botDiscordIDFromState` releases it before `DiscordIDToUserID`.

## Findings the review raised that are NOT real

- **`sync.Mutex` copied by value at `server/evr_match.go:1063` / `:1532`.** Not real; no change made. `NewEarlyQuitPlayerState()` returns `*EarlyQuitPlayerState` (`server/evr_earlyquit.go:187-191`) and both `logger.WithFields({"eqconfig": eqconfig})` sites hold that pointer. `zap.Any` boxes the pointer — no struct copy, no lock copy. `GOWORK=off go vet ./server/...` exits 0 with no output.
- **Unlocked field access in `resolveAndApplyPenaltyLockout` (`server/evr_earlyquit.go:141-151`).** Real but **not** fixed here, deliberately. It reads `NumEarlyQuits` and writes `PenaltyLevel`/`PenaltyTimestamp` unlocked while `StorageMeta` (`:193`) and every sibling accessor lock. All three call sites (`server/evr_match.go:1041`, `:1414`, `server/evr_earlyquit.go:549`) operate on a locally-constructed config published via `params.earlyQuitConfig.Store(eqconfig)` only *after* the `StorableWrite`, so there is no race today. It is not trivially fixable — the lock cannot be held across `LoadEarlyQuitServiceConfig`, which does a storage read. Owned by `fix/earlyquit-penalty-state`.

## Merge coordination — read this before merging

`fix/discord-prune-safety` (#532) touches the same two files and **conflicts in both**:

1. `server/evr_discord_integrator_pruning.go` — #532 rewrites `pruneGuildGroups` (+380 lines to that file) and still reads `d.dg.State.Guilds` **unlocked, twice** (its `:360` and `:365`, `if len(d.dg.State.Guilds) == 0` and the `computePrunePlan` argument). Whichever branch merges second, a conflict resolved by "take theirs" silently reverts change #4. **The merge resolution must route #532's `computePrunePlan` input through `snapshotStateGuilds` and test the snapshot's length, not the live slice's.**
2. `server/evr_discord_integrator.go` — #532 inserts an unavailable-guild-stub guard immediately above the `botUserID := …` line this PR changes (its hunk `@@ -550,6 +631,15 @@`). Both edits belong; the resolution is to keep #532's new guard *and* this PR's `botDiscordIDFromState(d.dg.State)` call.

`TestPruneGuildGroups_UsesSnapshotNotLiveState` is deliberately deterministic (no `-race` needed) precisely so a bad merge resolution fails CI: `just test` (`justfile:70-71`) runs `go test ./server/... -count=1` without `-race`.

Other concurrent Tier-1 branches, none of which touch these files: `fix/earlyquit-penalty-state`, `fix/storage-occ-retry` (#529), `fix/security-join-gates` (#531), `fix/match-lifecycle` (#534), `fix/assorted-one-offs` (#530).

## Known follow-ups (not fixed here)

- **`copyStateGuild` cost.** It copies every `discordgo.Channel` by value under `State.RLock()`. At ~1000 guilds × ~50 channels that is ~50k struct copies per prune cycle, blocking gateway state *writes* for the duration. Every 15 minutes, so almost certainly fine — but the pre-fix read was non-blocking, and this is the one respect in which the fix costs something. A narrow projection struct (`{ID, Name, OwnerID, Description, Icon, rulesChannel}`) instead of `*discordgo.Guild` would cut it and remove the clear-every-field discipline entirely.
- **The snapshot yields empty `Members`/`Roles`/`Presences` with no guard.** A future caller reading `len(guild.Members)` gets `0`, not an error, and `MemberCount` (a scalar) is preserved, which makes the inconsistency easy to trip over. `TestSnapshotStateGuilds_NoFieldAliasesLiveState` enforces *non-aliasing* but cannot enforce *don't read this*.
- **`TestStatisticsGroup_MarshalText/Daily_Arena` fails on `./server/evr/`** — **not** a hardcoded date, as an earlier revision of this section claimed. It is a local-vs-UTC mismatch: the production `MarshalText` formats `time.Now().UTC()` (`server/evr/core_account_statistics.go:47`), while the test builds its expectation from local `time.Now()` (`server/evr/core_account_statistics_test.go:24`); line `:62` is only where the assertion reports it. The test therefore fails every day in the window between UTC midnight and local midnight — five hours a day on a CDT host. **Pre-existing at `d3e7e5549`**, reproduced on a clean baseline checkout:

```
=== BASE d3e7e5549: TestStatisticsGroup_MarshalText ===
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05

$ TZ=UTC go test ./server/evr/ -run TestStatisticsGroup_MarshalText   # same base checkout
ok  	github.com/heroiclabs/nakama/v3/server/evr	0.006s
```

Not touched by this PR, out of scope. The fix is to make the test use `time.Now().UTC()`.

---

## Review round 2 — Copilot on `3ab7a49c5`

**`evr_latencyhistory.go:190` — VALID, fixed in `536ea6f39`.**

`UnmarshalJSON` allocated an empty map whenever the receiver's was nil, including when the
decoded document carried a null or absent map. Verified against stock `encoding/json` (decoding
into `latencyHistoryData`, which is the exact struct the reflection decode operated on), and
the round-trip consequence reproduces:

```
--- FAIL: TestLatencyHistory_UnmarshalNullMapIntoNilReceiverStaysNil
    decoding {"game_server_latencies":null} into a nil-map receiver produced a non-nil map
    (map[string][]server.LatencyHistoryItem{}); stock encoding/json leaves it nil
--- FAIL: TestLatencyHistory_UnmarshalAbsentMapIntoNilReceiverStaysNil
    decoding {} into a nil-map receiver produced a non-nil map ...
--- FAIL: TestLatencyHistory_NullMapRecordRoundTrips
    a stored null-map record round-tripped to {"game_server_latencies":{}}, want
    {"game_server_latencies":null}
```

Whether the map is nil is *persisted* state, not an implementation detail: a nil map marshals
to `null`, an allocated empty one to `{}`. So a `StorableRead` -> `StorableWrite` round trip
rewrote a stored `null` record in which not one sample had changed. `UnmarshalJSON` now returns
early on a nil decoded map, before allocating and before the lock — a no-op needs neither, and
the decode-error path above already returns unlocked.

The guard on the other side is `TestLatencyHistory_UnmarshalEmptyObjectMapStillAllocates`: an
explicit `{"game_server_latencies":{}}` is not null and must still allocate. Perturbing the fix
to the over-broad `len(decoded.GameServerLatencies) == 0` fails it:

```
--- FAIL: TestLatencyHistory_UnmarshalEmptyObjectMapStillAllocates
    an empty-object record round-tripped to {"game_server_latencies":null}, want
    {"game_server_latencies":{}}
```

The doc comment claimed the sole divergence from `encoding/json` was preserving receiver
entries on null; the allocation was a second, undocumented one. Corrected to state that
nil-ness is preserved too, with the reasoning and pinning tests named.

### Composition with #529 (`fix/storage-occ-retry`)

Both branches touch `server/evr_latencyhistory.go` and **they compose — no conflict.**
`git merge-tree --write-tree` succeeds in either order and yields the identical tree
(`1605723f9`), which builds and passes the latency suite. The hunks are disjoint by function:
#529 rewrites `writeWithRetry` (base `:62-121`), this PR adds `MarshalJSON`/`UnmarshalJSON` and
touches `Get`.

They are also complementary rather than redundant on the locking: #529's re-read decodes into a
*fresh* object and then swaps `h`'s map header under its own `h.Lock()`, so this PR's decode
lock does not cover that adoption — #529's explicit lock is what does.

**One residual finding for #529, evidenced in the merged tree.** #529 does
`fresh := NewLatencyHistory()`, which pre-allocates the map, so this PR's early return leaves it
non-nil. Adopting a stored null record on an OCC conflict therefore still rewrites the shape:

```
fresh map nil=false ; adopted h marshals to {"game_server_latencies":{}}
```

Not a regression (the pre-fix merge behaved the same) and not fixable from this branch, but
`fresh := &LatencyHistory{}` in #529 would close it. Raised on #529; not edited from here.

**Suggested order: this PR (#536) first.** #529's new `writeWithRetry` comment reasons
explicitly about `encoding/json`'s map-merge semantics, which after #536 is a claim about
*this PR's explicit `UnmarshalJSON`* rather than about reflection — landing #536 first lets that
rationale be checked against the code it actually describes, and makes the `NewLatencyHistory()`
nit above visible.

### Re-verification at `536ea6f39`

```
$ GOWORK=off go build ./server/...   → BUILD_OK
$ GOWORK=off go vet ./server/...     → VET_OK
$ GOWORK=off go test ./server/... -count=1
ok  	github.com/heroiclabs/nakama/v3/server	125.897s
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena     (the same pre-existing failure documented below)
$ GOWORK=off go test -race ./server/ -run 'Match|Latency|Tick|Lifecycle' -count=1
ok  	github.com/heroiclabs/nakama/v3/server	95.898s
$ gofmt -l server/evr_latencyhistory.go server/evr_latencyhistory_nullmap_test.go
(no output)
```

---

## Verification

All commands run `GOWORK=off`. Full-suite and race runs were done in a **pristine detached worktree at `3ab7a49c5`** (`git status --porcelain` empty).

```
$ go build ./server/...   → BUILD_OK
$ go vet ./server/...     → VET_OK (exit 0, no output)
$ gofmt -l <all 7 touched files>  → no output
```

Full suite at `3ab7a49c5`:
```
ok  	github.com/heroiclabs/nakama/v3/server	128.607s
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena     (pre-existing, see follow-ups)
FAIL	github.com/heroiclabs/nakama/v3/server/evr	0.015s
```
Same failure on a clean baseline worktree at `d3e7e5549`:
```
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena (0.00s)
    core_account_statistics_test.go:62: MarshalText() got = daily_2026_08_06, expected daily_2026_08_05
```
No new failures.

Full suite with `-race` at `3ab7a49c5`:
```
ok  	github.com/heroiclabs/nakama/v3/server	145.388s
--- FAIL: TestStatisticsGroup_MarshalText/Daily_Arena     (same pre-existing failure)
```
No `WARNING: DATA RACE` anywhere in the run.

Targeted `-race`, three consecutive runs:
```
$ go test -race ./server/ -run 'TestLatencyHistory|TestSnapshotStateGuilds|TestPruneGuildGroups|TestBotDiscordIDFromState' -count=1
ok  	github.com/heroiclabs/nakama/v3/server	4.681s
ok  	github.com/heroiclabs/nakama/v3/server	4.634s
ok  	github.com/heroiclabs/nakama/v3/server	4.816s
```

Every load-bearing test was RED-proven by reverting only the production code under test via `go test -overlay` (the worktree itself was never modified). Per-test pre-fix results, isolated `-race` runs:

| test | pre-fix |
|---|---|
| `TestLatencyHistory_StorableRead_UnmarshalIsLocked` | FAIL — the production `writeWithRetry` → `StorableRead` stack |
| `TestLatencyHistory_StorableWrite_MarshalIsLocked` | FAIL |
| `TestLatencyHistory_StorageMeta_IsLocked` | FAIL |
| `TestLatencyHistory_Get_DoesNotEscapeLiveSlice` | FAIL |
| `TestLatencyHistory_UnmarshalNullMapPreservesExisting` | FAIL |
| `TestSnapshotStateGuilds_*` (base semantics: no lock, live slice) | 6 of 9 FAIL, 15 races |
| `TestSnapshotStateGuilds_SafeAgainst*` (deep copy kept, **only** `state.RLock()` removed) | FAIL, 17 races |
| `TestSnapshotStateGuilds_DropsUncopiedLiveCollections` (pointer clears removed) | FAIL on `LastPinTimestamp` and `DefaultSortOrder` |
| `TestPruneGuildGroups_SafeAgainstGatewayMutation` (bot-ID read reverted) | FAIL, DATA RACE at `evr_discord_integrator.go:554` |
| `TestPruneGuildGroups_UsesSnapshotNotLiveState` (prune read site reverted) | FAIL, panic at `evr_discord_integrator_pruning.go:174` (`botGuildMap[g.ID] = g`, the nil-guild entry), **no `-race` needed** |
| `TestLatencyHistory_String_ConcurrentWithAdd` (with `RLock` re-added to `String()`) | FAIL after 30s — deadlock guard |

Structural claims re-verified directly against `discordgo@v0.29.0/state.go` in the module cache: `State` embeds `sync.RWMutex` + `Ready` (`:36-38`); `GuildAdd` `:89`, `s.Lock()` `:94`, `*g = *guild` `:142`, `s.Guilds = append` `:146`; `ChannelAdd` `:482`, `*c = *channel` `:502`, `guild.Channels = append` `:520`; `ChannelRemove` `:529`; `onReady` `:911`, `s.Lock()` `:916`, `s.Ready = *r` `:935`. `go doc discordgo.Guild` lists exactly ten reference-typed fields and `go doc discordgo.Channel` exactly ten — all twenty are copied or cleared, and `TestSnapshotStateGuilds_NoFieldAliasesLiveState` enforces that reflectively so a discordgo upgrade that adds a field fails here rather than silently aliasing.

## Scope

4 source files (2 modified, 1 one-line call-site change, 1 new 38-line file) and 3 test files. No drive-by fixes; no changes outside the assigned findings and the review's follow-ups on them.


