### PR TITLE
fix(discord): read the bot's username under the state lock

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -145,8 +145,14 @@ func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.Nak
 
 	dg.AddHandlerOnce(func(s *discordgo.Session, m *discordgo.Ready) {
 
-		// Create a user for the bot based on it's discord profile
-		userID, _, _, err := nk.AuthenticateCustom(ctx, m.User.ID, s.State.User.Username, true)
+		// Create a user for the bot based on it's discord profile.
+		//
+		// Both fields come from m, the handler's own READY payload, rather than
+		// from s.State: m is not shared with the gateway goroutine, so it needs
+		// no lock and cannot be swapped mid-read. The ID was already read this
+		// way; the username was not, and an unlocked s.State.User.Username here
+		// could persist a stale name onto the bot's own Nakama account.
+		userID, _, _, err := nk.AuthenticateCustom(ctx, m.User.ID, m.User.Username, true)
 		if err != nil {
 			logger.WithField("error", err).Error("Error creating discordbot user")
 		}
@@ -161,10 +167,7 @@ func NewDiscordAppBot(ctx context.Context, logger runtime.Logger, nk runtime.Nak
 
 		appbot.userID = userID
 
-		displayName := dg.State.User.GlobalName
-		if displayName == "" {
-			displayName = dg.State.User.Username
-		}
+		displayName := botDisplayNameFromState(dg.State)
 
 		if err := appbot.RegisterSlashCommands(); err != nil {
 			logger.WithField("error", err).Error("Failed to register slash commands")

--- a/server/evr_discord_botname_race_test.go
+++ b/server/evr_discord_botname_race_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// The bot's own username was read as `State.User.Username` with no lock held in
+// nine places: the Ready handler's "Bot ready" line, and six reads in the login
+// pipeline. State embeds Ready, so State.User is a *User that discordgo
+// REPLACES wholesale on every gateway READY -- `s.Ready = *r` under
+// State.Lock() (state.go:911/916/935 @ v0.29.0) writes the pointer word itself.
+//
+// The login-pipeline reads are the reason this matters more than the guild
+// count: they run on a session goroutine once per player login, so the exposure
+// is the life of the process rather than startup.
+
+// readyWriter starts a goroutine performing exactly the write State.onReady
+// performs, and returns a stop function. started is closed after the first
+// write, so a reader can wait for the writer to actually be running: a reader
+// loop that finishes before the writer is scheduled never overlaps it, and
+// -race reports nothing at all. (That is not hypothetical -- an earlier
+// concurrency test in this package passed against a deliberately unlocked
+// accessor for exactly that reason.)
+func readyWriter(state *discordgo.State) (stop func()) {
+	stopCh := make(chan struct{})
+	done := make(chan struct{})
+	started := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for i := 0; ; i++ {
+			select {
+			case <-stopCh:
+				return
+			default:
+			}
+			state.Lock()
+			state.Ready = discordgo.Ready{User: &discordgo.User{
+				ID:         fmt.Sprintf("bot-%d", i),
+				Username:   fmt.Sprintf("EchoTools%d", i),
+				GlobalName: fmt.Sprintf("Echo Tools %d", i),
+			}}
+			state.Unlock()
+			if i == 0 {
+				close(started)
+			}
+		}
+	}()
+
+	<-started
+	return func() {
+		close(stopCh)
+		<-done
+	}
+}
+
+// TestBotUsernameFromState_ConcurrentWithReady fails under -race if the
+// accessor is ever changed back to an unlocked read.
+func TestBotUsernameFromState_ConcurrentWithReady(t *testing.T) {
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-0", Username: "EchoTools0"}
+	stop := readyWriter(state)
+
+	for i := 0; i < 20000; i++ {
+		name, present := botUsernameFromState(state)
+		if !present || name == "" {
+			stop()
+			t.Fatalf("read an absent/empty bot username at iteration %d; the login pipeline would fall back or skip verification", i)
+		}
+	}
+	stop()
+}
+
+// TestBotDisplayNameFromState_ConcurrentWithReady covers the two-field
+// accessor, whose fallback would otherwise be able to straddle a READY.
+func TestBotDisplayNameFromState_ConcurrentWithReady(t *testing.T) {
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-0", Username: "EchoTools0", GlobalName: "Echo Tools 0"}
+	stop := readyWriter(state)
+
+	for i := 0; i < 20000; i++ {
+		if got := botDisplayNameFromState(state); got == "" {
+			stop()
+			t.Fatalf("read an empty display name at iteration %d", i)
+		}
+	}
+	stop()
+}
+
+// TestBotUsernameFromState_PresentIsNotNonEmpty pins the distinction the login
+// pipeline depends on. Its IP-verification block is entered on "State.User was
+// present", not on "the username is non-empty", because every path inside that
+// block returns an error -- skipping it lets the login through. Collapsing the
+// two would turn a degenerate state into a fail-open.
+func TestBotUsernameFromState_PresentIsNotNonEmpty(t *testing.T) {
+	if _, present := botUsernameFromState(nil); present {
+		t.Error("nil state reported present")
+	}
+	if _, present := botUsernameFromState(discordgo.NewState()); present {
+		t.Error("pre-READY state (nil User) reported present")
+	}
+
+	state := discordgo.NewState()
+	state.User = &discordgo.User{ID: "bot-1"} // present, but no username
+	name, present := botUsernameFromState(state)
+	if !present {
+		t.Error("User present but reported absent; the login guard would skip IP verification")
+	}
+	if name != "" {
+		t.Errorf("got username %q, want empty", name)
+	}
+}
+
+// TestBotDisplayNameFromState_PrefersGlobalName pins the fallback order the
+// Ready handler used to open-code.
+func TestBotDisplayNameFromState_PrefersGlobalName(t *testing.T) {
+	if got := botDisplayNameFromState(nil); got != "" {
+		t.Errorf("nil state: got %q, want empty", got)
+	}
+	if got := botDisplayNameFromState(discordgo.NewState()); got != "" {
+		t.Errorf("pre-READY: got %q, want empty", got)
+	}
+
+	state := discordgo.NewState()
+	state.User = &discordgo.User{Username: "echotools", GlobalName: "Echo Tools"}
+	if got := botDisplayNameFromState(state); got != "Echo Tools" {
+		t.Errorf("got %q, want the global name", got)
+	}
+
+	state.User = &discordgo.User{Username: "echotools"}
+	if got := botDisplayNameFromState(state); got != "echotools" {
+		t.Errorf("got %q, want the username fallback", got)
+	}
+}

--- a/server/evr_discord_state_access.go
+++ b/server/evr_discord_state_access.go
@@ -64,3 +64,48 @@ func stateGuildCount(state *discordgo.State) int {
 	defer state.RUnlock()
 	return len(state.Guilds)
 }
+
+// botUsernameFromState returns the bot's own Discord username, read under the
+// discordgo state's read lock. present reports whether State.User existed at
+// all, which is NOT the same question as whether the username is non-empty --
+// see evr_pipeline_login.go's IP-verification branch, where the two decide
+// different things and conflating them would let a login through that the
+// original guard blocked.
+//
+// Same hazard as botDiscordIDFromState above: State.User is a *User that
+// discordgo replaces wholesale on every gateway READY, under State.Lock().
+//
+// The widest exposure for this one is the login pipeline
+// (evr_pipeline_login.go), which reads it on a session goroutine once per
+// player login -- not a startup-only path, so it is live for the life of the
+// process.
+func botUsernameFromState(state *discordgo.State) (username string, present bool) {
+	if state == nil {
+		return "", false
+	}
+	state.RLock()
+	defer state.RUnlock()
+	if state.User == nil {
+		return "", false
+	}
+	return state.User.Username, true
+}
+
+// botDisplayNameFromState returns the name to show for the bot: its global
+// (display) name when it has one, otherwise its username. Both fields are read
+// in ONE critical section, so the fallback cannot straddle a gateway READY and
+// mix a stale GlobalName with a fresh Username.
+func botDisplayNameFromState(state *discordgo.State) string {
+	if state == nil {
+		return ""
+	}
+	state.RLock()
+	defer state.RUnlock()
+	if state.User == nil {
+		return ""
+	}
+	if state.User.GlobalName != "" {
+		return state.User.GlobalName
+	}
+	return state.User.Username
+}

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -396,8 +396,10 @@ func (p *EvrPipeline) authenticateSession(ctx context.Context, logger *zap.Logge
 				return fmt.Errorf("error creating link ticket: %w", err)
 			} else {
 				botUsername := "EchoTools"
-				if p.appBot != nil && p.appBot.dg != nil && p.appBot.dg.State != nil && p.appBot.dg.State.User != nil && p.appBot.dg.State.User.Username != "" {
-					botUsername = p.appBot.dg.State.User.Username
+				if p.appBot != nil && p.appBot.dg != nil {
+					if name, _ := botUsernameFromState(p.appBot.dg.State); name != "" {
+						botUsername = name
+					}
 				}
 
 				return DeviceNotLinkedError{
@@ -553,8 +555,21 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 		// Use the last two digits of the nanos seconds as the 2FA code.
 		twoFactorCode := fmt.Sprintf("%02d", entry.CreatedAt.Nanosecond()%100)
 		metricsTags["error"] = "ip_verification_required"
-		if p.appBot != nil && p.appBot.dg != nil && p.appBot.dg.State != nil && p.appBot.dg.State.User != nil {
-			botUsername := p.appBot.dg.State.User.Username
+		// botUsername is read ONCE here and reused below. The branch at the
+		// bottom used to re-read State.User.Username twice more, so a gateway
+		// READY landing mid-branch could name a different bot than the one this
+		// block already decided to use.
+		//
+		// The entry condition stays "State.User was present", NOT "the username
+		// is non-empty": every path inside this block returns an error, so
+		// skipping it lets the login proceed. Gating on a non-empty username
+		// would turn a degenerate state (User present, Username "") from a
+		// blocked login into an allowed one.
+		botUsername, botUserPresent := "", false
+		if p.appBot != nil && p.appBot.dg != nil {
+			botUsername, botUserPresent = botUsernameFromState(p.appBot.dg.State)
+		}
+		if botUserPresent {
 			if err := p.appBot.SendIPApprovalRequest(ctx, params.profile.ID(), entry, params.ipInfo); err == nil {
 				return NewLocationError{
 					code:        twoFactorCode,
@@ -575,10 +590,10 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 							code:      twoFactorCode,
 						}
 					}
-				} else if p.appBot.dg.State.User.Username != "" {
+				} else if botUsername != "" {
 					// Use the bot name
 					return NewLocationError{
-						botUsername: p.appBot.dg.State.User.Username,
+						botUsername: botUsername,
 						code:        twoFactorCode,
 					}
 				} else {


### PR DESCRIPTION
Closes #538 — unit 3 of 3 for the unlocked-`State` class (#537 → #542, `.ID` reads → #543).

The last nine unlocked `State.User` reads. Six are in the login pipeline, which is what makes this the widest of the three units: they run on a session goroutine **once per player login**, so the exposure is the life of the process rather than startup.

```
evr_discord_appbot.go:149       AuthenticateCustom username
evr_discord_appbot.go:164-166   "Bot ready" display name
evr_pipeline_login.go:399-400   DeviceNotLinkedError bot name
evr_pipeline_login.go:556-557   IP-verification bot name
evr_pipeline_login.go:578,581   IP-verification fallback bot name
```

After this, `grep` finds **no executable `State.User` read** outside the accessors.

## Three things that are more than a mechanical swap

**1. `:149` gets no accessor.** It already read the *ID* from `m`, the handler’s own READY payload — not shared with the gateway, so no lock needed. Only the username came from `s.State`. Reading both from `m` is simpler *and* removes the race. This is the site that mattered most: it persists a username onto the bot’s own Nakama account, so a stale read outlives the moment.

**2. `botUsernameFromState` returns `(username, present)`, and conflating those would have been a fail-open.** The login IP-verification block is entered on *"State.User was present"*, not *"username is non-empty"*. Every path inside that block **returns an error** — so skipping it lets the login proceed. Gating on a non-empty username would turn a degenerate state (User present, Username `""`) from a blocked login into an allowed one: a fail-open on a fail-closed control. The entry condition is preserved exactly, and pinned by `TestBotUsernameFromState_PresentIsNotNonEmpty`.

**3. The IP-verification branch re-read `State.User.Username` twice more** at the bottom, after the block had already chosen a name — so a READY landing mid-branch could name a different bot than the block decided on. One read, reused. (Same shape as the `UnregisterCommands` loop in #543.)

`botDisplayNameFromState` also reads `GlobalName` and `Username` in **one** critical section, so the fallback cannot straddle a READY and mix a stale global name with a fresh username — which the open-coded version at `:164-166` could.

## Witness

Against deliberately unlocked accessors:
```
WARNING: DATA RACE
Read at 0x00c00022d210 by goroutine 50:
  server.botUsernameFromState()
Previous write at 0x00c00022d210 by goroutine 51:
  [the READY assignment]
--- FAIL: TestBotUsernameFromState_ConcurrentWithReady
```
Locks restored: `ok github.com/heroiclabs/nakama/v3/server 1.572s`. Full DB-free suite green (`SUITE_EXIT=0`, 128.6s).

The `readyWriter` helper waits for its first write before returning. That is not decoration — a concurrency test in this package was already caught passing under `-race` against an unlocked accessor because the two goroutines never actually overlapped.