### PR TITLE
build: arm the tracked git hooks from any just recipe

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -6,20 +6,27 @@
 # 2. Go quality: run fast checks on changed files
 #    (gofmt, go vet, gopls staticcheck)
 #
-# Install: git config core.hooksPath .githooks
+# Install: automatic on the first `just <recipe>`; or `just hooks`; or
+#          git config core.hooksPath .githooks
 # Skip:    git push --no-verify
 #
 # THIS HOOK IS OFF UNTIL ARMED, AND ITS FAILURE MODE IS SILENCE.
 #
 # core.hooksPath is local config and cannot be committed, so this file shipping
-# with the repo does not activate it. Until someone runs `just hooks` (or the
-# git config line above) in a given clone, git never looks here and pushes are
-# unguarded -- with no warning, since a hook that is not wired up is
-# indistinguishable from one that approved.
+# with the repo does not activate it. Until something sets that config in a
+# given clone, git never looks here and pushes are unguarded -- with no warning,
+# since a hook that is not wired up is indistinguishable from one that approved.
 #
-# That gap is not a rounding error: a fresh clone, a newly created worktree, and
-# an agent starting cold are all unarmed by default, and those are exactly the
-# situations phase 0 was built for.
+# The justfile now arms the clone whenever any recipe runs (see _HOOKS_ARMED
+# there), so in practice `just test` or `just nakama` is enough. That shrinks
+# the window; it does not close it. Git will not let a repository activate its
+# own hooks -- a clone that armed itself would be arbitrary code execution on
+# `git clone` -- so a clone that pushes without ever running a recipe is still
+# unguarded, permanently and by design.
+#
+# That residual gap is not a rounding error: a fresh clone, a newly created
+# worktree, and an agent starting cold are all unarmed until they run something,
+# and those are exactly the situations phase 0 was built for.
 #
 # Check whether it is armed:
 #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,12 +29,23 @@ The repo ships a pre-push hook in `.githooks/pre-push` that checks:
 4. `gopls` diagnostics on changed files
 5. `go mod tidy` hasn't drifted
 
-Install: `just hooks` (or `git config core.hooksPath .githooks`)
+Install: automatic — running any `just` recipe arms the clone. Explicitly:
+`just hooks` (or `git config core.hooksPath .githooks`).
 
 **The hook is off until installed, and that failure mode is silent** —
-`core.hooksPath` is local config and cannot be committed, so a fresh clone or a
-newly created worktree is unguarded with no warning. Check with
-`git config --get core.hooksPath`. `git push --no-verify` also skips it entirely.
+`core.hooksPath` is local config and cannot be committed, so nothing in the
+repository can activate it on its own. Git refuses that deliberately: a clone
+that armed its own hooks would be arbitrary code execution on `git clone`.
+
+So the auto-arm shrinks the window rather than closing it. **If you clone and
+push without running a single `just` recipe, you are unguarded.** `just --list`
+does not count — just evaluates variables lazily and `--list` does not trigger
+them. Check with `git config --get core.hooksPath`; it must print `.githooks`.
+`git push --no-verify` also skips the hook entirely.
+
+The backstop for everything the hook cannot cover is
+`.github/workflows/main-push-audit.yaml`, which is server-side and arms itself —
+but detects after the push has landed rather than preventing it.
 
 Check 0 exists because a worktree branch created from `origin/main` *tracks*
 `origin/main`, and with `push.default=tracking` git resolves the destination

--- a/justfile
+++ b/justfile
@@ -114,17 +114,73 @@ test-db:
 # opinionated.
 FMT_FILES := "git ls-files '*.go' | xargs grep -LE 'Code generated .* DO NOT EDIT'"
 
-# Point git at the repo's tracked hooks (.githooks). One-time, per clone.
+# ---------------------------------------------------------------------------
+# Hook arming.
 #
-# core.hooksPath is local config and cannot be committed, so a tracked hooks
-# directory does not activate itself -- this recipe is the activation step. Run
-# it once per clone; linked worktrees inherit it from the parent repo.
+# `.githooks/pre-push` ships with the repo but does NOT activate itself.
+# core.hooksPath is local config and cannot be committed, so until something
+# sets it, git never looks at .githooks and every push is unguarded -- with no
+# warning, because a hook that is not wired up is indistinguishable from one
+# that approved. A fresh clone, a newly created worktree, and an agent starting
+# cold are all unarmed by default, which is exactly the population the
+# destination guard exists for.
 #
-# Installs the pre-push guard that refuses a push resolving to main. See
-# .githooks/pre-push for why that guard exists and how to override it.
+# just evaluates variables before running any recipe, so this arms the clone on
+# the first `just <anything that runs>` -- `just test`, `just nakama`,
+# `just fmt`. The unguarded window shrinks from "until someone reads AGENTS.md
+# and runs a git config command" to "until someone runs one just recipe", and
+# running a recipe is the first thing anyone working here does.
+#
+# IT DOES NOT CLOSE THE WINDOW, AND NOTHING CAN. Git deliberately refuses to let
+# a repository activate its own hooks: a clone that armed itself would be
+# arbitrary code execution on `git clone`. That is a security boundary, not an
+# oversight, so "the hook arms itself" is not achievable at any level of effort
+# -- only "the hook is armed earlier, by something the user already runs".
+# Whoever clones and pushes without ever running a recipe is still unguarded.
+# The self-arming backstop for that case is
+# .github/workflows/main-push-audit.yaml, which is server-side and cannot be
+# skipped -- but detects after the push has landed rather than preventing it.
+#
+# `just --list` alone does NOT arm: just evaluates variables lazily and --list
+# does not trigger them (verified, just 1.57). That is acceptable -- --list does
+# not push anything.
+#
+# Backticks run with the working directory set to the justfile's directory
+# regardless of where just was invoked from, and regardless of -f (verified,
+# just 1.57), so this cannot arm the wrong repository.
+#
+# Opt out with NAKAMA_NO_AUTO_HOOKS=1. Every failure path here is non-fatal: a
+# missing git, or a directory that is not a repository, must never break
+# `just test`.
+_HOOKS_ARMED := ```
+    if [ -n "${NAKAMA_NO_AUTO_HOOKS:-}" ]; then
+        echo opted-out
+    elif [ ! -x .githooks/pre-push ]; then
+        # Nothing to point at, or it is not executable. Git skips a
+        # non-executable hook SILENTLY, so arming toward one would install the
+        # appearance of a guard without the guard. See exec-bit-check.
+        echo unavailable
+    elif [ "$(git config --get core.hooksPath 2>/dev/null || true)" = ".githooks" ]; then
+        echo armed
+    elif git config core.hooksPath .githooks 2>/dev/null; then
+        # Announced once, on the run that changes it, and silent forever after.
+        echo "git hooks armed: core.hooksPath -> .githooks (pre-push guards now active)" >&2
+        echo armed
+    else
+        echo unavailable
+    fi
+```
+
+# Point git at the repo's tracked hooks (.githooks) and report the result.
+#
+# Recipes arm the clone on their own (see _HOOKS_ARMED above). This recipe
+# remains the explicit form: it is what to run after NAKAMA_NO_AUTO_HOOKS, what
+# to point someone at, and what answers "is this clone guarded?" without having
+# to infer it from silence.
 hooks:
     @git config core.hooksPath .githooks
     @echo "core.hooksPath -> $(git config --get core.hooksPath)"
+    @echo "auto-arm status: {{ _HOOKS_ARMED }}"
 
 # Format all non-generated Go sources in place (prints the files it rewrote)
 fmt:


### PR DESCRIPTION
Closes #557 (split out of #541, which is closed on its own record).

Note for whoever merges: the commit message body still reads `Closes #541`. That is left as-is deliberately — the work did originate from #541 and the line is historically accurate — and it is a no-op, since #541 is already closed. This PR body is the authoritative close target.

## The gap

The pre-push guard shipped with the repo and did not turn itself on. Until `core.hooksPath` was set by hand, git never looked at `.githooks` and every push was unguarded — silently, because an unwired hook is indistinguishable from one that approved. A fresh clone, a newly created worktree, and an agent starting cold were all unarmed, which is precisely the population the destination guard exists for.

I was in that population when I picked this up: this clone had `core.hooksPath` pointing at `.git/hooks` and `push.default = tracking`.

## What changed

`_HOOKS_ARMED` in the `justfile`. just evaluates variables before running a recipe, so the clone arms on the first `just test`, `just nakama`, `just fmt` — whatever anyone runs first. The window shrinks from *"until someone reads AGENTS.md and runs a git config command"* to *"until someone runs one recipe"*.

## The window does not close, and it cannot

Git refuses to let a repository activate its own hooks. A clone that armed itself would be arbitrary code execution on `git clone` — that is a security boundary, not an oversight. So **"the hook arms itself" is unreachable at any level of effort**; only "the hook is armed earlier, by something the user already runs" is available.

Clone and push without running a recipe and you are still unguarded. That residual is now written down as **permanent** in `AGENTS.md` and in the hook's own header, rather than left looking like an unfinished to-do. The self-arming backstop for it remains `main-push-audit.yaml` — server-side, unskippable, and post-hoc.

This is the "or document the limitation as permanent" half of the issue, answered honestly: both halves apply. The part that could be mechanised is mechanised; the part that cannot is labelled.

## Behaviour established by measurement (just 1.57)

- Backticks run with the working directory set to the justfile's directory regardless of where just was invoked from or whether `-f` was used — so this cannot arm the wrong repository.
- `{{...}}` does **not** interpolate inside backticks, so the guard is plain shell.
- `just --list` does **not** evaluate variables and so does not arm. Acceptable — `--list` pushes nothing — and now documented rather than assumed in either direction.

Non-fatal on every path: a missing git or a non-repository directory must never break `just test`. `NAKAMA_NO_AUTO_HOOKS=1` opts out. Arming toward a *non-executable* hook is refused, since git skips one of those silently and that would install the appearance of a guard without the guard.

## Proof

Not "the code looks right" — a genuinely fresh `git clone`, then the planted violation.

```
core.hooksPath before any recipe: '<UNSET>'
just --list                    -> core.hooksPath = '<UNSET>'     (must not arm)
just fmt-check                 -> git hooks armed: core.hooksPath -> .githooks
                                  core.hooksPath = '.githooks'
just fmt-check (again)         -> notice does not repeat
```

Then the exact #541 mechanism — worktree branch tracking `origin/main`, `push.default=tracking`:

```
branch=feature/some-fix upstream=origin/main push.default=tracking

A. git push -u origin feature/some-fix          EXIT=1
   ✗ This push resolves to main (source: refs/heads/feature/some-fix)
         push.default is 'tracking'
         and this branch's upstream is 'origin/main'.
         git took the destination from the upstream, not the branch name.
   ── 1 check(s) failed — push rejected ──

B. git push origin HEAD:refs/heads/feature/some-fix    EXIT=0
   * [new branch]          HEAD -> feature/some-fix
```

Both directions, because a gate that blocks everything is as broken as one that blocks nothing.

One unplanned confirmation: while building the harness, the hook refused *my own* setup push seeding a test remote's `main`. It fired on a push I had not thought of as dangerous — which is the exact failure mode #541 describes — and seeding it required stating `ALLOW_MAIN_PUSH=1` deliberately, which is the escape hatch working as designed.
