### PR TITLE
fix(alts): search the machine fingerprint, not only compare it

### DIFF
--- a/server/evr_authenticate_alts.go
+++ b/server/evr_authenticate_alts.go
@@ -14,13 +14,32 @@ type AlternateSearchMatch struct {
 	Items       []string `json:"items"`
 }
 
+// AltSearchPatterns returns the keys used to DISCOVER candidate alternate
+// accounts in the login-cache index.
+//
+// These must stay in step with the keys rebuildCache writes into the indexed
+// `cache` field (LoginHistoryEntry.Items) and with the keys loginHistoryCompare
+// forms edges on. A key that is written and compared but never searched is
+// inert: the comparison only ever runs against candidates this query already
+// returned, so an account whose ONLY overlap with a banned account is that key
+// is never surfaced, never compared, and produces zero edges.
+//
+// SystemProfile was in exactly that state — captured in Items, indexed, and
+// compared, but absent here. A cheater rotating IP, HMD serial and XPID (all
+// trivially changed) kept the same machine and linked to nothing. That is #516.
 func (h *LoginHistory) AltSearchPatterns() []string {
-	items := make([]string, 0, len(h.History)*3+len(h.XPIs))
+	items := make([]string, 0, len(h.History)*4+len(h.XPIs))
 	for _, e := range h.History {
 		for _, s := range [...]string{
 			e.ClientIP,
 			e.LoginData.HMDSerialNumber,
 			e.XPID.Token(),
+			// The machine fingerprint. Rotating an account does not rotate the
+			// hardware. Commodity profiles (Quest headsets, and any profile with
+			// no hardware identity at all) are dropped by matchIgnoredAltPattern
+			// below, so this adds a discovery key only where it is a fingerprint
+			// rather than a bucket.
+			e.SystemProfile(),
 		} {
 			items = append(items, s)
 		}

--- a/server/evr_authenticate_alts_test.go
+++ b/server/evr_authenticate_alts_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -291,6 +292,201 @@ func TestFilterStrongAlts(t *testing.T) {
 			slices.Sort(tt.want)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterStrongAlts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #516 — the machine fingerprint must be a DISCOVERY key, not only a
+// comparison key.
+// ---------------------------------------------------------------------------
+
+// profileString joins system-profile components exactly the way
+// LoginHistoryEntry.SystemProfile does. Building the expected strings from
+// their parts rather than typing them out is deliberate: the separator is "::"
+// and several components are empty, so a hand-written literal turns into a run
+// of colons that is trivial to miscount — and a test asserting the wrong string
+// fails for a reason that has nothing to do with the behaviour under test.
+func profileString(components ...string) string {
+	if len(components) != systemProfileComponents {
+		panic("profileString: wrong component count")
+	}
+	return strings.Join(components, "::")
+}
+
+// richSystemInfo is a desktop profile with real hardware strings: the kind of
+// fingerprint that identifies one machine rather than a class of them.
+func richSystemInfo() evr.SystemInfo {
+	return evr.SystemInfo{
+		HeadsetType:        "Valve Index",
+		NetworkType:        "Wired",
+		VideoCard:          "NVIDIA GeForce RTX 4080",
+		CPUModel:           "AMD Ryzen 9 7950X 16-Core Processor",
+		NumPhysicalCores:   16,
+		NumLogicalCores:    32,
+		MemoryTotal:        68719476736,
+		DedicatedGPUMemory: 17179869184,
+	}
+}
+
+// TestAltSearchPatterns_IncludesSystemProfile is the direct regression test for
+// #516: the fingerprint has to appear among the keys the index is queried with.
+func TestAltSearchPatterns_IncludesSystemProfile(t *testing.T) {
+	entry := &LoginHistoryEntry{
+		XPID:     evr.EvrId{PlatformCode: evr.OVR, AccountId: 27670},
+		ClientIP: "45.33.90.154",
+		LoginData: &evr.LoginProfile{
+			HMDSerialNumber: "WMHD3157200FJE",
+			SystemInfo:      richSystemInfo(),
+		},
+	}
+	h := &LoginHistory{
+		userID:  "user-a",
+		History: map[string]*LoginHistoryEntry{entry.Key(): entry},
+	}
+
+	patterns := h.AltSearchPatterns()
+	want := entry.SystemProfile()
+	if !slices.Contains(patterns, want) {
+		t.Errorf("AltSearchPatterns() omits the system profile %q; got %v", want, patterns)
+	}
+}
+
+// TestAltSearchPatterns_RotatedIdentifiersStillDiscoverable is the defect as
+// reported. Two accounts share nothing but the machine: different IP, different
+// HMD serial, different XPID — every key a cheater can rotate by hand.
+//
+// Discoverability is asserted the way the index actually decides it. The query
+// in LoginAlternatePatternSearch is `+value.cache:<patterns>` against the
+// indexed `cache` field, so the other account is returned iff one of this
+// account's search patterns appears in that account's rebuilt cache. Anything
+// the query does not return is never passed to loginHistoryCompare, so it can
+// never form an edge no matter what loginHistoryCompare would have concluded.
+func TestAltSearchPatterns_RotatedIdentifiersStillDiscoverable(t *testing.T) {
+	sysinfo := richSystemInfo()
+
+	bannedEntry := &LoginHistoryEntry{
+		XPID:      evr.EvrId{PlatformCode: evr.OVR, AccountId: 11111},
+		ClientIP:  "45.33.90.154",
+		UpdatedAt: time.Now(),
+		LoginData: &evr.LoginProfile{
+			HMDSerialNumber: "SERIAL-OLD",
+			SystemInfo:      sysinfo,
+		},
+	}
+	banned := &LoginHistory{
+		userID:  "banned-user",
+		History: map[string]*LoginHistoryEntry{bannedEntry.Key(): bannedEntry},
+	}
+	banned.rebuildCache()
+
+	// The burner: same machine, every hand-rotatable identifier changed.
+	burnerEntry := &LoginHistoryEntry{
+		XPID:      evr.EvrId{PlatformCode: evr.OVR, AccountId: 22222},
+		ClientIP:  "198.51.100.7",
+		UpdatedAt: time.Now(),
+		LoginData: &evr.LoginProfile{
+			HMDSerialNumber: "SERIAL-NEW",
+			SystemInfo:      sysinfo,
+		},
+	}
+	burner := &LoginHistory{
+		userID:  "burner-user",
+		History: map[string]*LoginHistoryEntry{burnerEntry.Key(): burnerEntry},
+	}
+
+	// Guard the premise: if the two accounts shared a rotatable key, this test
+	// would pass for the wrong reason.
+	for _, shared := range []string{bannedEntry.ClientIP, bannedEntry.LoginData.HMDSerialNumber, bannedEntry.XPID.Token()} {
+		if slices.Contains(burner.AltSearchPatterns(), shared) {
+			t.Fatalf("premise broken: the two accounts share rotatable key %q", shared)
+		}
+	}
+
+	var hits []string
+	for _, p := range burner.AltSearchPatterns() {
+		if slices.Contains(banned.Cache, p) {
+			hits = append(hits, p)
+		}
+	}
+	if len(hits) == 0 {
+		t.Fatalf("burner account is not discoverable from the banned account's index entry; "+
+			"search patterns %v matched nothing in cache %v", burner.AltSearchPatterns(), banned.Cache)
+	}
+
+	// And once discovered, an edge actually forms.
+	if matches := loginHistoryCompare(burner, banned); len(matches) == 0 {
+		t.Error("loginHistoryCompare formed no edge between accounts sharing a machine")
+	}
+}
+
+// TestAltSearchPatterns_ExcludesDegenerateSystemProfile guards the hazard the
+// fix introduces if left unguarded. Every account that logs in with no
+// SystemInfo produces the byte-identical profile string, so making the profile
+// a discovery key without this filter would make every profile-less account a
+// candidate alt of every other one.
+func TestAltSearchPatterns_ExcludesDegenerateSystemProfile(t *testing.T) {
+	newHistory := func(userID string, accountID uint64, ip string) *LoginHistory {
+		e := &LoginHistoryEntry{
+			XPID:      evr.EvrId{PlatformCode: evr.OVR, AccountId: accountID},
+			ClientIP:  ip,
+			UpdatedAt: time.Now(),
+			LoginData: &evr.LoginProfile{HMDSerialNumber: "SERIAL-" + userID},
+		}
+		h := &LoginHistory{userID: userID, History: map[string]*LoginHistoryEntry{e.Key(): e}}
+		h.rebuildCache()
+		return h
+	}
+
+	a := newHistory("user-a", 1, "45.33.90.154")
+	b := newHistory("user-b", 2, "198.51.100.7")
+
+	// Both produce the same empty profile — that is the point.
+	degenerate := profileString("Unknown", "", "", "", "0", "0", "0", "0")
+	for name, h := range map[string]*LoginHistory{"a": a, "b": b} {
+		for _, e := range h.History {
+			if got := e.SystemProfile(); got != degenerate {
+				t.Fatalf("premise broken: account %s profile is %q, expected the degenerate %q", name, got, degenerate)
+			}
+		}
+		if slices.Contains(h.AltSearchPatterns(), degenerate) {
+			t.Errorf("account %s searches on the degenerate profile %q", name, degenerate)
+		}
+		if slices.Contains(h.Cache, degenerate) {
+			t.Errorf("account %s indexes the degenerate profile %q", name, degenerate)
+		}
+	}
+
+	// Nothing links them: they share no machine and no rotatable key.
+	for _, p := range a.AltSearchPatterns() {
+		if slices.Contains(b.Cache, p) {
+			t.Errorf("unrelated accounts linked by %q", p)
+		}
+	}
+}
+
+func TestIsDegenerateSystemProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    bool
+	}{
+		{"no SystemInfo at all", profileString("Unknown", "", "", "", "0", "0", "0", "0"), true},
+		{"placeholder headset, numbers only", profileString("Unknown", "", "", "", "16", "32", "68719476736", "17179869184"), true},
+		{"empty headset, numbers only", profileString("", "", "", "", "16", "32", "68719476736", "17179869184"), true},
+		{"real desktop profile", profileString("Valve Index", "Wired", "NVIDIA GeForce RTX 4080", "AMD Ryzen 9 7950X 16-Core Processor", "16", "32", "68719476736", "17179869184"), false},
+		{"headset only", profileString("Meta Quest 3", "", "", "", "0", "0", "0", "0"), false},
+		{"network type only", profileString("Unknown", "Wireless", "", "", "0", "0", "0", "0"), false},
+		{"not a system profile — HMD serial", "WMHD3157200FJE", false},
+		{"not a system profile — IP", "45.33.90.154", false},
+		{"not a system profile — empty", "", false},
+		{"wrong component count", "a::b::c", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDegenerateSystemProfile(tt.pattern); got != tt.want {
+				t.Errorf("isDegenerateSystemProfile(%q) = %v, want %v", tt.pattern, got, tt.want)
 			}
 		})
 	}

--- a/server/evr_authenticate_history.go
+++ b/server/evr_authenticate_history.go
@@ -69,7 +69,47 @@ func matchIgnoredAltPattern(pattern string) bool {
 			return true
 		}
 	}
+	// Filter system profiles that carry no hardware identity.
+	if isDegenerateSystemProfile(pattern) {
+		return true
+	}
 	return false
+}
+
+// systemProfileComponents is the number of "::"-joined fields produced by
+// LoginHistoryEntry.SystemProfile. A string with any other count is not a
+// system profile and is left alone.
+const systemProfileComponents = 8
+
+// isDegenerateSystemProfile reports whether a system-profile string is present
+// but carries no hardware identity — every one of its four descriptive fields
+// (headset type, network type, video card, CPU model) is empty or the
+// normalizer's "Unknown" placeholder.
+//
+// This matters because such a profile is not rare, it is SHARED. Every account
+// that logs in without SystemInfo produces the byte-identical string
+// "Unknown::::::0::0::0::0". Left unfiltered it is not a fingerprint, it is a
+// bucket that every profile-less account falls into at once, and any code that
+// treats profile equality as evidence of shared hardware would link them all.
+//
+// The remaining four fields are numeric (core counts, memory sizes). They are
+// deliberately not enough to rescue a profile on their own: "8 cores, 32 GB"
+// describes a large share of the player base, so a profile identified only by
+// its numbers is still a bucket rather than a fingerprint.
+func isDegenerateSystemProfile(pattern string) bool {
+	parts := strings.Split(pattern, "::")
+	if len(parts) != systemProfileComponents {
+		return false
+	}
+	// parts[0:4] are headset type, network type, video card, CPU model.
+	for _, p := range parts[:4] {
+		// "Unknown" is what normalizeHeadsetType substitutes for an empty
+		// headset type, so it is an absent value wearing a name.
+		if p != "" && p != "Unknown" {
+			return false
+		}
+	}
+	return true
 }
 
 type LoginHistoryEntry struct {


### PR DESCRIPTION
Closes the linking half of #516.

## The defect

`system_profile` was captured (`LoginHistoryEntry.Items`), indexed (`rebuildCache` → the `cache` field → `index_login_cache`), and compared (`loginHistoryCompare`) — but it was **never searched on**. `AltSearchPatterns` built the index query from `ClientIP`, `HMDSerialNumber` and `XPID.Token()` only: exactly the three keys a cheater rotates by hand.

That asymmetry is the whole bug. `loginHistoryCompare` only ever runs against candidates the query already returned, so an account whose sole overlap with a banned account is *the machine it runs on* is never surfaced, never compared, and forms zero edges — which is what was observed on account #11 (`tanakron_.`, 2026-07-13): exact `system_profile` match to three accounts banned 26 minutes earlier, no link formed.

## The hazard the fix would have shipped with

Adding the profile to the discovery keys is **not safe on its own**. Every account that logs in without `SystemInfo` produces the byte-identical string `Unknown::::::::0::0::0::0`. That is not a rare fingerprint, it is a bucket that every profile-less account falls into together — and unguarded, this fix would have linked all of them to each other on its first run.

`isDegenerateSystemProfile` drops a profile whose four descriptive fields (headset type, network type, video card, CPU model) are all empty or the `Unknown` placeholder. It lives in `matchIgnoredAltPattern`, so it filters the index and the comparison as well as the query — the degenerate profile was already being written into every profile-less account's `cache`, inert only because nothing queried for it.

The numeric fields alone do not rescue a profile: "8 cores, 32 GB" describes a large share of the player base.

Commodity profiles (Quest headsets) were already handled by the existing `IsWeakSignal` prefix filter, which this inherits. Note that filter depends on `CommodityProfilePrefixes` being configured — unconfigured, a popular headset becomes a wide match. That was already true on the comparison side; this does not change it, but it now matters on the discovery side too.

## Proof

Both directions witnessed, not assumed:

| change | result |
|---|---|
| discovery change reverted | `TestAltSearchPatterns_RotatedIdentifiersStillDiscoverable` fails — burner patterns `[198.51.100.7 OVR-22222 SERIAL-NEW]` match nothing in the banned account's cache, which *does* contain the shared profile |
| degenerate guard disabled | `TestAltSearchPatterns_ExcludesDegenerateSystemProfile` fails — two unrelated profile-less accounts link to each other |
| both applied | green |

`gofmt` clean, `go vet ./server/...` clean, `go test -race -count=1 ./server/...` green (148.7s).

The discoverability test asserts the predicate the index actually uses (`+value.cache:<patterns>`): the other account is returned iff one of this account's search patterns appears in that account's rebuilt cache. No mock index, and it guards its own premise — it fails loudly if the two fixtures accidentally share a rotatable key.

## Deliberately not addressed

- **Removing `"N/A"` from `IgnoredLoginValues`** — rejected. A nulled HMD serial is shared by every account that nulls it, so treating it as a *linking key* mass-links strangers. Nulling the serial may well be a signal of evasion, but that is a detection rule, not a linking key, and it does not belong in this list.
- **First-sight reject/flag on a banned machine**, **subnet/ASN reuse as a link signal**, and the **Nakama- vs Discord-account-age gate** are enforcement policy rather than linking, and remain open on #516.