### PR TITLE
chore(ci): flag any commit that reaches main without a PR

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,6 +37,30 @@
 # worktrees. The worktree upstream is how it happened, but a gate scoped to the
 # way it happened last time is a gate with a hole in it, and the escape hatch
 # already covers the legitimate case.
+#
+# THIS HOOK IS OFF UNTIL ARMED, AND ITS FAILURE MODE IS SILENCE.
+#
+# core.hooksPath is local config and cannot be committed, so this file shipping
+# with the repo does not activate it. Until someone runs `just hooks` in a given
+# clone, git never looks here and pushes are unguarded -- with no warning, since
+# a hook that is not wired up is indistinguishable from a hook that approved.
+#
+# That gap is not a rounding error: a fresh clone, a newly created worktree, and
+# an agent starting cold are all unarmed by default, and those are exactly the
+# situations this guard was built for.
+#
+# Check whether it is armed here:
+#
+#     git config --get core.hooksPath     # must print .githooks
+#
+# Two other layers exist because of that gap:
+#
+#   - .github/workflows/main-push-audit.yaml flags a commit that reached main
+#     without a PR. Server-side, so it arms itself -- but it is DETECTION: it
+#     goes red after the push has landed.
+#   - GitHub branch protection requiring a PR would be actual prevention and
+#     cannot be bypassed. It is a repository setting, not a file, and it
+#     constrains every human with push access, so it is the owner's decision.
 
 set -uo pipefail
 

--- a/.github/workflows/main-push-audit.yaml
+++ b/.github/workflows/main-push-audit.yaml
@@ -1,0 +1,78 @@
+# Flags any commit that reaches main without an associated pull request.
+#
+# DETECTION, NOT PREVENTION. This runs after the push has landed. When it goes
+# red the commit is already on main and already fetchable. It converts a silent
+# direct push into a dated, red one; it cannot stop one.
+#
+# The layer that PREVENTS is .githooks/pre-push -- but only in a clone that has
+# run `just hooks`, so it is off by default in a fresh clone, a new worktree, or
+# an agent starting cold. That is the population the guard exists for, which is
+# why this server-side backstop is here: it arms itself and cannot be skipped by
+# a clone that never set anything up.
+#
+# The mechanism that would close this properly is GitHub branch protection
+# requiring a PR to land on main. That is unbypassable, but it is a repository
+# setting rather than a file and it constrains every human with push access, so
+# it is the owner's call and is deliberately not assumed here.
+
+name: Main push audit
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit:
+    name: Commits on main came through a PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The audit reads commit subjects and authors for its report, and needs
+          # the pushed range present locally. 0 = full history; the range can be
+          # arbitrarily long after a force-push or an initial import.
+          fetch-depth: 0
+
+      - name: Collect the commits this push added to main
+        id: collect
+        env:
+          BEFORE: ${{ github.event.before }}
+          AFTER: ${{ github.event.after }}
+        run: |
+          set -uo pipefail
+          # A new branch (or an unreachable before) reports all-zeros. There is
+          # no range to walk, so audit just the tip.
+          if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "no usable before-ref; auditing the pushed tip only" >&2
+            shas="$AFTER"
+          else
+            shas="$(git rev-list "$BEFORE..$AFTER")"
+          fi
+
+          if [ -z "$shas" ]; then
+            echo "nothing to audit" >&2
+          fi
+          {
+            echo "shas<<EOF"
+            echo "$shas"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Audit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -uo pipefail
+          shas="$(printf '%s' '${{ steps.collect.outputs.shas }}' | tr -d '\r')"
+          if [ -z "$(printf '%s' "$shas" | tr -d '[:space:]')" ]; then
+            echo "no commits to audit"
+            exit 0
+          fi
+          # shellcheck disable=SC2086
+          ./scripts/audit-main-push.sh $shas

--- a/scripts/audit-main-push.sh
+++ b/scripts/audit-main-push.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Report any commit that reached main without an associated pull request.
+#
+# THIS IS DETECTION, NOT PREVENTION. It runs after the push has already landed.
+# By the time it goes red, the commit is on main and anyone who fetched has it.
+# It exists to make a direct push loud and dated rather than silent, and to give
+# the audit trail a red mark to point at -- not to stop one.
+#
+# The mechanism that would actually PREVENT this is GitHub branch protection
+# requiring a pull request to land on main. That is a repository setting, not a
+# file, and it constrains every human with push access too, so it is the
+# repository owner's decision and deliberately not made here.
+#
+# The other layer is .githooks/pre-push, which DOES prevent -- but only in a
+# clone that has run `just hooks`. A fresh clone, a new worktree, or an agent
+# starting cold is unprotected until that runs, which is exactly the population
+# the guard was built for. This check is the backstop for that gap: it is
+# server-side, arms itself, and cannot be skipped by a clone that never set
+# anything up.
+#
+# Usage:
+#   scripts/audit-main-push.sh <sha> [<sha>...]
+#
+# Requires gh with repo read access. GH_TOKEN is provided in Actions.
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <sha> [<sha>...]" >&2
+	exit 2
+fi
+
+repo="${GITHUB_REPOSITORY:-EchoTools/nakama}"
+violations=0
+
+for sha in "$@"; do
+	# A commit that arrived through a PR -- the merge commit itself, and every
+	# commit the PR carried -- is associated with that PR. A commit pushed
+	# straight to main is associated with none.
+	#
+	# On API failure this prints nothing and count stays empty; treat that as
+	# UNKNOWN and do not fail the build on it. A flaky API call must not read as
+	# a policy violation, or the check trains people to ignore it.
+	count="$(gh api "repos/${repo}/commits/${sha}/pulls" --jq 'length' 2>/dev/null)"
+
+	if [ -z "$count" ]; then
+		echo "  ?  ${sha}  could not query associated PRs (API error) -- not counted" >&2
+		continue
+	fi
+
+	if [ "$count" -eq 0 ]; then
+		subject="$(git log -1 --format='%s' "$sha" 2>/dev/null || echo '<unknown>')"
+		author="$(git log -1 --format='%an <%ae>' "$sha" 2>/dev/null || echo '<unknown>')"
+		echo "  ✗  ${sha}  ${subject}"
+		echo "         author: ${author}"
+		violations=$((violations + 1))
+	else
+		echo "  ✓  ${sha}  (PR #$(gh api "repos/${repo}/commits/${sha}/pulls" --jq '.[0].number' 2>/dev/null))"
+	fi
+done
+
+if [ "$violations" -gt 0 ]; then
+	cat >&2 <<EOF
+
+${violations} commit(s) reached main without a pull request.
+
+This check is post-hoc: the commit is already on main and this cannot undo it.
+What it gives you is a dated, red record instead of a silent one.
+
+If this was accidental -- the usual cause is a push resolving to main via a
+worktree's upstream, see .githooks/pre-push -- the commit stays. Rewriting
+shared history to hide the mistake is worse than the mistake.
+
+If it was intentional, nothing here objects to that; it just refuses to let it
+be quiet.
+EOF
+	exit 1
+fi
+
+echo "every commit in this push is associated with a pull request"


### PR DESCRIPTION
Refs #541. Closes the residual gap I flagged on #546.

## The gap

The pre-push hook from #546 prevents direct pushes to main — **but only in a clone that has run `just hooks`**. `core.hooksPath` is local config and cannot be committed, so the hook ships with the repo and does not arm itself.

A fresh clone, a newly created worktree, and an agent starting cold are all unguarded by default. Those are precisely the situations the hook was built for. A gate that requires a setup step is a gate that is off for the whole population it targets.

## What this is — and is not

**Detection, not prevention.** It runs after the push has landed; when it goes red the commit is already on main and already fetchable. What it buys is a dated red mark instead of silence. The workflow header says this in its own words rather than leaving it to be inferred.

It is server-side, so it arms itself and cannot be skipped by a clone that never set anything up.

**The mechanism that would actually prevent this is GitHub branch protection** requiring a PR to land on main — unbypassable, but a repository setting rather than a file, and it constrains every human with push access. That is the owner’s decision and is deliberately not assumed here.

## Proof

Against **real history**, not a manufactured violation — this repo already contains the exact case, from earlier today:

```
$ scripts/audit-main-push.sh 684c895af…
  ✗  684c895af…  chore(gitignore): match tools/ build outputs by shape…
         author: nakama-fixer <nakama-fixer@metis.agents>
1 commit(s) reached main without a pull request.
EXIT=1
```

Passing cases, covering both a PR merge commit and a commit merely *carried* by a PR:

```
$ scripts/audit-main-push.sh ca0569f04… 9f4125fe6… 711efa2bb…
  ✓  ca0569f04…  (PR #546)
  ✓  9f4125fe6…  (PR #535)
  ✓  711efa2bb…  (PR #545)
EXIT=0
```

Mixed input fails too, so one good commit cannot mask a bad one in the same push.

## Two design notes

**An API error is UNKNOWN, not a violation.** A flaky call must not fail the build, or the check trains people to ignore its red.

**The hook’s docs now record that it is off until armed**, and how to check (`git config --get core.hooksPath`). A guard whose failure mode is silence should say so where it lives — an unwired hook is indistinguishable from one that approved.

## Incidental

`exec-bit-check` caught my own new script during development: `chmod +x` was not recorded in the index because this repo carries `core.fileMode=false`. Fixed with `git update-index --chmod=+x`. The check extended in #546 to cover `.githooks/` earned its keep on `scripts/` the same day.