### PR TITLE
fix(earlyquit): withdraw a deprecation that pointed at the wrong API

### DIFF
--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -31,7 +31,13 @@ const (
 	TierRestoredMessage = "Matchmaking Priority Restored: You have returned to Tier 1 status. Complete full matches to maintain your standing."
 )
 
-// EarlyQuitLockoutDurations maps penalty levels to their lockout durations
+// EarlyQuitLockoutDurations maps penalty levels to their lockout durations.
+//
+// It must have an entry for every level in 0..MaxEarlyQuitPenaltyLevel:
+// GetLockoutDuration returns 0 for an unmapped level, which reads as "no
+// lockout" and is indistinguishable from level 0. Raising the max without
+// extending this map would silently un-penalise the new top level, so
+// TestEarlyQuitLockoutDurations_CoversEveryLevel fails if the two drift.
 var EarlyQuitLockoutDurations = map[int]time.Duration{
 	0: 0 * time.Second,   // No lockout
 	1: 120 * time.Second, // 2 minutes
@@ -325,8 +331,32 @@ func ResolveSteadyPlayerLevel(steadyMatches, steadyEarlyQuits int32, cfg *evr.SN
 	return best
 }
 
-// GetLockoutDuration returns the lockout duration for a given penalty level.
-// Uses the hardcoded fallback map (deprecated — callers should use ResolvePenaltyLevel with config).
+// GetLockoutDuration returns the built-in lockout duration for a penalty LEVEL.
+//
+// This carried a note saying it was deprecated and that callers should use
+// ResolvePenaltyLevel with config instead. That was withdrawn: ResolvePenaltyLevel
+// cannot answer this question. It is keyed on QUIT COUNT --
+// ResolvePenaltyLevel(numQuits, cfg) maps a count to the band it falls in and
+// returns that band's lockout. Getting "the lockout for level L" out of it means
+// inventing a quit count that resolves to L, and for a level absent from the
+// configured ladder no such count exists.
+//
+// Following the old advice is what produced the bug fixed in #535: seeding the
+// lockout from the level the target's CURRENT quit count maps to made a level
+// absent from the ladder borrow a different level's lockout. See the comment at
+// evr_runtime_rpc_earlyquit_manage.go where the lockout must come from the level
+// being SET.
+//
+// So the two coexist deliberately:
+//
+//	ResolvePenaltyLevel  quit count -> (level, lockout), config-driven
+//	GetLockoutDuration   level      -> lockout, built-in defaults
+//
+// A caller that has config and wants a configured level's lockout should still
+// prefer the config value; this is the floor underneath it. Its domain is
+// 0..MaxEarlyQuitPenaltyLevel and TestEarlyQuitLockoutDurations_CoversEveryLevel
+// pins that, because an unmapped level returns 0 -- a silent "no lockout" that
+// nothing downstream would report.
 func GetLockoutDuration(penaltyLevel int) time.Duration {
 	duration, ok := EarlyQuitLockoutDurations[penaltyLevel]
 	if !ok {

--- a/server/evr_earlyquit_lockout_domain_test.go
+++ b/server/evr_earlyquit_lockout_domain_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heroiclabs/nakama/v3/server/evr"
+)
+
+// TestEarlyQuitLockoutDurations_CoversEveryLevel is the sensor for a drift that
+// would otherwise be silent.
+//
+// GetLockoutDuration returns 0 for a level that is not in
+// EarlyQuitLockoutDurations. Zero is not an error value here -- it is what
+// level 0 legitimately returns, and what "no lockout" looks like everywhere
+// downstream: IsPenaltyActive() reports no active lockout and the scheduler
+// treats the penalty as already expired. So a missing entry does not fail, it
+// un-penalises.
+//
+// Today the map and MaxEarlyQuitPenaltyLevel agree at 3, and every path that
+// can reach GetLockoutDuration is bounded to that: the modify RPC rejects
+// level > MaxEarlyQuitPenaltyLevel (evr_runtime_rpc_earlyquit_manage.go), the
+// /earlyquit command validates 0..3, and evr_match.go clamps to it. The gap
+// this test closes is the future edit that raises the ceiling and forgets the
+// table.
+func TestEarlyQuitLockoutDurations_CoversEveryLevel(t *testing.T) {
+	for level := 0; level <= MaxEarlyQuitPenaltyLevel; level++ {
+		if _, ok := EarlyQuitLockoutDurations[level]; !ok {
+			t.Errorf("penalty level %d has no entry in EarlyQuitLockoutDurations, so GetLockoutDuration(%d) "+
+				"returns 0 and the level silently carries no lockout. MaxEarlyQuitPenaltyLevel is %d — "+
+				"raising it requires extending the table.", level, level, MaxEarlyQuitPenaltyLevel)
+		}
+	}
+}
+
+// TestEarlyQuitLockoutDurations_OnlyLevelZeroIsFree pins the other half: a
+// non-zero level must actually cost something, or the ladder has a rung that
+// does nothing.
+func TestEarlyQuitLockoutDurations_OnlyLevelZeroIsFree(t *testing.T) {
+	if got := GetLockoutDuration(0); got != 0 {
+		t.Errorf("level 0 should carry no lockout, got %v", got)
+	}
+	for level := 1; level <= MaxEarlyQuitPenaltyLevel; level++ {
+		if got := GetLockoutDuration(level); got <= 0 {
+			t.Errorf("level %d carries no lockout (%v); a penalty rung that costs nothing is indistinguishable from level 0", level, got)
+		}
+	}
+}
+
+// TestGetLockoutDuration_UnmappedLevelIsZero documents the behaviour the two
+// tests above exist to contain, so it is not mistaken for a bug when read in
+// isolation. Out-of-domain input is the caller's contract to satisfy.
+func TestGetLockoutDuration_UnmappedLevelIsZero(t *testing.T) {
+	if got := GetLockoutDuration(MaxEarlyQuitPenaltyLevel + 1); got != 0 {
+		t.Errorf("got %v, want 0 for an out-of-domain level", got)
+	}
+	if got := GetLockoutDuration(-1); got != 0 {
+		t.Errorf("got %v, want 0 for a negative level", got)
+	}
+}
+
+// TestGetLockoutDuration_IsKeyedOnLevelNotQuitCount is the regression guard for
+// the deprecation note this change withdrew.
+//
+// The note said callers should use ResolvePenaltyLevel instead. The two are
+// keyed on different things, and swapping one for the other is what produced
+// the bug fixed in #535 — a level absent from the configured ladder borrowed a
+// different level's lockout. This pins that they are not interchangeable, so
+// the advice cannot quietly come back.
+func TestGetLockoutDuration_IsKeyedOnLevelNotQuitCount(t *testing.T) {
+	// A config whose ladder does not configure level 2 at all: one band, for
+	// level 1, covering quit counts 0..99.
+	cfg := &evr.SNSEarlyQuitConfig{
+		PenaltyLevels: []evr.EarlyQuitPenaltyLevelConfig{
+			{PenaltyLevel: 1, MinEarlyQuits: 0, MaxEarlyQuits: 99, MMLockoutSec: 120},
+		},
+	}
+
+	// ResolvePenaltyLevel is asked about a QUIT COUNT and can only ever answer
+	// with the band that count falls in.
+	level, lockoutSec := ResolvePenaltyLevel(5, cfg)
+	if level != 1 {
+		t.Fatalf("precondition: quit count 5 should resolve to the only configured level, got %d", level)
+	}
+
+	// GetLockoutDuration is asked about a LEVEL. Level 2's built-in lockout is
+	// its own value, not level 1's — which is exactly what ResolvePenaltyLevel
+	// would have handed back for any quit count in this config.
+	if got := GetLockoutDuration(2); got == time.Duration(lockoutSec)*time.Second {
+		t.Errorf("level 2's lockout (%v) collapsed onto the configured band's (%ds); "+
+			"if these are ever equal by construction this test stops proving the two are keyed differently", got, lockoutSec)
+	}
+	if got := GetLockoutDuration(2); got != EarlyQuitLockoutDurations[2] {
+		t.Errorf("got %v, want level 2's own entry %v", got, EarlyQuitLockoutDurations[2])
+	}
+}


### PR DESCRIPTION
Closes #540. UNIT 3 of wave 3.

`GetLockoutDuration` carried `(deprecated — callers should use ResolvePenaltyLevel with config)`. **`ResolvePenaltyLevel` cannot answer this question.**

```
ResolvePenaltyLevel  quit count -> (level, lockout)   config-driven
GetLockoutDuration   level      -> lockout            built-in defaults
```

Getting "the lockout for level L" out of `ResolvePenaltyLevel` means inventing a quit count that resolves to L — and for a level absent from the configured ladder, no such count exists. Following the note is exactly what produced the bug fixed in #535: *"seeding it from the level the target's current quit count maps to made a level absent from the ladder borrow a different level's lockout."*

There is no level-keyed replacement to repoint the note at, so it is **withdrawn rather than redirected**, and the reason the two coexist is written where it used to be. `TestGetLockoutDuration_IsKeyedOnLevelNotQuitCount` pins that they are not interchangeable, so the advice cannot quietly come back.

## Two things I measured and deliberately did NOT do

**1. No config-first consolidation helper.** I proposed one on #540; withdrawn. Two of the three callers cannot supply config — `evr_earlyquit.go:128` is inside `UnmarshalJSON` (no `ctx`, no `nk`), and the `/earlyquit` caller clamps to 0–3 and never consults config. A helper taking `cfg` would have nothing to read at exactly the sites needing the fallback.

**2. No fix for "a configured level ≥ 4 gets a silent zero" — I overstated that on #540 and have corrected the issue.** It is not reachable: `MaxEarlyQuitPenaltyLevel = 3`, the modify RPC rejects above it, `/earlyquit` validates 0–3, and `evr_match.go:1116-1117` clamps to it. The map's domain already matches the ceiling.

## What is real: drift, and it gets a sensor

`GetLockoutDuration` returns `0` for an unmapped level — and `0` is **not** an error value. It is precisely what level 0 returns and what "no lockout" looks like downstream (`IsPenaltyActive()` reports nothing active). So a missing entry does not fail loudly, it un-penalises.

Raising the ceiling without extending the table now fails:

```
--- FAIL: TestEarlyQuitLockoutDurations_CoversEveryLevel
    penalty level 4 has no entry in EarlyQuitLockoutDurations, so GetLockoutDuration(4)
    returns 0 and the level silently carries no lockout. MaxEarlyQuitPenaltyLevel is 4 —
    raising it requires extending the table.
--- FAIL: TestEarlyQuitLockoutDurations_OnlyLevelZeroIsFree
    level 4 carries no lockout (0s); a penalty rung that costs nothing is
    indistinguishable from level 0
```

Verified by mutation (temporarily setting the constant to 4), then reverted. Full DB-free suite green (`SUITE_EXIT=0`, 128.1s). No production behaviour changes — comments, plus tests.