### PR TITLE
feat(guilds): optional minimum EchoVR account age, independent of Discord's

### DIFF
--- a/server/evr_account.go
+++ b/server/evr_account.go
@@ -80,6 +80,20 @@ func (e EVRProfile) UserID() string {
 	return e.account.User.Id
 }
 
+// AccountCreateTime reports when the Nakama account itself was created.
+//
+// The second return distinguishes "not loaded" from "created at the zero time",
+// which matters to callers that gate on account age: every real account has a
+// creation time, so an absent one means the profile is incomplete rather than
+// that the account is brand new. Silently returning the zero time would make an
+// unloaded profile look infinitely old and pass any age check.
+func (e EVRProfile) AccountCreateTime() (time.Time, bool) {
+	if e.account == nil || e.account.User == nil || e.account.User.CreateTime == nil {
+		return time.Time{}, false
+	}
+	return e.account.User.CreateTime.AsTime(), true
+}
+
 func (e EVRProfile) IsDisabled() bool {
 	if e.account == nil {
 		return false

--- a/server/evr_group_metadata.go
+++ b/server/evr_group_metadata.go
@@ -12,9 +12,22 @@ import (
 )
 
 type GroupMetadata struct {
-	GuildID                              string            `json:"guild_id"`                      // The guild ID
-	OwnerID                              string            `json:"owner_id"`                      // The owner ID
-	MinimumAccountAgeDays                int               `json:"minimum_account_age_days"`      // The minimum account age in days to be able to play echo on this guild's sessions
+	GuildID               string `json:"guild_id"`                 // The guild ID
+	OwnerID               string `json:"owner_id"`                 // The owner ID
+	MinimumAccountAgeDays int    `json:"minimum_account_age_days"` // The minimum DISCORD account age in days to be able to play echo on this guild's sessions
+	// MinimumNakamaAccountAgeDays gates on the age of the EchoVR account itself,
+	// which MinimumAccountAgeDays does not: that one reads the Discord
+	// snowflake, so a fresh burner created on an aged Discord account passes it
+	// unchanged. See #516.
+	//
+	// Zero means off, and off is the default, because this gate is not a
+	// strictly better version of the Discord one -- it rejects genuinely new
+	// EchoVR players who happen to have long-standing Discord accounts, which
+	// is a real population and not the one it is aimed at. Guilds opt in.
+	//
+	// The two are independent and both apply when both are set: an account must
+	// clear whichever gates the guild has enabled.
+	MinimumNakamaAccountAgeDays          int               `json:"minimum_nakama_account_age_days"`
 	EnableMembersOnlyMatchmaking         bool              `json:"members_only_matchmaking"`      // Restrict matchmaking to members only (when this group is the active one)
 	DisableCreateCommand                 bool              `json:"disable_create_command"`        // Disable the public allocate command
 	LogAlternateAccounts                 bool              `json:"log_alternate_accounts"`        // Log alternate accounts

--- a/server/evr_lobby_account_age_test.go
+++ b/server/evr_lobby_account_age_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/api"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// now is fixed rather than time.Now() so the boundary cases are boundary cases
+// every run, not only when the suite happens to execute away from midnight.
+var accountAgeNow = time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+
+func TestAccountTooNew(t *testing.T) {
+	tests := []struct {
+		name        string
+		createdAt   time.Time
+		minDays     int
+		wantTooNew  bool
+		wantAgeDays int
+	}{
+		{
+			name:        "OlderThanGate",
+			createdAt:   accountAgeNow.AddDate(0, 0, -30),
+			minDays:     7,
+			wantTooNew:  false,
+			wantAgeDays: 30,
+		},
+		{
+			name:        "YoungerThanGate",
+			createdAt:   accountAgeNow.AddDate(0, 0, -2),
+			minDays:     7,
+			wantTooNew:  true,
+			wantAgeDays: 2,
+		},
+		{
+			// Exactly on the cutoff is NOT too new: the check is strictly
+			// After, so an account created precisely minDays ago passes.
+			name:        "ExactlyOnTheCutoff",
+			createdAt:   accountAgeNow.AddDate(0, 0, -7),
+			minDays:     7,
+			wantTooNew:  false,
+			wantAgeDays: 7,
+		},
+		{
+			name:        "OneSecondInsideTheCutoff",
+			createdAt:   accountAgeNow.AddDate(0, 0, -7).Add(time.Second),
+			minDays:     7,
+			wantTooNew:  true,
+			wantAgeDays: 6,
+		},
+		{
+			// A brand-new account against a one-day gate: the case the gate
+			// exists for.
+			name:        "CreatedMomentsAgo",
+			createdAt:   accountAgeNow.Add(-time.Minute),
+			minDays:     1,
+			wantTooNew:  true,
+			wantAgeDays: 0,
+		},
+		{
+			// Clock skew or a bad record can put creation in the future. It
+			// must read as too new, not wrap into "very old".
+			name:        "CreatedInTheFuture",
+			createdAt:   accountAgeNow.AddDate(0, 0, 5),
+			minDays:     7,
+			wantTooNew:  true,
+			wantAgeDays: -5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotTooNew, gotAgeDays := accountTooNew(tt.createdAt, tt.minDays, accountAgeNow)
+			if gotTooNew != tt.wantTooNew {
+				t.Errorf("accountTooNew(...) tooNew = %v, want %v", gotTooNew, tt.wantTooNew)
+			}
+			if gotAgeDays != tt.wantAgeDays {
+				t.Errorf("accountTooNew(...) ageDays = %d, want %d", gotAgeDays, tt.wantAgeDays)
+			}
+		})
+	}
+}
+
+// TestAccountTooNew_DiscordGateMissesFreshNakamaAccount is #516's evasion,
+// stated as a test: an aged Discord account carrying a brand-new EchoVR account
+// clears the Discord-snowflake gate and is caught only by the Nakama one.
+//
+// If someone ever "simplifies" the two gates into one, this fails.
+func TestAccountTooNew_DiscordGateMissesFreshNakamaAccount(t *testing.T) {
+	const minDays = 30
+
+	discordCreatedAt := accountAgeNow.AddDate(-4, 0, 0) // a four-year-old Discord account
+	nakamaCreatedAt := accountAgeNow.Add(-2 * time.Hour)
+
+	if tooNew, _ := accountTooNew(discordCreatedAt, minDays, accountAgeNow); tooNew {
+		t.Fatalf("precondition failed: the aged Discord account should clear a %d-day gate", minDays)
+	}
+
+	tooNew, ageDays := accountTooNew(nakamaCreatedAt, minDays, accountAgeNow)
+	if !tooNew {
+		t.Errorf("the fresh EchoVR account cleared a %d-day gate; #516's evasion is open", minDays)
+	}
+	if ageDays != 0 {
+		t.Errorf("ageDays = %d, want 0", ageDays)
+	}
+}
+
+// TestEVRProfileAccountCreateTime covers the reason AccountCreateTime returns a
+// second value: an unloaded profile must not read as an infinitely old account.
+// Returning the zero time alone would make every age gate pass on a profile
+// that simply failed to load -- fail-open on a fail-closed control.
+func TestEVRProfileAccountCreateTime(t *testing.T) {
+	createdAt := accountAgeNow.AddDate(0, 0, -10)
+
+	tests := []struct {
+		name    string
+		profile EVRProfile
+		wantOK  bool
+		want    time.Time
+	}{
+		{
+			name: "Loaded",
+			profile: EVRProfile{account: &api.Account{
+				User: &api.User{CreateTime: timestamppb.New(createdAt)},
+			}},
+			wantOK: true,
+			want:   createdAt,
+		},
+		{
+			name:    "NilAccount",
+			profile: EVRProfile{},
+			wantOK:  false,
+		},
+		{
+			name:    "NilUser",
+			profile: EVRProfile{account: &api.Account{}},
+			wantOK:  false,
+		},
+		{
+			name:    "NilCreateTime",
+			profile: EVRProfile{account: &api.Account{User: &api.User{}}},
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := tt.profile.AccountCreateTime()
+			if ok != tt.wantOK {
+				t.Fatalf("AccountCreateTime() ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				// The caller must not be able to mistake this for a real,
+				// very old creation time.
+				if !got.IsZero() {
+					t.Errorf("AccountCreateTime() = %v on a failure, want the zero time", got)
+				}
+				return
+			}
+			if !got.Equal(tt.want) {
+				t.Errorf("AccountCreateTime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -286,6 +286,21 @@ func LobbyJoinEntrants(logger *zap.Logger, matchRegistry MatchRegistry, tracker 
 }
 
 // lobbyAuthorize checks if the user is allowed to join the lobby based on various criteria such as guild membership, suspensions, and account age.
+// accountTooNew reports whether an account created at createdAt is younger than
+// minDays, and its age in whole days for the rejection message.
+//
+// Extracted so the policy can be exercised without a session, a guild, or a
+// database -- the gates that call it sit deep inside lobby authorization, which
+// is why their behaviour at the boundaries went untested for as long as it did.
+//
+// The cutoff is calendar arithmetic (AddDate), not minDays*24h. Those differ
+// across a DST transition, and this preserves the original behaviour rather
+// than quietly changing where the line falls.
+func accountTooNew(createdAt time.Time, minDays int, now time.Time) (tooNew bool, ageDays int) {
+	ageDays = int(now.Sub(createdAt).Hours() / 24)
+	return createdAt.After(now.AddDate(0, 0, -minDays)), ageDays
+}
+
 func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, session Session, lobbyParams *LobbySessionParameters) error {
 	groupID := lobbyParams.GroupID.String()
 	metricsTags := map[string]string{
@@ -432,11 +447,36 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 			return fmt.Errorf("failed to get discord snowflake timestamp: %w", err)
 		}
 
-		if t.After(time.Now().AddDate(0, 0, -gg.MinimumAccountAgeDays)) {
-			accountAge := time.Since(t).Hours() / 24
-			reason := fmt.Sprintf("Your account age (%d days) is too new (<%d days) to join this guild. ", int(accountAge), gg.MinimumAccountAgeDays)
-			auditLog := fmt.Sprintf("account age (%d > %d days.", int(accountAge), gg.MinimumAccountAgeDays)
+		if tooNew, ageDays := accountTooNew(t, gg.MinimumAccountAgeDays, time.Now()); tooNew {
+			reason := fmt.Sprintf("Your account age (%d days) is too new (<%d days) to join this guild. ", ageDays, gg.MinimumAccountAgeDays)
+			auditLog := fmt.Sprintf("account age (%d > %d days.", ageDays, gg.MinimumAccountAgeDays)
 			return joinRejected("account_age", reason, auditLog)
+		}
+	}
+
+	// The EchoVR account's own age, which the Discord gate above cannot see: it
+	// reads the Discord snowflake, so a fresh burner created on an aged Discord
+	// account clears it unchanged. That is the evasion recorded in #516.
+	//
+	// Independent of the Discord gate rather than a replacement for it. Both
+	// apply when both are configured, and this one is off unless the guild sets
+	// it -- see MinimumNakamaAccountAgeDays for why it is not simply the
+	// stricter default.
+	if gg.MinimumNakamaAccountAgeDays > 0 && !gg.IsAccountAgeBypass(userID) {
+		createdAt, ok := params.profile.AccountCreateTime()
+		if !ok {
+			// Every Nakama account has a creation time, so an absent one means
+			// the profile did not load rather than that the account is new.
+			// Treated as an error for the same reason the malformed-snowflake
+			// case above is: a gate that cannot read its input must not decide
+			// it passed.
+			return fmt.Errorf("cannot evaluate minimum_nakama_account_age_days: account creation time unavailable for %s", userID)
+		}
+
+		if tooNew, ageDays := accountTooNew(createdAt, gg.MinimumNakamaAccountAgeDays, time.Now()); tooNew {
+			reason := fmt.Sprintf("Your EchoVR account age (%d days) is too new (<%d days) to join this guild. ", ageDays, gg.MinimumNakamaAccountAgeDays)
+			auditLog := fmt.Sprintf("echovr account age (%d < %d days).", ageDays, gg.MinimumNakamaAccountAgeDays)
+			return joinRejected("nakama_account_age", reason, auditLog)
 		}
 	}
 


### PR DESCRIPTION
`Refs #516` — this is the third of the three open enforcement items. Items 1 and 2 are measured and escalated in [this comment](https://github.com/EchoTools/nakama/issues/516#issuecomment-5225147688) rather than guessed at; both turn out to be policy calls rather than missing mechanism.

## The gap

`server/evr_lobby_joinentrant.go:428` reads the **Discord** snowflake:

```go
t, err := discordgo.SnowflakeTimestamp(lobbyParams.DiscordID)
```

So it measures how old the *Discord* account is. A fresh burner created on an aged Discord account clears it unchanged — exactly the evasion #516 documents.

## What changed

`MinimumNakamaAccountAgeDays` on `GroupMetadata`, gating on the Nakama account's own creation time. **Independent of the Discord gate, not a replacement** — both apply when both are set.

**Off by default, and opt-in rather than "take the stricter of the two."** This is the design decision worth arguing with if you disagree: making Nakama age authoritative would reject **genuinely new EchoVR players who have long-standing Discord accounts**. That is a real and sizeable population, and not the one this is aimed at. The trade belongs to each guild, so no guild's behaviour changes until one sets the field.

## The fail-open this avoids

`AccountCreateTime` returns `(time.Time, bool)`, not a bare time. An unloaded profile would otherwise yield the zero time — which reads as an *infinitely old* account and passes every age check. That is fail-open on a fail-closed control, and it is the failure mode a gate like this is most likely to have.

The gate treats an unreadable creation time as an error, for the same reason the existing malformed-snowflake path does: **a gate that cannot read its input must not decide that it passed.**

## Testable without a database

The decision is extracted into `accountTooNew(createdAt, minDays, now)` — pure, and exercisable without a session, guild, or database. These gates sit deep inside lobby authorization, which is why their boundary behaviour went untested for as long as it did.

Covered:

| case | why |
|---|---|
| exactly on the cutoff | **not** too new — the comparison is strictly `After` |
| one second inside it | too new |
| created moments ago | the case the gate exists for |
| **created in the future** | clock skew must read as too new, not wrap into "very old" |

And #516's evasion is pinned directly, as `TestAccountTooNew_DiscordGateMissesFreshNakamaAccount`: a four-year-old Discord account carrying a two-hour-old EchoVR account clears the Discord gate and is caught only by this one. **If someone ever collapses the two gates into one, that test fails.**

## Mutation-proven, not assumed

Making `accountTooNew` always return `false`:

```
--- FAIL: TestAccountTooNew/YoungerThanGate
--- FAIL: TestAccountTooNew/OneSecondInsideTheCutoff
--- FAIL: TestAccountTooNew/CreatedMomentsAgo
--- FAIL: TestAccountTooNew/CreatedInTheFuture
--- FAIL: TestAccountTooNew_DiscordGateMissesFreshNakamaAccount
```

## The existing gate

Rewired through the same helper with behaviour preserved exactly, including the calendar-arithmetic cutoff (`AddDate`, not `minDays*24h` — those differ across a DST transition). One incidental improvement: it previously read the clock twice, once for the comparison and once for the age in the message, so the two could disagree.

## Stated plainly

The **policy** is unit-tested; the **wiring** into `lobbyAuthorize` is covered by build and vet only. That function needs a session, a guild group, and a Discord cache to call, and I did not build a harness for it here. Full `just test` green (22 packages, `server` 128s).

Configuration matches its sibling: `MinimumAccountAgeDays` is also set through raw group metadata, with no Discord command behind it.

Co-authored-by: Andrew Bates <a@sprock.io>