### PR TITLE
fix(test): stop the EVR module fatal from killing the server test binary

### DIFF
--- a/server/runtime_test.go
+++ b/server/runtime_test.go
@@ -104,7 +104,24 @@ func runtimeWithModulesWithData(t *testing.T, modules map[string]string) (*Runti
 	tracker := &LocalTracker{sessionRegistry: sessionRegistry}
 	statusRegistry := NewLocalStatusRegistry(logger, cfg, sessionRegistry, protojsonMarshaler)
 
+	// See disableEvrRuntimeModules: without this the EVR InitModule fails on the
+	// missing DISCORD_BOT_TOKEN and runtime_go.go escalates that to a zap fatal,
+	// os.Exit-ing the whole test binary.
+	//
+	// This harness is the reason the `server` package died in 0.07s whenever a
+	// database was reachable (#553). Without a database NewDB(t) skips first, so
+	// nothing here is ever reached and the package looks green -- which is why
+	// the failure was invisible locally and appeared only in the one
+	// configuration nobody was running.
+	//
+	// These are upstream Nakama tests. They construct a full runtime because
+	// that is what the API surface they exercise needs; none of them wants the
+	// EVR module, so disabling it costs no coverage here. What the EVR
+	// InitModule itself does with a real database remains untested -- that is a
+	// separate gap, not one this closes.
+	restoreEvrModules := disableEvrRuntimeModules()
 	rt, rtInfo, err := NewRuntime(ctx, logger, logger, db, protojsonMarshaler, protojsonUnmarshaler, cfg, "", nil, lbCache, lbRankCache, lbSched, sessionRegistry, nil, statusRegistry, nil, tracker, metrics, nil, &DummyMessageRouter{}, storageIdx, nil)
+	restoreEvrModules()
 
 	return rt, rtInfo, data, err
 }


### PR DESCRIPTION
`Refs #553` — not `Closes`. This fixes the part that could be proven; two parts of that issue are design calls and are left open deliberately. See "Not fixed here".

## The defect, reproduced end to end

With a database reachable, the entire `server` package test binary dies:

```
FAIL	github.com/heroiclabs/nakama/v3/server	0.072s
```

It normally takes ~130 s. **Every EVR test in the repo's largest package went unrun**, and the configuration where this happens is exactly the CI configuration.

The chain: `runtimeWithModulesWithData` → `NewRuntime` → every function in `EvrRuntimeModuleFns` → EVR `InitModule` errors on the missing `DISCORD_BOT_TOKEN` → `runtime_go.go` escalates to `startupLogger.Fatal`, which is a zap fatal, which is `os.Exit(1)`. The process dies mid-test and takes everything not yet run with it.

**Why it was invisible locally:** without a database `NewDB(t)` skips first, so the harness is never reached and the package looks green. The failure requires a database to appear, and `just test` does not have one.

## The fix

`disableEvrRuntimeModules` already existed and was already applied to the two other test `NewRuntime` call sites — both of which pass a **nil** database. `runtime_test.go:107` is the third, and the only one that passes a **real** one. That asymmetry is the whole bug.

These are upstream Nakama tests. They construct a full runtime because the API surface they exercise needs one; none of them wants the EVR module, so disabling it costs no coverage here.

## Two things deliberately not done

**Injecting a dummy token.** Already considered and recorded as unsafe in `disableEvrRuntimeModules`' own comment: `InitModule` would then run to completion and spawn background goroutines (notably `go MigrateSystem(...)`, which sleeps 20 s and then issues storage queries) against the test's database.

**Relaxing the production hard-fail.** #553 asks whether `InitModule` should degrade instead. It should not:

- A missing required credential should stop startup. Starting silently without the Discord integration is a fail-open on a control that is currently fail-closed.
- Degrading to `dg = nil` needs a nil check at **every** use of `dg` — `NewRPCHandler`, `NewVRMLScanQueue`, `NewEventDispatch`, and `evr_pipeline.go:228`'s `dg.Open()`, which would panic today. That is a large diff with nil-deref risk, in service of a behaviour nobody asked for.

The test harness was the right place to fix this, and the production check is left exactly as it was.

## Measured

Real Postgres 16.8, migrations applied, per #553's own repro:

| | |
|---|---|
| before | `FAIL	github.com/heroiclabs/nakama/v3/server	0.072s` |
| after | `ok	github.com/heroiclabs/nakama/v3/server	132.191s` |

Full `just test-db` run green across all 22 packages.

**And checked that the measurement measured the thing** rather than merely returning — the failure mode #553 itself was found by. `TestApiLeaderboard`'s subtests *skip* with no database:

```
api_test.go:223: skipping: no test database reachable at ...
```

and *execute* with one:

```
=== RUN   TestApiLeaderboard/create_and_list_leaderboard
--- PASS: TestApiLeaderboard (0.30s)
```

So the DB-backed paths really did run. (The 132 s total is close to the DB-free 129 s because the DB-backed tests are fast — 0.3 s — relative to the EVR suite that dominates the package.)

## Not fixed here — why #553 stays open

1. **The EVR `InitModule` is still exercised by no test.** This stops it from killing the binary; it does not test it. That gap is real and is now the interesting half of #553.
2. **No test gate runs on pull requests.** `docker-compose-tests.yml` is the only thing that would run this suite, and its `pull_request` trigger is commented out. Enabling it means a DB service and an image build on every PR — a cost/policy call for the repository owner, not a patch. It could not have completed before this change; it can now.

Co-authored-by: Andrew Bates <a@sprock.io>