### PR TITLE
fix(git): restore the pre-push quality gates destroyed in #546

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,113 +1,179 @@
-#!/usr/bin/env bash
+#!/bin/bash
+# pre-push hook: quality gates for EchoTools/nakama
 #
-# Refuse any push that RESOLVES to main.
+# 0. Destination: refuse a push that RESOLVES to main
+# 1. Tag format: reject semver tags without -evr.<N>
+# 2. Go quality: run fast checks on changed files
+#    (gofmt, go vet, gopls staticcheck)
 #
-# Why this exists (see the incident issue): a branch created with
-#
-#     git worktree add <dir> -b <branch> origin/main
-#
-# tracks origin/main. With push.default=tracking (or upstream), git resolves a
-# push destination from the branch's UPSTREAM, not from its name -- so
-#
-#     git push -u origin my-feature-branch
-#
-# names the feature branch twice and still pushes it to refs/heads/main. It does
-# not look wrong at the call site, and it has now happened twice in this repo.
-#
-# The rule that prevents it is "always use an explicit refspec"
-# (git push origin HEAD:refs/heads/<branch>). That rule was written down a month
-# before the second occurrence and did not stop it. Prose is not a control: it
-# fires only when the reader happens to be attending to it, which is exactly not
-# the moment a routine push happens. This is the control.
-#
-# pre-push receives on stdin, one line per ref being pushed:
-#
-#     <local ref> <local sha> <remote ref> <remote sha>
-#
-# The remote ref is the RESOLVED destination -- the value that was wrong in both
-# incidents, and the one no human reads at the call site. That is why the check
-# belongs here and not in a wrapper around the push command.
-#
-# Deliberate escape hatch: an authorized push to main must be STATED, never
-# inferred.
-#
-#     ALLOW_MAIN_PUSH=1 git push origin HEAD:refs/heads/main
-#
-# Scope note: this refuses pushes to main from anywhere, not only from linked
-# worktrees. The worktree upstream is how it happened, but a gate scoped to the
-# way it happened last time is a gate with a hole in it, and the escape hatch
-# already covers the legitimate case.
+# Install: git config core.hooksPath .githooks
+# Skip:    git push --no-verify
 #
 # THIS HOOK IS OFF UNTIL ARMED, AND ITS FAILURE MODE IS SILENCE.
 #
 # core.hooksPath is local config and cannot be committed, so this file shipping
-# with the repo does not activate it. Until someone runs `just hooks` in a given
-# clone, git never looks here and pushes are unguarded -- with no warning, since
-# a hook that is not wired up is indistinguishable from a hook that approved.
+# with the repo does not activate it. Until someone runs `just hooks` (or the
+# git config line above) in a given clone, git never looks here and pushes are
+# unguarded -- with no warning, since a hook that is not wired up is
+# indistinguishable from one that approved.
 #
 # That gap is not a rounding error: a fresh clone, a newly created worktree, and
 # an agent starting cold are all unarmed by default, and those are exactly the
-# situations this guard was built for.
+# situations phase 0 was built for.
 #
-# Check whether it is armed here:
+# Check whether it is armed:
 #
 #     git config --get core.hooksPath     # must print .githooks
 #
-# Two other layers exist because of that gap:
+# Note that `git push --no-verify` skips this hook ENTIRELY, phase 0 included.
+# The backstop for both gaps is .github/workflows/main-push-audit.yaml, which is
+# server-side and arms itself -- but is detection after the fact, not
+# prevention. Actual prevention would be GitHub branch protection requiring a
+# PR; that is a repository setting and the owner's decision.
+
+set -e
+
+# ---- Color helpers ----
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+pass() { echo -e " ${GREEN}✓${NC} $1"; }
+fail() { echo -e " ${RED}✗${NC} $1"; fail_count=$((fail_count + 1)); }
+warn() { echo -e " ${YELLOW}⚠${NC} $1"; }
+fail_count=0
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# ---- Capture push refs ----
+# Pre-push receives refs on stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+# Store them so we can iterate in multiple phases.
+PUSH_REFS=$(cat)
+
+# ---- Phase 0: Destination check ----
 #
-#   - .github/workflows/main-push-audit.yaml flags a commit that reached main
-#     without a PR. Server-side, so it arms itself -- but it is DETECTION: it
-#     goes red after the push has landed.
-#   - GitHub branch protection requiring a PR would be actual prevention and
-#     cannot be bypassed. It is a repository setting, not a file, and it
-#     constrains every human with push access, so it is the owner's decision.
+# A branch created with `git worktree add <dir> -b <branch> origin/main` tracks
+# origin/main. With push.default=tracking, git resolves the destination from the
+# branch's UPSTREAM rather than its name, so
+#
+#     git push -u origin my-feature-branch
+#
+# names the feature branch twice and pushes it to refs/heads/main. It does not
+# look wrong at the call site, and it has happened twice in this repo.
+#
+# The remote ref below is the RESOLVED destination -- the value that was wrong
+# both times, and the one nobody reads at the call site. That is why the check
+# belongs in a hook and not in a wrapper around the push command.
+#
+# An authorized push to main must be STATED, never inferred:
+#
+#     ALLOW_MAIN_PUSH=1 git push origin HEAD:refs/heads/main
+#
+# Scope: refuses pushes to main from anywhere, not only from linked worktrees. A
+# gate scoped to the way it happened last time is a gate with a hole in it.
+if [ "${ALLOW_MAIN_PUSH:-}" != "1" ]; then
+    while read -r local_ref local_sha remote_ref remote_sha; do
+        # Explicit `if` rather than `[ ... ] && continue`: under `set -e` a
+        # trailing AND-list that evaluates false is a non-zero body result, and
+        # whether that aborts the hook depends on shell version and position.
+        # Not worth relying on for a guard.
+        if [ "${remote_ref:-}" != "refs/heads/main" ]; then
+            continue
+        fi
 
-set -uo pipefail
-
-protected_branch="main"
-
-if [ "${ALLOW_MAIN_PUSH:-}" = "1" ]; then
-	exit 0
+        fail "This push resolves to main (source: ${local_ref:-<unknown>})"
+        if [ "${local_ref:-}" != "refs/heads/main" ]; then
+            upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+            echo "       The source is not main, so this is very likely the upstream trap:"
+            echo "       push.default is '$(git config --get push.default || echo unset)'"
+            echo "       and this branch's upstream is '${upstream:-<none>}'."
+            echo "       git took the destination from the upstream, not the branch name."
+        fi
+        echo "       Use an explicit refspec: git push origin HEAD:refs/heads/<branch>"
+        echo "       To push to main deliberately: ALLOW_MAIN_PUSH=1 git push ..."
+    # A here-string, NOT a pipe: a piped `while` runs in a subshell, so every
+    # fail_count increment inside it is discarded and the summary below cannot
+    # see it. See phase 1 -- that bug is why its tag gate never rejected.
+    done <<< "$PUSH_REFS"
 fi
 
-blocked=0
+# ---- Phase 1: Tag format check ----
+# Reads from a here-string rather than a pipe. Piping PUSH_REFS into `while`
+# put the loop in a subshell, so `fail` incremented a COPY of fail_count and the
+# summary at the bottom always saw 0 -- this gate has never actually rejected a
+# malformed tag since it was written.
 while read -r local_ref local_sha remote_ref remote_sha; do
-	# A deletion or an empty line has nothing to inspect.
-	[ -z "${remote_ref:-}" ] && continue
+    [[ "$remote_ref" != refs/tags/* ]] && continue
+    tag="${remote_ref#refs/tags/}"
+    [[ "$tag" =~ ^v[0-9] ]] || continue
+    if [[ ! "$tag" =~ -evr\.[0-9]+$ ]]; then
+        fail "Tag '$tag' rejected — EVR releases use v3.27.2-evr.<N>"
+        echo "       Upstream Nakama tags (v3.x.x) must not be pushed here."
+    fi
+done <<< "$PUSH_REFS"
 
-	if [ "$remote_ref" = "refs/heads/$protected_branch" ]; then
-		blocked=1
-		cat >&2 <<EOF
+# ---- Phase 2: Go quality checks ----
+# Determine what's changed: diff HEAD against the remote's current state.
+# For branch pushes, check outgoing commits. For first push, check index.
 
-  REFUSED: this push resolves to $protected_branch.
+# Determine what changed: use ORIG_HEAD or diff against remote
+if git rev-parse --verify ORIG_HEAD 2>/dev/null; then
+    CHANGED_GO=$(git diff --name-only ORIG_HEAD..HEAD -- '*.go' 2>/dev/null || true)
+else
+    CHANGED_GO=$(git diff --name-only --cached -- '*.go' 2>/dev/null || true)
+fi
 
-    source:      ${local_ref:-<unknown>}
-    destination: $remote_ref
+if [ -n "$CHANGED_GO" ]; then
+    echo ""
+    echo "── Go quality checks ──"
 
-EOF
-		# Name the upstream trap explicitly when it is the likely cause, because
-		# the source ref above will look like an ordinary feature branch.
-		if [ "${local_ref:-}" != "refs/heads/$protected_branch" ]; then
-			upstream="$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
-			cat >&2 <<EOF
-  The source is not $protected_branch, so this is very likely the upstream trap:
-  push.default is '$(git config --get push.default || echo unset)' and this
-  branch's upstream is '${upstream:-<none>}'. git took the destination from the
-  upstream, not from the branch name.
+    # gofmt
+    UNFORMATTED=$(gofmt -l $CHANGED_GO 2>/dev/null || true)
+    if [ -n "$UNFORMATTED" ]; then
+        fail "gofmt needs these files:"
+        echo "$UNFORMATTED" | sed 's/^/       /'
+    else
+        pass "gofmt"
+    fi
 
-EOF
-		fi
-		cat >&2 <<EOF
-  Push with an explicit refspec instead:
+    # go vet (targeted, quiet mode)
+    if go vet ./server/... 2>/dev/null; then
+        pass "go vet ./server/..."
+    else
+        fail "go vet ./server/... — run 'go vet ./...' locally to see details"
+    fi
 
-    git push origin HEAD:refs/heads/<your-branch>
+    # gopls check (static analysis)
+    if command -v gopls &>/dev/null; then
+        GOPLS_ANALYSIS=$(gopls check $CHANGED_GO 2>/dev/null | head -20 || true)
+        if [ -n "$GOPLS_ANALYSIS" ]; then
+            warn "gopls diagnostics (review before push):"
+            echo "$GOPLS_ANALYSIS" | while IFS= read -r line; do echo "       $line"; done
+        else
+            pass "gopls check"
+        fi
+    else
+        warn "gopls not installed — skipping gopls check"
+    fi
 
-  If you really do mean to push to $protected_branch, say so:
+    # go mod tidy check
+    cd "$REPO_ROOT"
+    TIDY_BEFORE=$(git rev-parse HEAD 2>/dev/null)
+    go mod tidy 2>/dev/null
+    if [ -n "$(git status --porcelain go.mod go.sum 2>/dev/null)" ]; then
+        fail "go mod tidy modified go.mod/go.sum — commit these changes"
+    else
+        pass "go mod tidy"
+    fi
+    cd - >/dev/null
+fi
 
-    ALLOW_MAIN_PUSH=1 git push ...
+# ---- Summary ----
+if [ "$fail_count" -gt 0 ]; then
+    echo ""
+    echo -e " ${RED}── ${fail_count} check(s) failed — push rejected ──${NC}"
+    echo " To bypass: git push --no-verify origin <branch>"
+    exit 1
+fi
 
-EOF
-	fi
-done
-
-exit "$blocked"
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,13 +22,30 @@ govulncheck    # vulnerability check
 ### Pre-push hook (automated gate)
 
 The repo ships a pre-push hook in `.githooks/pre-push` that checks:
+0. Destination — refuses a push that **resolves** to `main`
 1. Tag format (`v*` tags must include `-evr.<N>`)
 2. `gofmt` compliance
 3. `go vet` on changed packages
 4. `gopls` diagnostics on changed files
 5. `go mod tidy` hasn't drifted
 
-Install: `git config core.hooksPath .githooks`
+Install: `just hooks` (or `git config core.hooksPath .githooks`)
+
+**The hook is off until installed, and that failure mode is silent** —
+`core.hooksPath` is local config and cannot be committed, so a fresh clone or a
+newly created worktree is unguarded with no warning. Check with
+`git config --get core.hooksPath`. `git push --no-verify` also skips it entirely.
+
+Check 0 exists because a worktree branch created from `origin/main` *tracks*
+`origin/main`, and with `push.default=tracking` git resolves the destination
+from the upstream rather than the branch name — so `git push -u origin
+my-branch` lands on `main`. That has happened twice here. Push with an explicit
+refspec (`git push origin HEAD:refs/heads/<branch>`); to push to `main`
+deliberately, say so: `ALLOW_MAIN_PUSH=1 git push ...`.
+
+The server-side backstop for an uninstalled hook is
+`.github/workflows/main-push-audit.yaml`, which flags a commit that reached
+`main` without a PR. It is detection after the fact, not prevention.
 
 ### Architecture rules
 


### PR DESCRIPTION
**Regression I introduced.** Refs #541.

`.githooks/pre-push` **already existed** — blob `70294f159`, 105 lines, added in `df5949b3a` *"docs: add AGENTS.md and pre-push quality gates"*. #546 wrote a new file at that path and replaced it wholesale, silently deleting five checks:

1. Tag format — `v*` tags must carry `-evr.<N>`
2. `gofmt` on changed files
3. `go vet ./server/...`
4. `gopls` diagnostics
5. `go mod tidy` drift

I did not read the target before writing it. `AGENTS.md` documented the hook and its five checks the entire time and I never opened it. The `mkdir -p .githooks` I ran should have been the tell that I was assuming the directory was mine to create.

This restores the original and re-adds the main-destination guard as **phase 0 of it**, rather than instead of it.

## Found while restoring: the tag gate has never worked

Phase 1 piped `PUSH_REFS` into `while read`, which runs the loop in a **subshell** — so every `fail_count` increment landed in a copy and the summary always saw zero. The gate printed its rejection and exited 0.

Demonstrated against the original file:

```
$ printf refs/tags/v3.27.2 ... | orig-hook
  ✗ Tag v3.27.2 rejected — EVR releases use v3.27.2-evr.<N>
EXIT=0        ← push allowed anyway
```

It reported without preventing. Both loops now read from a here-string.

## Verification, every phase

| | | |
|---|---|---|
| T1 | push resolving to `main` | `EXIT=1` refused |
| T2 | feature push | `EXIT=0` allowed |
| T3 | `ALLOW_MAIN_PUSH=1` to main | `EXIT=0` allowed |
| T4 | bad tag `v3.27.2` | `EXIT=1` refused — **was 0** |
| T5 | good tag `v3.27.2-evr.5` | `EXIT=0` allowed |

## Notes for review

- Phase 0 uses explicit `if` rather than `[ test ] && continue`. Under `set -e`, whether a false trailing AND-list aborts the hook depends on shell version and position — not something a guard should rest on.
- `AGENTS.md` now lists check 0 **and what the hook does not cover**: it is off until installed, that failure mode is silent, and `git push --no-verify` skips it entirely.
- Left alone deliberately: phase 2 prints a bare SHA from `git rev-parse --verify ORIG_HEAD` (stdout not redirected). Cosmetic, pre-existing, outside this fix.