### PR TITLE
fix(discord): take the bot application ID from the locked accessor

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -1193,14 +1193,23 @@ func (d *DiscordAppBot) UnregisterCommandsAll(ctx context.Context, logger runtim
 
 // If guildID is empty, it will unregister all global commands.
 func (d *DiscordAppBot) UnregisterCommands(ctx context.Context, logger runtime.Logger, dg *discordgo.Session, guildID string) {
-	commands, err := dg.ApplicationCommands(dg.State.User.ID, guildID)
+	// One locked read, reused: the delete loop below used to re-read the ID per
+	// command, so a reconnect mid-loop could delete against a different
+	// application than the fetch listed.
+	botID := botDiscordIDFromState(dg.State)
+	if botID == "" {
+		logger.Error("Cannot unregister commands: bot user ID not in state yet")
+		return
+	}
+
+	commands, err := dg.ApplicationCommands(botID, guildID)
 	if err != nil {
 		logger.Error("Error fetching commands,", zap.Error(err))
 		return
 	}
 
 	for _, command := range commands {
-		err := dg.ApplicationCommandDelete(dg.State.User.ID, guildID, command.ID)
+		err := dg.ApplicationCommandDelete(botID, guildID, command.ID)
 		if err != nil {
 			logger.Error("Error deleting command,", zap.Error(err))
 		} else {

--- a/server/evr_discord_botid_guard_test.go
+++ b/server/evr_discord_botid_guard_test.go
@@ -1,0 +1,57 @@
+package server
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// The command-registration paths read the bot's own application ID straight out
+// of discordgo state as `dg.State.User.ID`, unlocked. #536 established why that
+// is a data race and built botDiscordIDFromState for it; these call sites were
+// not converted at the time.
+//
+// The accessor's race-safety is already witnessed by #536
+// (TestBotDiscordIDFromState_ConcurrentWithReady). What is pinned here is the
+// consequence of adopting it: the accessor returns "" where the old expression
+// panicked, so every caller now needs to decide what "" means. Sending it on to
+// Discord as an application ID is not an option — it is a well-formed call
+// against the wrong resource.
+
+// unreadyDiscordSession is a session whose State has not seen a READY yet, so
+// State.User is nil. The old `dg.State.User.ID` expression panicked on this.
+func unreadyDiscordSession() *discordgo.Session {
+	return &discordgo.Session{State: discordgo.NewState()}
+}
+
+// TestUnregisterCommands_RefusesWithoutBotID pins that a pre-READY state stops
+// the unregister sweep instead of asking Discord to list commands for
+// application "".
+func TestUnregisterCommands_RefusesWithoutBotID(t *testing.T) {
+	logger := newCaptureLogger()
+	d := &DiscordAppBot{}
+
+	// Must not panic, and must not reach the network: a nil HTTP client in the
+	// session would fault if ApplicationCommands were actually called.
+	d.UnregisterCommands(context.Background(), logger, unreadyDiscordSession(), "guild-1")
+
+	if _, found := logger.find("error", "Cannot unregister commands: bot user ID not in state yet"); !found {
+		t.Error("pre-READY unregister did not report why it stopped; it must not silently no-op")
+	}
+}
+
+// TestRegisterDiscordCommands_RefusesWithoutBotID pins the same for the
+// reservation integration, which returns an error rather than logging.
+func TestRegisterDiscordCommands_RefusesWithoutBotID(t *testing.T) {
+	ri := &ReservationIntegration{}
+
+	err := ri.RegisterDiscordCommands(unreadyDiscordSession())
+	if err == nil {
+		t.Fatal("pre-READY registration returned nil; it would have created the command against application \"\"")
+	}
+	if !strings.Contains(err.Error(), "bot user ID not in state yet") {
+		t.Errorf("error does not say why registration was refused: %v", err)
+	}
+}

--- a/server/evr_reservation_integration.go
+++ b/server/evr_reservation_integration.go
@@ -45,7 +45,12 @@ func NewReservationIntegration(nk runtime.NakamaModule, logger runtime.Logger) *
 func (ri *ReservationIntegration) RegisterDiscordCommands(dg *discordgo.Session) error {
 	command := GetReserveCommandDefinition()
 
-	_, err := dg.ApplicationCommandCreate(dg.State.User.ID, "", command)
+	botID := botDiscordIDFromState(dg.State)
+	if botID == "" {
+		return fmt.Errorf("failed to register /reserve command: bot user ID not in state yet")
+	}
+
+	_, err := dg.ApplicationCommandCreate(botID, "", command)
 	if err != nil {
 		return fmt.Errorf("failed to register /reserve command: %w", err)
 	}


### PR DESCRIPTION
Part of #538 — unit 2 of 3 for the unlocked-`State` class. (#537 was unit 1, merged as #542.)

Converts the three `dg.State.User.ID` reads to #536's existing `botDiscordIDFromState`:

```
evr_discord_appbot.go:1196        ApplicationCommands (fetch)
evr_discord_appbot.go:1203        ApplicationCommandDelete (inside the loop)
evr_reservation_integration.go:48 ApplicationCommandCreate
```

## Mechanism

Already established by #536 and unchanged here: `State` embeds `Ready`, so `State.User` is a `*User` that discordgo **replaces wholesale** on every gateway READY — `s.Ready = *r` under `State.Lock()` (`state.go:911/916/935` @ v0.29.0), which writes the pointer word itself. #536 converted the one call site it was about; these three were left behind.

## This is not a pure substitution — please review this part

`botDiscordIDFromState` returns `""` where `dg.State.User.ID` **panicked**. So every adopting call site has to decide what `""` means, and passing it through is not an option: an empty application ID is a well-formed Discord API call against the wrong resource. Both sites now refuse explicitly rather than proceeding.

Separately, `UnregisterCommands` re-read the ID *inside* its delete loop. A reconnect between the fetch and a delete could therefore delete against a different application than the fetch listed. It now takes one locked read and reuses it.

## Witness

No new `-race` test — the accessor's race-safety is already witnessed by #536's `TestBotDiscordIDFromState_ConcurrentWithReady`, and duplicating it would add nothing. What the new tests pin is the **consequence of adoption**, and they are load-bearing. Reverting the reservation site to the old expression:

```
--- FAIL: TestRegisterDiscordCommands_RefusesWithoutBotID
panic: runtime error: invalid memory address or nil pointer dereference
```

That is the pre-READY crash #536 documented in prose, now covered by a test.

Full DB-free suite green (`SUITE_EXIT=0`, 128.1s).

## Remaining

Unit 3 closes #538: a new `botDisplayNameFromState` for the nine `.Username` / `.GlobalName` reads (appbot `:149,:164,:166` plus six in `evr_pipeline_login.go`, which run on session goroutines once per player login — the widest window of the three units).