### PR TITLE
feat(detect): optional first-sight login reject on a machine-fingerprint match

### DIFF
--- a/server/evr_authenticate_alts.go
+++ b/server/evr_authenticate_alts.go
@@ -4,10 +4,46 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 )
+
+// disabledAccountIDs returns which of the given user IDs belong to accounts
+// that are currently disabled.
+//
+// Returns an error rather than swallowing one, so callers choose their own
+// failure posture. The two that gate on this choose differently and both are
+// deliberate: the login rejection fails open (a lookup failure must not lock a
+// legitimate player out, and the delayed kick still runs behind it), while a
+// caller that already admitted the session can afford to be stricter.
+func disabledAccountIDs(ctx context.Context, nk runtime.NakamaModule, userIDs []string) ([]string, error) {
+	if len(userIDs) == 0 {
+		return nil, nil
+	}
+
+	accounts, err := nk.AccountsGetId(ctx, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get accounts for user IDs %v: %w", userIDs, err)
+	}
+
+	disabled := make([]string, 0, len(accounts))
+	for _, a := range accounts {
+		// A zero DisableTime is "not disabled", not "disabled at the epoch" --
+		// both the nil and the zero form appear in practice.
+		if a.GetDisableTime() == nil || a.GetDisableTime().AsTime().IsZero() {
+			continue
+		}
+		if a.GetUser() != nil {
+			disabled = append(disabled, a.GetUser().GetId())
+		}
+	}
+	if len(disabled) == 0 {
+		return nil, nil
+	}
+	return disabled, nil
+}
 
 type AlternateSearchMatch struct {
 	OtherUserID string   `json:"other_user_id"`
@@ -142,6 +178,68 @@ func LoginDeniedClientIPAddressSearch(ctx context.Context, nk runtime.NakamaModu
 	}
 	return userIDs, nil
 
+}
+
+// isMachineFingerprint reports whether an alt-match item is a specific machine
+// fingerprint, as opposed to any of the other things a match can be keyed on.
+//
+// The distinction is the whole basis for treating this signal differently from
+// the rest. An IP is a household and is rotated by a reboot; an HMD serial is
+// rotated by editing a config. The full system profile is the one key that
+// tracks the hardware someone actually owns.
+//
+// "Specific" is doing real work here. The same string is a bucket rather than a
+// key in two cases, and both are excluded:
+//
+//   - matchIgnoredAltPattern drops the degenerate profile -- every account that
+//     logs in without SystemInfo emits the identical Unknown::::::::0::0::0::0,
+//     which links strangers to each other en masse.
+//   - IsWeakSignal drops commodity headset prefixes: "Meta Quest 3::..." plus
+//     stock numbers describes a large share of the player base.
+//
+// A nil detector only skips the commodity check. It does not turn the whole
+// test into "true" -- an unavailable classifier must narrow what this matches,
+// never widen it.
+func isMachineFingerprint(item string, detector *CGNATDetector) bool {
+	if len(strings.Split(item, "::")) != systemProfileComponents {
+		return false
+	}
+	if matchIgnoredAltPattern(item) {
+		return false
+	}
+	if detector != nil && detector.IsWeakSignal(item) {
+		return false
+	}
+	return true
+}
+
+// machineMatchedAlts returns the subset of altIDs linked to this account by a
+// specific machine fingerprint.
+//
+// Narrower than filterStrongAlts on purpose: that one keeps an alt if ANY of
+// its match items is a strong signal, so an alt linked only by a residential IP
+// on a non-CGNAT range survives it. This one asks the single question #516's
+// item 1 is about -- is this the same machine?
+func machineMatchedAlts(history *LoginHistory, altIDs []string, detector *CGNATDetector) []string {
+	if history == nil || len(altIDs) == 0 {
+		return nil
+	}
+
+	matched := make([]string, 0, len(altIDs))
+	for _, altID := range altIDs {
+		for _, m := range history.AlternateMatches[altID] {
+			if slices.ContainsFunc(m.Items, func(item string) bool {
+				return isMachineFingerprint(item, detector)
+			}) {
+				matched = append(matched, altID)
+				break
+			}
+		}
+	}
+	if len(matched) == 0 {
+		return nil
+	}
+	return matched
 }
 
 func loginHistoryCompare(a, b *LoginHistory) []*AlternateSearchMatch {

--- a/server/evr_authenticate_alts_machine_test.go
+++ b/server/evr_authenticate_alts_machine_test.go
@@ -1,0 +1,170 @@
+package server
+
+import (
+	"slices"
+	"testing"
+)
+
+// A realistic PC fingerprint: eight "::"-joined components, none of them empty.
+const pcFingerprint = "Windows::Wired::NVIDIA GeForce RTX 4070::AMD Ryzen 7 5800X::8::16::34359738368::12884901888"
+
+// What every account that logs in without SystemInfo emits. Not a rare
+// fingerprint -- a bucket shared by all of them. This is the string that would
+// have linked every profile-less account to every other one.
+const degenerateFingerprint = "Unknown::::::::0::0::0::0"
+
+// A stock Quest 3, which describes a large share of the player base.
+const commodityFingerprint = "Meta Quest 3::Wifi::::::4::8::8589934592::0"
+
+func newTestCGNATDetector(t *testing.T) *CGNATDetector {
+	t.Helper()
+	d := &CGNATDetector{}
+	d.UpdateSettings(CGNATSettings{
+		CommodityProfilePrefixes: []string{"Meta Quest 2::", "Meta Quest 3::", "Meta Quest 3S::"},
+	})
+	return d
+}
+
+func TestIsMachineFingerprint(t *testing.T) {
+	detector := newTestCGNATDetector(t)
+
+	tests := []struct {
+		name string
+		item string
+		want bool
+	}{
+		{
+			name: "SpecificPCProfile",
+			item: pcFingerprint,
+			want: true,
+		},
+		{
+			// The bucket that nearly shipped with #551. If this ever returns
+			// true, every account with no SystemInfo is a machine match for
+			// every other one, and the login gate locks out the lot.
+			name: "DegenerateProfileIsNotAFingerprint",
+			item: degenerateFingerprint,
+			want: false,
+		},
+		{
+			name: "CommodityHeadsetIsNotAFingerprint",
+			item: commodityFingerprint,
+			want: false,
+		},
+		{
+			name: "ClientIPIsNotAFingerprint",
+			item: "203.0.113.7",
+			want: false,
+		},
+		{
+			name: "HMDSerialIsNotAFingerprint",
+			item: "1PASH9AB12345",
+			want: false,
+		},
+		{
+			name: "XPIDIsNotAFingerprint",
+			item: "OVR-ORG-3963667097037078",
+			want: false,
+		},
+		{
+			name: "EmptyIsNotAFingerprint",
+			item: "",
+			want: false,
+		},
+		{
+			// Right component count, but it is the wrong shape entirely.
+			name: "WrongComponentCount",
+			item: "Windows::Wired::GPU",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMachineFingerprint(tt.item, detector); got != tt.want {
+				t.Errorf("isMachineFingerprint(%q) = %v, want %v", tt.item, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsMachineFingerprint_NilDetectorNarrows pins that losing the commodity
+// classifier makes this match LESS, not more.
+//
+// The opposite -- treating an unavailable classifier as "nothing is commodity"
+// -- would turn every Quest profile into a machine match the moment settings
+// failed to load, and this gate rejects logins. An unavailable input must never
+// widen what an enforcement rule matches.
+func TestIsMachineFingerprint_NilDetectorNarrows(t *testing.T) {
+	detector := newTestCGNATDetector(t)
+
+	if !isMachineFingerprint(pcFingerprint, nil) {
+		t.Error("a specific PC profile should still be a fingerprint with no detector")
+	}
+
+	// With a detector the commodity profile is excluded. Without one the
+	// commodity check cannot run -- so this documents the residual honestly
+	// rather than pretending it is covered.
+	if isMachineFingerprint(commodityFingerprint, detector) {
+		t.Error("commodity profile matched despite a detector that classifies it")
+	}
+
+	// The degenerate profile must stay excluded even with no detector at all,
+	// because that exclusion does not depend on settings.
+	if isMachineFingerprint(degenerateFingerprint, nil) {
+		t.Error("degenerate profile matched with no detector; the bucket guard must not depend on settings")
+	}
+}
+
+func TestMachineMatchedAlts(t *testing.T) {
+	detector := newTestCGNATDetector(t)
+
+	const (
+		machineAlt   = "11111111-1111-1111-1111-111111111111"
+		ipOnlyAlt    = "22222222-2222-2222-2222-222222222222"
+		commodityAlt = "33333333-3333-3333-3333-333333333333"
+		mixedAlt     = "44444444-4444-4444-4444-444444444444"
+	)
+
+	history := &LoginHistory{
+		AlternateMatches: map[string][]*AlternateSearchMatch{
+			machineAlt: {{OtherUserID: machineAlt, Items: []string{pcFingerprint}}},
+			// Linked only by an IP. filterStrongAlts would keep this one on a
+			// non-CGNAT address; this must not.
+			ipOnlyAlt: {{OtherUserID: ipOnlyAlt, Items: []string{"203.0.113.7"}}},
+			// A shared stock headset profile is not evidence of a shared machine.
+			commodityAlt: {{OtherUserID: commodityAlt, Items: []string{commodityFingerprint}}},
+			// Several matches, only one of which is the machine.
+			mixedAlt: {
+				{OtherUserID: mixedAlt, Items: []string{"203.0.113.9"}},
+				{OtherUserID: mixedAlt, Items: []string{"1PASH9AB12345", pcFingerprint}},
+			},
+		},
+	}
+
+	altIDs := []string{machineAlt, ipOnlyAlt, commodityAlt, mixedAlt}
+	got := machineMatchedAlts(history, altIDs, detector)
+
+	want := []string{machineAlt, mixedAlt}
+	slices.Sort(got)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Errorf("machineMatchedAlts() = %v, want %v", got, want)
+	}
+}
+
+func TestMachineMatchedAlts_Empty(t *testing.T) {
+	detector := newTestCGNATDetector(t)
+
+	if got := machineMatchedAlts(nil, []string{"x"}, detector); got != nil {
+		t.Errorf("machineMatchedAlts(nil history) = %v, want nil", got)
+	}
+	if got := machineMatchedAlts(&LoginHistory{}, nil, detector); got != nil {
+		t.Errorf("machineMatchedAlts(no ids) = %v, want nil", got)
+	}
+	// An ID with no recorded match must not be reported as a machine match.
+	history := &LoginHistory{AlternateMatches: map[string][]*AlternateSearchMatch{}}
+	if got := machineMatchedAlts(history, []string{"unknown-id"}, detector); got != nil {
+		t.Errorf("machineMatchedAlts(unknown id) = %v, want nil", got)
+	}
+}

--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -61,33 +61,48 @@ type SkillRatingSettings struct {
 }
 
 type ServiceSettingsData struct {
-	LinkInstructions                      string                    `json:"link_instructions"`     // Instructions for linking the headset
-	DisableLoginMessage                   string                    `json:"disable_login_message"` // Disable the login, and show this message
-	ServiceGuildID                        string                    `json:"service_guild_id"`      // Central/Support guild ID
-	DisableStatisticsUpdates              bool                      `json:"disable_statistics_updates"`
-	PruneSettings                         PruneSettings             `json:"prune_settings"` // Settings for pruning Discord guilds and Nakama groups
-	SkillRating                           SkillRatingSettings       `json:"skill_rating"`   // Skill rating configuration
-	Matchmaking                           GlobalMatchmakingSettings `json:"matchmaking"`
-	RemoteLogFilters                      map[string][]string       `json:"remote_logs_filter"` //	Ignore remote logs from specific servers
-	ReportURL                             string                    `json:"report_url"`         // URL to report issues
-	ServiceAuditChannelID                 string                    `json:"service_audit_channel_id"`
-	ServiceSessionsChannelID              string                    `json:"service_sessions_channel_id"` // Service-wide sessions channel
-	ServiceDebugChannelID                 string                    `json:"service_debug_channel_id"`
-	GlobalErrorChannelID                  string                    `json:"service_error_channel_id"`
-	CommandLogChannelID                   string                    `json:"service_command_log_channel_id"`
-	DiscordBotUserID                      string                    `json:"discord_bot_user_id"`
-	KickPlayersWithDisabledAlternates     bool                      `json:"kick_players_with_disabled_alts"` // Kick players with disabled alts
-	VRMLEntitlementNotifyChannelID        string                    `json:"vrml_entitlement_notify_channel_id"`
-	VRMLOutageMode                        bool                      `json:"vrml_outage_mode"` // Disable live VRML API calls and rely on cached data only.
-	EnableContinuousGameserverHealthCheck bool                      `json:"enable_continuous_gameserver_health_check"`
-	DisplayNameInUseNotifications         bool                      `json:"display_name_in_use_notifications"` // Display name in use notifications
-	EnableSessionDebug                    bool                      `json:"enable_session_debug"`
-	version                               string
-	serviceStatusMessage                  string
-	PingServerBeforeJoin                  bool          `json:"ping_server_before_join"`   // Ping the server before joining to measure latency
-	EnableVibinatorsGravity               bool          `json:"enable_vibinators_gravity"` // Novelty: redirect social-lobby echo_arena matchmakers toward vibinator's echo_combat
-	UseQuestEncoderFlags                  bool          `json:"use_quest_encoder_flags"`   // Send Quest-shifted encoder flag bit layout in LobbySessionSuccessv5 for standalone clients
-	CGNAT                                 CGNATSettings `json:"cgnat"`
+	LinkInstructions                  string                    `json:"link_instructions"`     // Instructions for linking the headset
+	DisableLoginMessage               string                    `json:"disable_login_message"` // Disable the login, and show this message
+	ServiceGuildID                    string                    `json:"service_guild_id"`      // Central/Support guild ID
+	DisableStatisticsUpdates          bool                      `json:"disable_statistics_updates"`
+	PruneSettings                     PruneSettings             `json:"prune_settings"` // Settings for pruning Discord guilds and Nakama groups
+	SkillRating                       SkillRatingSettings       `json:"skill_rating"`   // Skill rating configuration
+	Matchmaking                       GlobalMatchmakingSettings `json:"matchmaking"`
+	RemoteLogFilters                  map[string][]string       `json:"remote_logs_filter"` //	Ignore remote logs from specific servers
+	ReportURL                         string                    `json:"report_url"`         // URL to report issues
+	ServiceAuditChannelID             string                    `json:"service_audit_channel_id"`
+	ServiceSessionsChannelID          string                    `json:"service_sessions_channel_id"` // Service-wide sessions channel
+	ServiceDebugChannelID             string                    `json:"service_debug_channel_id"`
+	GlobalErrorChannelID              string                    `json:"service_error_channel_id"`
+	CommandLogChannelID               string                    `json:"service_command_log_channel_id"`
+	DiscordBotUserID                  string                    `json:"discord_bot_user_id"`
+	KickPlayersWithDisabledAlternates bool                      `json:"kick_players_with_disabled_alts"` // Kick players with disabled alts
+	// RejectDisabledAlternatesOnMachineMatch refuses the LOGIN, rather than
+	// admitting the session and kicking it 1-4 minutes later, when the account
+	// shares a full machine fingerprint with a currently-disabled account.
+	//
+	// Narrow on purpose: only the machine fingerprint, and only a specific one
+	// (commodity headset profiles and degenerate all-empty profiles are
+	// excluded, since those are buckets rather than keys). IP and HMD serial do
+	// NOT trigger it -- they are rotated trivially, and a shared IP is a
+	// household, not a person.
+	//
+	// Off by default, because it is a trade rather than an upgrade. The delayed
+	// kick costs a few minutes of presence and buys ambiguity about which signal
+	// caught them; rejecting at login is immediate but tells an evader exactly
+	// what to change, on the login that carried it. See #516.
+	RejectDisabledAlternatesOnMachineMatch bool   `json:"reject_disabled_alts_on_machine_match"`
+	VRMLEntitlementNotifyChannelID         string `json:"vrml_entitlement_notify_channel_id"`
+	VRMLOutageMode                         bool   `json:"vrml_outage_mode"` // Disable live VRML API calls and rely on cached data only.
+	EnableContinuousGameserverHealthCheck  bool   `json:"enable_continuous_gameserver_health_check"`
+	DisplayNameInUseNotifications          bool   `json:"display_name_in_use_notifications"` // Display name in use notifications
+	EnableSessionDebug                     bool   `json:"enable_session_debug"`
+	version                                string
+	serviceStatusMessage                   string
+	PingServerBeforeJoin                   bool          `json:"ping_server_before_join"`   // Ping the server before joining to measure latency
+	EnableVibinatorsGravity                bool          `json:"enable_vibinators_gravity"` // Novelty: redirect social-lobby echo_arena matchmakers toward vibinator's echo_combat
+	UseQuestEncoderFlags                   bool          `json:"use_quest_encoder_flags"`   // Send Quest-shifted encoder flag bit layout in LobbySessionSuccessv5 for standalone clients
+	CGNAT                                  CGNATSettings `json:"cgnat"`
 }
 
 // CGNATSettings configures detection of CGNAT and shared-IP providers

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -616,7 +616,53 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 	}
 
 	firstIDs, _ := loginHistory.AlternateIDs()
-	if detector := GetCGNATDetector(); detector != nil {
+	detector := GetCGNATDetector()
+
+	// #516 item 1: refuse the login outright when this machine is the same
+	// machine as a currently-disabled account's, instead of admitting the
+	// session and kicking it minutes later.
+	//
+	// Deliberately evaluated before filterStrongAlts narrows firstIDs, so the
+	// two filters cannot mask one another; machineMatchedAlts applies its own,
+	// stricter test.
+	//
+	// Off unless the operator turns it on -- see
+	// RejectDisabledAlternatesOnMachineMatch for the trade. ignoreDisabledAlternates
+	// is honoured here exactly as the delayed-kick path honours it, so an account
+	// cleared by a moderator stays cleared.
+	if ServiceSettings().RejectDisabledAlternatesOnMachineMatch && !params.ignoreDisabledAlternates {
+		if machineIDs := machineMatchedAlts(loginHistory, firstIDs, detector); len(machineIDs) > 0 {
+			disabled, err := disabledAccountIDs(ctx, p.nk, machineIDs)
+			if err != nil {
+				// Fail open, and say so. This gate is an addition to the
+				// existing delayed kick, not a replacement for it: a lookup
+				// failure must not lock out a legitimate player, and the
+				// delayed path still runs behind it.
+				logger.Warn("Failed to check machine-matched alternates for disabled accounts", zap.Error(err))
+			} else if len(disabled) > 0 {
+				p.nk.MetricsCounterAdd("login_rejected_machine_matched_disabled_alt", nil, 1)
+
+				logger.Info("Rejected login: machine fingerprint matches a disabled account.",
+					zap.String("xpid", params.xpID.Token()),
+					zap.String("client_ip", session.clientIP),
+					zap.String("uid", params.profile.ID()),
+					zap.Strings("disabled_alt_uids", disabled))
+
+				metricsTags["error"] = "machine_matched_disabled_alt"
+
+				// The same error a disabled account itself gets. Telling an
+				// evader which signal caught them is the cost this whole
+				// setting trades against; the audit log above carries the
+				// detail for moderators.
+				return AccountDisabledError{
+					message:   "Account Disabled",
+					reportURL: ServiceSettings().ReportURL,
+				}
+			}
+		}
+	}
+
+	if detector != nil {
 		firstIDs = filterStrongAlts(loginHistory, firstIDs, detector)
 	}
 	params.enforcementUserIDs = append(firstIDs, params.profile.ID())


### PR DESCRIPTION
`Refs #516` — its **top-ranked** fix direction: *"First-sight reject/flag on exact full `system_profile` match to a currently-disabled account."*

## What was actually missing

Detection already worked. After #551 a specific system profile is a strong signal, so `filterStrongAlts` does not suppress it and the delayed kick fires. **The gap was only timing** — the current path admits the session and disables + kicks it after a jittered 1–4 minutes.

So this adds the first-sight path and **leaves the delayed one intact behind it**.

## Off by default — a trade, not an upgrade

The delayed kick costs a few minutes of presence and buys **ambiguity about which signal caught them**. Rejecting at login is immediate but tells an evader exactly what to change, on the login that carried it — which is the feedback loop that makes rotation cheap.

That is an operator's call, so the operator makes it. `RejectDisabledAlternatesOnMachineMatch`, default false. Same posture as `MinimumNakamaAccountAgeDays` in #562.

## Narrower than `filterStrongAlts`, deliberately

`filterStrongAlts` keeps an alt if **any** match item is strong — so an alt linked only by a residential IP on a non-CGNAT range survives it. This asks the single question item 1 is about: *is this the same machine?*

Only a full system profile answers that. An IP is a household and a reboot rotates it; an HMD serial is rotated by editing a config. Neither triggers this gate.

## The bucket guards are the load-bearing part

**This rejects logins.** A bucket here does not mis-tag someone — it locks out real players en masse. Two exclusions, both proven rather than assumed:

| excluded | why |
|---|---|
| `Unknown::::::::0::0::0::0` | Every account that logs in without `SystemInfo` emits this identical string. **The bucket that nearly shipped with #551.** |
| `Meta Quest 3::…` and siblings | Stock hardware describes a large share of the player base. |

**Mutation-proven.** Removing the degenerate guard:

```
--- FAIL: TestIsMachineFingerprint/DegenerateProfileIsNotAFingerprint
--- FAIL: TestIsMachineFingerprint_NilDetectorNarrows
```

Removing the commodity guard:

```
--- FAIL: TestIsMachineFingerprint/CommodityHeadsetIsNotAFingerprint
--- FAIL: TestIsMachineFingerprint_NilDetectorNarrows
--- FAIL: TestMachineMatchedAlts
```

## An unavailable classifier must narrow, never widen

`TestIsMachineFingerprint_NilDetectorNarrows` pins this directly. If the CGNAT detector is unavailable, the commodity check cannot run — and the wrong reading of that ("nothing is commodity") would turn **every Quest profile into a machine match** the moment settings failed to load, on a gate that rejects logins.

So a nil detector only skips the commodity check; it never makes `isMachineFingerprint` return true on its own. And the degenerate guard does not consult settings at all, so it holds even then.

## Failure posture

- **Fails open on a lookup error**, and logs it. This gate is an *addition* to the delayed kick, not a replacement — a failed `AccountsGetId` must not lock out a legitimate player when the existing path still runs behind it.
- `ignoreDisabledAlternates` is honoured exactly as the delayed path honours it, so an account a moderator has cleared stays cleared.
- Evaluated **before** `filterStrongAlts` narrows `firstIDs`, so the two filters cannot mask one another.
- The rejection reuses `AccountDisabledError` — the same message a disabled account gets. Telling an evader which signal caught them is the cost this setting trades against; the detail goes to the log and the metric, where moderators can see it.

## Also

`disabledAccountIDs` extracted rather than inlined a fourth time. It returns an error instead of swallowing one, so each caller picks its own failure posture — the two that gate on it choose differently, and both are deliberate.

New metric: `login_rejected_machine_matched_disabled_alt`.

## Still open on #516

Item 2 (subnet/ASN) is unchanged and still needs the bucket question answered against production data — see [this comment](https://github.com/EchoTools/nakama/issues/516#issuecomment-5225217000), where the datacenter data turned out to already exist in both providers.

And the operational question this PR does not answer: **is `KickPlayersWithDisabledAlternates` enabled in production?** If it is not, the delayed path this sits in front of has never fired either.

Full `just test-audit` green: 3387 pass, 130 skip, 0 fail.

Co-authored-by: Andrew Bates <a@sprock.io>