### PR TITLE
ci: bound test-suite memory at the compose layer

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,8 +13,61 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Fails fast if a service lost its memory limit in an edit. This only
+      # reads the file; whether the runtime HONOURED the key is a separate
+      # question, checked after the run below.
+      - name: Check memory limits are declared
+        run: |
+          set -euo pipefail
+          missing=0
+          for svc in db nakama test; do
+            limit="$(docker compose -f ./docker-compose-tests.yml config --format json \
+              | jq -r --arg s "$svc" '.services[$s].mem_limit // "null"')"
+            if [ "$limit" = "null" ] || [ "$limit" = "0" ]; then
+              echo "::error::service '$svc' declares no mem_limit in docker-compose-tests.yml"
+              missing=1
+            else
+              echo "$svc: mem_limit=$limit"
+            fi
+          done
+          exit "$missing"
+
       - name: Run tests
         run: docker compose -f ./docker-compose-tests.yml up --build --abort-on-container-exit
+
+      # Two jobs, both about not trusting silence.
+      #
+      # 1. An OOM kill surfaces as a bare exit 137 and reads as a mystery. Name
+      #    it, so an over-budget test is attributed instead of investigated.
+      # 2. Assert the limit was actually APPLIED. A memory key that the runtime
+      #    ignores yields a limit that does nothing plus a false sense of
+      #    coverage, and it fails the same way it succeeds — silently. The
+      #    authority is HostConfig.Memory on the container that just ran, not
+      #    the key in the file.
+      - name: Report container memory outcome
+        if: always()
+        run: |
+          set -uo pipefail
+          failed=0
+          for id in $(docker compose -f ./docker-compose-tests.yml ps -aq); do
+            read -r name limit oom code <<< "$(docker inspect \
+              -f '{{.Name}} {{.HostConfig.Memory}} {{.State.OOMKilled}} {{.State.ExitCode}}' "$id")"
+            echo "${name#/}: limit=${limit} oom_killed=${oom} exit=${code}"
+            if [ "$limit" = "0" ]; then
+              echo "::error::${name#/} ran with NO memory limit applied — the compose key was not honoured"
+              failed=1
+            fi
+            if [ "$oom" = "true" ] || [ "$code" = "137" ]; then
+              echo "::error::${name#/} was killed for exceeding its ${limit}-byte memory limit (exit ${code}). This is a memory budget failure, not an infrastructure flake."
+              failed=1
+            fi
+          done
+          # This step fails on an OOM in its own right rather than leaning on the
+          # run step above. `docker compose up --abort-on-container-exit` does
+          # propagate 137 today (verified), but that is version-dependent
+          # behaviour, and a guard that only reports while something else does
+          # the failing is one release away from being decoration.
+          exit "$failed"
 
       - name: Cleanup
         if: always()

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,8 +1,15 @@
+# Memory limits: see the `test` service below for the measurement they come
+# from and why they are stated as a pair (mem_limit + memswap_limit).
 services:
   db:
     container_name: db
     image: postgres:16.8-alpine
     command: -c 'max_connections=1000'
+    # An unbounded Postgres is the other route to exhausting the runner. This is
+    # generous for a test database — the suite's working set is small — and is
+    # here so a runaway query cannot take the runner down anonymously.
+    mem_limit: 2g
+    memswap_limit: 2g
     environment:
       - POSTGRES_DB=nakama
       - POSTGRES_PASSWORD=localdb
@@ -20,6 +27,9 @@ services:
       context: .
       dockerfile: ./build/Dockerfile
     image: nakama-tests
+    # The server under test: one Go process against a small dataset.
+    mem_limit: 2g
+    memswap_limit: 2g
     entrypoint:
       - "/bin/sh"
       - "-ecx"
@@ -42,6 +52,43 @@ services:
   test:
       image: "golang:1.25"
       command: /bin/sh -c "mkdir -p /nakama/internal/gopher-lua/_lua5.1-tests/libs/P1; go test -vet=off -v -race ./..."
+
+      # ---- Memory budget ----------------------------------------------------
+      #
+      # WHY: a test fixture with an unbounded producer goroutine reached 11.6 GB
+      # RSS and was still climbing after seven minutes. It OOM'd a developer
+      # machine twice, and because the kernel's machine-wide OOM killer picks by
+      # badness heuristic it killed unrelated processes while the runaway test
+      # kept going. The point of this cap is not hygiene, it is ATTRIBUTION: the
+      # test container is the only thing eligible to die, and it dies naming
+      # itself. Had that fixture been pushed, this job would otherwise have died
+      # as an opaque runner failure.
+      #
+      # THE VALUE: measured, not guessed. The full suite as this service runs it
+      # (`-race -v`, cold cache, `-p 4` to match the runner's 4 cores) peaks at
+      # 1.04 GiB aggregate across all parallel test binaries — read from cgroup
+      # v2 `memory.peak`, which is the sum actually resident, not
+      # `/usr/bin/time -v`'s max-of-any-single-child. 4g is ~4x that, and is the
+      # same number as GO_TEST_MEMORY_LIMIT in the justfile, so there is one
+      # budget to reason about rather than two.
+      #
+      # Caveat on the measurement, stated because it bounds what the number
+      # proves: DB-backed tests skipped in that run, and the `server` package's
+      # full-runtime tests cannot execute at all right now (they abort the test
+      # binary on a missing DISCORD_BOT_TOKEN). 1.04 GiB is therefore a floor.
+      # It is still four times below this cap, and the runaway it exists to
+      # catch was three times ABOVE the cap.
+      #
+      # HEADROOM: ubuntu-latest for public repositories is 4 cores / 16 GB. The
+      # three services here total 8 GB, leaving 8 GB for the runner agent and
+      # page cache.
+      #
+      # memswap_limit IS LOAD-BEARING and must equal mem_limit. Docker's default
+      # is to allow swap up to 2x mem_limit; with swap available the container
+      # thrashes for minutes before anything dies, which is the slow version of
+      # the failure this cap exists to make fast. Equal values mean no swap.
+      mem_limit: 4g
+      memswap_limit: 4g
 
       working_dir: "/nakama"
       environment:


### PR DESCRIPTION
Closes #526.

`test` 4g, `db` 2g, `nakama` 2g, each with `memswap_limit` equal to `mem_limit`.

## The limit value is measured

The suite as the `test` service runs it — `-race -v`, cold cache, `-p 4` to match the runner's 4 cores — peaks at **1.04 GiB aggregate**, read from cgroup v2 `memory.peak`. That instrument choice is load-bearing: `/usr/bin/time -v` reports the max of any *single* child, not the sum concurrently resident, which is what a container limit bounds.

`4g` is ~4x measured, and is the same number as `GO_TEST_MEMORY_LIMIT` in the `justfile`, so there is one budget to reason about rather than two. The runaway this exists to catch was at 11.6 GB and still climbing. Three services total 8 GB against `ubuntu-latest`'s 16 GB for public repositories (confirmed at implementation time).

**Caveat that bounds what the measurement proves:** DB-backed tests skipped in that run, and the `server` package's full-runtime tests cannot execute at all right now — see the blocker below. 1.04 GiB is a floor, not a ceiling. It is still 4x under the cap.

`memswap_limit` is not decoration. Docker's default allows swap up to 2x `mem_limit`; with swap available the container thrashes for minutes before anything dies, which is the slow version of the failure the cap exists to make fast. Same reasoning as `MemorySwapMax=0` in `scripts/go-test-limit.sh`.

## Two of the issue's premises did not survive checking

1. **The schema trap does not apply at this Compose version.** The issue warns that `deploy.resources.limits.memory` is silently ignored outside Swarm. Under Compose v5.3.1 *both* keys resolve and both are enforced — `HostConfig.Memory` set, container OOM-killed, exit 137. `mem_limit` is used anyway: it has the longer history of applying to `up`, and the cost of guessing wrong here is silent.
2. **`docker compose config` cannot verify the choice.** It is the verification the issue proposes, and it prints both keys happily — so it cannot distinguish an honoured key from an ignored one.

## So the workflow asks the runtime, not the file

Since the file cannot answer whether the limit is armed, a post-run step reads `HostConfig.Memory` off the containers that just ran and **fails the job if any ran with no limit applied**. An unarmed guard has to be loud: its failure mode is otherwise indistinguishable from success.

The same step names an OOM kill rather than leaving exit 137 to read as a mystery exit code. It fails in its own right rather than leaning on `--abort-on-container-exit` to propagate 137 — compose does propagate it today (verified), but that is version-dependent, and a guard that only reports while something else does the failing is one release away from decoration.

A cheap pre-flight step also fails fast if a service loses its `mem_limit` in a future edit.

## Proof

Planted the violation: `test` service with its command replaced by a memory hog, everything else unchanged.

```
wt526-test-1: limit=4294967296 oom_killed=true exit=137
::error::wt526-test-1 was killed for exceeding its 4294967296-byte memory limit (exit 137).
         This is a memory budget failure, not an infrastructure flake.
```

`actionlint` clean.

## Blocker found while measuring — not fixed here

This workflow cannot currently complete, for a reason unrelated to memory. With a database reachable, the `server` package aborts in **0.07s**:

```
FATAL  Error returned by InitModule function in Go module
       {"name": "evrRuntime", "error": "DISCORD_BOT_TOKEN is required but not set"}
```

`evr_runtime.go:107` returns an error when `DISCORD_BOT_TOKEN` is absent from the runtime env vars; that kills the whole test binary, so essentially no EVR test runs. `docker-compose-tests.yml` does not set it. `just test` does not hit this because without a DB those tests skip before constructing the runtime — so the gap is invisible from the local suite.

Separately, `internal/intents` `TestIntent_MarshalText` is **red on `main`** (`"storage"` vs `"storage_objects"`). `just test` only runs `./server/...`, so the repo's own gate structurally cannot see it.

Both are being filed as their own issues rather than folded in here.