### PR TITLE
fix(intents): correct the wire token, and gate the packages that hide it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Key requirements for any agent (including heisthecat31 or any AI assistant):
 gofmt -l -w    # format
 go vet ./...   # static analysis
 golangci-lint run  # comprehensive lint
-go test -race ./server/...  # tests with race detector
+just test      # tests -- repo-wide scope, see TEST_PKGS in the justfile
 go fix ./...   # apply modernizers
 go mod tidy    # clean dependencies
 govulncheck    # vulnerability check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,12 @@ This applies regardless of context — even if the task seems to require deploym
 ## Build
 
 - Go project: `just nakama` builds the binary locally
-- Tests: `just test` (DB-free suite; no CockroachDB or Discord bot token needed) or `go test ./server/...`
+- Tests: `just test` (DB-free suite; no CockroachDB or Discord bot token needed)
 - Full suite including DB-backed tests: `just test-db` (requires a reachable database at `TEST_DB_URL`)
+- Test scope is every package except the vendored `internal/gopher-lua` — see
+  `TEST_PKGS` in the `justfile` for what that exclusion costs and why. Prefer the
+  recipes over a hand-written `go test ./server/...`, which silently skips
+  `internal/`
 - Docker image build (local only, no push): `just build` — FORBIDDEN without explicit approval, see above
 
 ## Tests — per-test-binary memory cap

--- a/internal/intents/intents_test.go
+++ b/internal/intents/intents_test.go
@@ -1,6 +1,7 @@
 package intents
 
 import (
+	"reflect"
 	"strconv"
 	"testing"
 )
@@ -27,14 +28,16 @@ func TestIntent_MarshalText(t *testing.T) {
 			want:   strconv.QuoteToASCII("matches"),
 		},
 		{
+			// "storage", not "storage_objects": the token is the struct tag,
+			// and the tag is the wire vocabulary. See TestIntent_TextRoundTrip.
 			name:   "StorageObjectsTrue",
 			intent: Intent{StorageObjects: true},
-			want:   strconv.QuoteToASCII("storage_objects"),
+			want:   strconv.QuoteToASCII("storage"),
 		},
 		{
 			name:   "MultipleTrue",
 			intent: Intent{GuildMatches: true, Matches: true, StorageObjects: true},
-			want:   strconv.QuoteToASCII("guild_matches,matches,storage_objects"),
+			want:   strconv.QuoteToASCII("guild_matches,matches,storage"),
 		},
 		{
 			name:   "TwoTrue",
@@ -54,4 +57,109 @@ func TestIntent_MarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIntent_TextRoundTrip is the reason MarshalText emits "storage" and not
+// "storage_objects", and it exists so that answer stops depending on someone
+// remembering it.
+//
+// UnmarshalText is a live wire path: evr_runtime_rpc.go parses a
+// caller-supplied IntentStr with it. Both directions read the same `json`
+// struct tags, so the tags -- not the Go field names -- are the vocabulary.
+// Emitting a token the parser cannot read back would silently drop the intent,
+// and a dropped intent is a permission that quietly fails to be granted.
+//
+// Every field is covered by construction, so a field added without a tag, or
+// with a tag the other direction does not recognise, fails here.
+func TestIntent_TextRoundTrip(t *testing.T) {
+	typ := reflect.TypeOf(Intent{})
+
+	for idx := 0; idx < typ.NumField(); idx++ {
+		field := typ.Field(idx)
+		t.Run(field.Name, func(t *testing.T) {
+			if field.Tag.Get("json") == "" {
+				t.Fatalf("field %s has no json tag; MarshalText would drop it silently", field.Name)
+			}
+
+			var want Intent
+			reflect.ValueOf(&want).Elem().Field(idx).SetBool(true)
+
+			text, err := want.MarshalText()
+			if err != nil {
+				t.Fatalf("MarshalText() error = %v, want nil", err)
+			}
+
+			var got Intent
+			if err := got.UnmarshalText(text); err != nil {
+				t.Fatalf("UnmarshalText(%s) error = %v, want nil", text, err)
+			}
+			if got != want {
+				t.Errorf("round trip through %s = %+v, want %+v", text, got, want)
+			}
+		})
+	}
+
+	t.Run("AllFieldsAtOnce", func(t *testing.T) {
+		want := Intent{}
+		v := reflect.ValueOf(&want).Elem()
+		for idx := 0; idx < v.NumField(); idx++ {
+			v.Field(idx).SetBool(true)
+		}
+
+		text, err := want.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText() error = %v, want nil", err)
+		}
+
+		var got Intent
+		if err := got.UnmarshalText(text); err != nil {
+			t.Fatalf("UnmarshalText(%s) error = %v, want nil", text, err)
+		}
+		if got != want {
+			t.Errorf("round trip through %s = %+v, want %+v", text, got, want)
+		}
+	})
+}
+
+// TestIntent_UnmarshalText_WireVocabulary pins the exact tokens a caller may
+// send, because callers are outside this repository and cannot be migrated by
+// editing it. Renaming a tag is a breaking wire change and must fail here.
+func TestIntent_UnmarshalText_WireVocabulary(t *testing.T) {
+	tests := []struct {
+		token string
+		want  Intent
+	}{
+		{"guild_matches", Intent{GuildMatches: true}},
+		{"matches", Intent{Matches: true}},
+		{"storage", Intent{StorageObjects: true}},
+		{"global_bot", Intent{IsGlobalBot: true}},
+		{"global_operator", Intent{IsGlobalOperator: true}},
+		{"global_developer", Intent{IsGlobalDeveloper: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.token, func(t *testing.T) {
+			var got Intent
+			if err := got.UnmarshalText([]byte(tt.token)); err != nil {
+				t.Fatalf("UnmarshalText(%q) error = %v, want nil", tt.token, err)
+			}
+			if got != tt.want {
+				t.Errorf("UnmarshalText(%q) = %+v, want %+v", tt.token, got, tt.want)
+			}
+		})
+	}
+
+	// An unrecognised token grants nothing rather than granting something
+	// adjacent. "storage_objects" is here specifically: it is the Go field
+	// name, it is what the old test expected, and a caller sending it gets
+	// no storage access.
+	t.Run("UnknownTokenGrantsNothing", func(t *testing.T) {
+		var got Intent
+		if err := got.UnmarshalText([]byte("storage_objects")); err != nil {
+			t.Fatalf("UnmarshalText() error = %v, want nil", err)
+		}
+		if got != (Intent{}) {
+			t.Errorf("UnmarshalText(\"storage_objects\") = %+v, want zero Intent", got)
+		}
+	})
 }

--- a/justfile
+++ b/justfile
@@ -73,18 +73,53 @@ bench-compare:
 bench-check: bench-compare
     @echo "Benchmark regression check passed"
 
+# ---------------------------------------------------------------------------
+# Test scope.
+#
+# These recipes used to run `./server/...`, which meant `internal/` was covered
+# by NO routine gate. That is not a theoretical hole: `TestIntent_MarshalText`
+# sat red on main and nobody got a red signal, because nothing anyone runs
+# executed the package (#554).
+#
+# The scope is now discovered rather than enumerated, so a package added under
+# internal/ tomorrow is gated tomorrow, without anyone remembering to add it.
+#
+# internal/gopher-lua is the one exclusion, and it is vendored third-party code
+# rather than ours. Including it would cost more than it is worth, measured:
+#
+#   1. `go test` runs a subset of vet, and gopher-lua has 19 non-constant-format
+#      -string findings, so the package does not even BUILD under test. Covering
+#      it means `-vet=off`, which would disable printf/atomic/bool/... checks on
+#      OUR code in order to accommodate vendored code. That is turning a
+#      fail-closed control off to keep a green light on.
+#   2. Its Lua 5.1 conformance suite needs a fixture directory
+#      (_lua5.1-tests/libs/) that git cannot track because it is empty on
+#      checkout, so the suite is red on a fresh clone until someone mkdirs it.
+#
+# docker-compose-tests.yml already carries both workarounds (`-vet=off` and a
+# volume for that directory), so gopher-lua is covered there and only there.
+# Excluded here, deliberately and visibly -- not silently dropped.
+#
+# The trailing fallback is load-bearing. If `go list` fails or the filter ever
+# matches everything, the substitution is empty -- and `go test -count=1` with
+# no package arguments does not error, it tests the current directory, which is
+# a package with no test files. That is a green run over nothing: the exact
+# failure mode this scope change exists to remove. Substituting a path that
+# cannot exist turns that silence into a hard, self-naming failure.
+TEST_PKGS := "$(go list ./... | grep -v '/internal/gopher-lua' | grep . || echo ./TEST_PKGS_MATCHED_NO_PACKAGES)"
+
 # Needs no CockroachDB and no Discord bot token: tests that require a database
 # skip themselves when none is reachable.
 
-# Run the DB-free server test suite
+# Run the DB-free test suite
 test:
     GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
-        go test ./server/... -count=1
+        go test {{ TEST_PKGS }} -count=1
 
 # Run the DB-free suite with verbose output.
 test-verbose:
     GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
-        go test -v ./server/... -count=1
+        go test -v {{ TEST_PKGS }} -count=1
 
 # Requires a reachable CockroachDB/Postgres at TEST_DB_URL. TEST_DB_REQUIRED
 # makes an unreachable database a hard failure instead of a silent skip, so this
@@ -94,7 +129,7 @@ test-verbose:
 test-db:
     TEST_DB_URL="{{ TEST_DB_URL }}" TEST_DB_REQUIRED=1 \
         GOFLAGS="${GOFLAGS:-} {{ TEST_LIMIT_FLAG }}" GO_TEST_MEMORY_LIMIT="{{ GO_TEST_MEMORY_LIMIT }}" \
-        go test ./server/... -count=1
+        go test {{ TEST_PKGS }} -count=1
 
 # Formatting.
 # Scope is repo-wide: every *tracked* Go file except generated sources.


### PR DESCRIPTION
Closes #554. Both halves — the red test and the gate that could not see it — because either one alone leaves the other live.

## The test was wrong, not the implementation

The issue left this open deliberately: *"changing the implementation is a wire-format change and changing the test is not."* The evidence says the test.

`UnmarshalText` is **a live wire path**. `evr_runtime_rpc.go:1195` parses a caller-supplied `IntentStr` with it:

```go
sessionVars.Intents.UnmarshalText([]byte(request.IntentStr))
```

Both directions read the same `json` struct tags, so the **tags are the vocabulary** — not the Go field names. Making `MarshalText` emit `storage_objects` would emit a token its own parser drops on the floor, and a dropped intent is a permission that quietly fails to be granted. The tag is also the public contract: callers live outside this repository and cannot be migrated by editing it.

Nothing in the repo — Go, JS, JSON, or docs — contains the string `storage_objects` outside that test.

## Two sensors, so the answer stops depending on remembering it

- **`TestIntent_TextRoundTrip`** walks every field by reflection. A field added without a tag, or with a tag the two directions disagree on, fails by construction rather than by someone noticing.
- **`TestIntent_UnmarshalText_WireVocabulary`** pins the six accepted tokens literally, including that `storage_objects` grants *nothing*.

**Proven by mutation, not assumed.** Flipping the tag back to `json:"storage_objects"`:

```
--- FAIL: TestIntent_MarshalText/StorageObjectsTrue
--- FAIL: TestIntent_MarshalText/MultipleTrue
--- FAIL: TestIntent_UnmarshalText_WireVocabulary/storage
--- FAIL: TestIntent_UnmarshalText_WireVocabulary/UnknownTokenGrantsNothing
```

Stated honestly: the round-trip test does *not* catch that mutation, and is not meant to — it is tag-symmetric by construction, so it guards asymmetry while the vocabulary test guards renames. Two different failures, two sensors.

## The gate half

Every test recipe scoped to `./server/...`, so `internal/` was covered by **no routine gate** and a red test there produced no red signal for however long it sat. Scope is now discovered rather than enumerated, so a package added under `internal/` tomorrow is gated tomorrow. **CI already runs `just test`, so this needs no workflow change.**

Coverage goes from 2 packages to 22.

## The one exclusion, visible rather than silent

`internal/gopher-lua` is excluded. It is vendored third-party code and covering it would cost more than it is worth — measured:

1. It **does not build under `go test`**: 19 non-constant-format-string vet findings. Covering it means `-vet=off`, which disables printf/atomic/bool checks on **our** code to accommodate vendored code — turning a fail-closed control off to keep a green light on.
2. Its Lua 5.1 conformance suite needs `_lua5.1-tests/libs/`, a directory git cannot track because it is empty on checkout, so it is red on a fresh clone until someone `mkdir`s it.

`docker-compose-tests.yml` already carries both workarounds (`-vet=off` and a volume for that directory), so gopher-lua is covered there and only there. Confirmed locally: with the fixture dir present and vet off, it passes.

## Measured

| | |
|---|---|
| old gate (`./server/...`) | 2:25 |
| new gate (22 packages) | 2:13 |

No added wall-clock — `internal/` runs in parallel with `server`. Full run green.

## The vacuous-pass guard

`go test -count=1` **with no package arguments does not error** — it tests the current directory, which is a package with no test files, and reports success. A `go list` failure or an over-matching filter would therefore produce a green run over nothing: the exact failure mode this scope change exists to remove. An empty list now substitutes `./TEST_PKGS_MATCHED_NO_PACKAGES`, which cannot exist, turning that silence into a hard self-naming failure. Verified: exit 1.

## Not fixed here

`internal/gopher-lua` remains red on its own terms (19 vet findings, missing fixture dir). It is vendored upstream code and fixing it is a separate call from this issue — recorded rather than dropped.

Co-authored-by: Andrew Bates <a@sprock.io>