### PR TITLE
fix(discord): read the guild count under the state lock

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -170,7 +170,7 @@ func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.Nak
 			logger.WithField("error", err).Error("Failed to register slash commands")
 		}
 
-		logger.WithFields(map[string]interface{}{"display_name": displayName, "guild_count": len(dg.State.Guilds)}).Info("Bot ready")
+		logger.WithFields(map[string]interface{}{"display_name": displayName, "guild_count": stateGuildCount(dg.State)}).Info("Bot ready")
 	})
 
 	dg.AddHandler(func(s *discordgo.Session, m *discordgo.RateLimit) {
@@ -4128,7 +4128,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 	d.logger.Info("Registering slash commands.")
 	// Register global guild commands
 	d.updateSlashCommands(dg, d.logger, "")
-	d.logger.WithFields(map[string]interface{}{"command_count": len(mainSlashCommands), "guild_count": len(dg.State.Guilds)}).Info("Slash commands registered/updated")
+	d.logger.WithFields(map[string]interface{}{"command_count": len(mainSlashCommands), "guild_count": stateGuildCount(dg.State)}).Info("Slash commands registered/updated")
 
 	return nil
 }

--- a/server/evr_discord_appbot_guildcount_race_test.go
+++ b/server/evr_discord_appbot_guildcount_race_test.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// The `guild_count` reads in evr_discord_appbot.go (the Ready handler's "Bot
+// ready" line, and RegisterSlashCommands' "Slash commands registered/updated"
+// line) took len(dg.State.Guilds) with no lock held.
+//
+// discordgo mutates State from the gateway goroutine under State.Lock():
+// GuildAdd (state.go:89-95 @ v0.29.0) appends to State.Guilds (:146). Both
+// reads run on a handler goroutine instead — discordgo dispatches handlers with
+// `go eh.eventHandler.Handle(s, i)` unless Session.SyncEvents is set
+// (event.go:171, :180), and this repo never sets it. For a bot over the
+// large-guild threshold the gateway delivers GUILD_CREATE for every guild AFTER
+// READY, so the reader and the appender overlap during ordinary startup.
+//
+// This test fails under -race if stateGuildCount is ever changed back to an
+// unlocked len(state.Guilds). It says nothing useful without -race: a data race
+// is not an assertion failure, and the count it returns is allowed to be any
+// value the gateway has produced so far.
+
+// TestStateGuildCount_SafeAgainstGatewayGuildAdd runs the accessor against a
+// gateway goroutine that is appending to State.Guilds the whole time.
+func TestStateGuildCount_SafeAgainstGatewayGuildAdd(t *testing.T) {
+	state := discordgo.NewState()
+
+	stop := make(chan struct{})
+	gatewayDone := make(chan struct{})
+	// started is closed after the gateway's first append. Without this barrier
+	// the reader loop can run to completion before the writer goroutine is ever
+	// scheduled, and -race reports nothing because the two accesses never
+	// overlap — a green run that proves nothing. Measured: an earlier version of
+	// this test passed under -race against a deliberately UNLOCKED accessor.
+	started := make(chan struct{})
+
+	go func() {
+		defer close(gatewayDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// A fresh ID appends to State.Guilds; a repeat ID overwrites an
+			// existing *Guild in place. Both happen during a GUILD_CREATE burst.
+			id := fmt.Sprintf("guild-%d", i%64)
+			_ = state.GuildAdd(&discordgo.Guild{ID: id, Name: id, OwnerID: "owner"})
+			if i == 0 {
+				close(started)
+			}
+		}
+	}()
+
+	<-started
+	for i := 0; i < 200000; i++ {
+		// The value is deliberately unchecked: any count the gateway has
+		// reached is legitimate. What is under test is that reading it does not
+		// race the append.
+		_ = stateGuildCount(state)
+	}
+
+	close(stop)
+	<-gatewayDone
+}
+
+// TestStateGuildCount_NilAndEmpty pins the degenerate cases, so the accessor can
+// be called before the first READY without the caller guarding it.
+func TestStateGuildCount_NilAndEmpty(t *testing.T) {
+	if got := stateGuildCount(nil); got != 0 {
+		t.Errorf("nil state: got %d, want 0", got)
+	}
+	if got := stateGuildCount(discordgo.NewState()); got != 0 {
+		t.Errorf("empty state: got %d, want 0", got)
+	}
+}
+
+// TestStateGuildCount_CountsGuilds pins that the lock did not cost correctness.
+func TestStateGuildCount_CountsGuilds(t *testing.T) {
+	state := discordgo.NewState()
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("guild-%d", i)
+		if err := state.GuildAdd(&discordgo.Guild{ID: id, Name: id, OwnerID: "owner"}); err != nil {
+			t.Fatalf("GuildAdd: %v", err)
+		}
+	}
+	if got := stateGuildCount(state); got != 5 {
+		t.Errorf("got %d, want 5", got)
+	}
+}

--- a/server/evr_discord_state_access.go
+++ b/server/evr_discord_state_access.go
@@ -36,3 +36,31 @@ func botDiscordIDFromState(state *discordgo.State) string {
 	}
 	return state.User.ID
 }
+
+// stateGuildCount returns the number of guilds the bot is in, read under the
+// discordgo state's read lock.
+//
+// The count is only ever logged, so the stakes look low — but the read is a
+// plain data race and the writer is the busiest one discordgo has. GuildAdd
+// takes State.Lock() and APPENDS to State.Guilds (state.go:89-95, :146 @
+// v0.29.0), and for a bot over the large-guild threshold the gateway delivers
+// GUILD_CREATE for every guild AFTER READY. So the window is not an exotic
+// interleaving; it is startup.
+//
+// Both callers run on a handler goroutine rather than the gateway goroutine:
+// discordgo dispatches handlers with `go eh.eventHandler.Handle(s, i)` unless
+// Session.SyncEvents is set (event.go:171, :180 @ v0.29.0), and this repo never
+// sets it.
+//
+// An unlocked len() of a slice being appended to reads a torn slice header. On
+// amd64 the realistic outcome is a wrong number in one log line rather than a
+// crash, which is precisely why it survived: nothing downstream notices, and
+// -race is the only thing that ever complains.
+func stateGuildCount(state *discordgo.State) int {
+	if state == nil {
+		return 0
+	}
+	state.RLock()
+	defer state.RUnlock()
+	return len(state.Guilds)
+}


### PR DESCRIPTION
Closes #537.

Both `guild_count` log fields in `evr_discord_appbot.go` read `len(dg.State.Guilds)` with no lock held — `:173` ("Bot ready") and `:4131` ("Slash commands registered/updated"). Routed through a new `stateGuildCount`, alongside #536's `botDiscordIDFromState` in the same file.

## Mechanism

discordgo mutates `State` from the gateway goroutine under `State.Lock()`: `GuildAdd` (`state.go:89-95` @ v0.29.0) appends to `State.Guilds` (`:146`). Both reads run on a **handler** goroutine — discordgo dispatches with `go eh.eventHandler.Handle(s, i)` unless `Session.SyncEvents` is set (`event.go:171,:180`), and this repo never sets it. For a bot over the large-guild threshold, `GUILD_CREATE` arrives for every guild *after* READY, so reader and appender overlap during ordinary startup.

## Witness: `-race`, not a passing test

Against a deliberately unlocked accessor:

```
WARNING: DATA RACE
Read at 0x00c00029f4e8 by goroutine 50:
  server.stateGuildCount()
      server/evr_discord_state_access.go:63
  server.TestStateGuildCount_SafeAgainstGatewayGuildAdd()
      server/evr_discord_appbot_guildcount_race_test.go:64

Previous write at 0x00c00029f4e8 by goroutine 51:
  discordgo.(*State).GuildAdd()
      discordgo@v0.29.0/state.go:146
```

With the lock restored: `ok github.com/heroiclabs/nakama/v3/server 1.464s`. Full DB-free suite green (`SUITE_EXIT=0`, 127.9s).

The test goes red again if `stateGuildCount` is ever changed back to an unlocked read.

## One thing worth flagging to reviewers

The `started` barrier in the test is load-bearing, and I only have it because the first version **passed under `-race` against the unlocked accessor**. The reader loop finished before the writer goroutine was scheduled, so the accesses never overlapped and the detector had nothing to report — a concurrency test that never achieves concurrency, i.e. a green light wired to nothing. The barrier makes the reader wait for the gateway's first append.

## Impact, stated honestly

On amd64 a torn slice-header read yields a wrong number in one log line, not a crash. Nothing downstream notices — which is exactly why it survived. `-race` is the only thing that ever complains.

## Scope

This is unit 1 of 3 for the unlocked-`State` class, decomposed **by accessor** rather than by area. #538 follows as two units: adopting the existing `botDiscordIDFromState` at the three `.ID` sites, then a new `botDisplayNameFromState` for the nine `.Username`/`.GlobalName` sites. Splitting by area would put both accessors in one appbot commit and lose the clean red-green.