### PR TITLE
fix(ipinfo): surface the datacenter classification both providers already fetch

### DIFF
--- a/server/evr_ip_info.go
+++ b/server/evr_ip_info.go
@@ -3,6 +3,21 @@ package server
 type IPInfo interface {
 	DataProvider() string // IPQS, MaxMind, etc
 	IsVPN() bool
+
+	// IsDataCenter reports whether the address belongs to hosting, colocation
+	// or datacenter infrastructure rather than a consumer connection.
+	//
+	// Distinct from IsVPN, and not a synonym for it. Both providers treat them
+	// as separate facts: ip-api's `proxy` is "proxy, VPN or Tor exit" while
+	// `hosting` is "hosting, colocated or data center", and IPQS reports
+	// `connection_type` independently of its `vpn` flag. A rented VPS used as a
+	// game proxy is commonly hosting-but-not-proxy, so IsVPN() alone does not
+	// see it.
+	//
+	// Both providers already fetched this -- ip-api's request even names
+	// `hosting` in its field mask -- and nothing read it. See #516.
+	IsDataCenter() bool
+
 	IsSharedIP() bool
 	Latitude() float64
 	Longitude() float64
@@ -25,6 +40,10 @@ func (r StubIPInfo) DataProvider() string {
 }
 
 func (r StubIPInfo) IsVPN() bool {
+	return false
+}
+
+func (r StubIPInfo) IsDataCenter() bool {
 	return false
 }
 

--- a/server/evr_ip_info_datacenter_test.go
+++ b/server/evr_ip_info_datacenter_test.go
@@ -1,0 +1,121 @@
+package server
+
+import "testing"
+
+// TestIPInfoIsDataCenter covers the fact that both providers already fetched
+// and both then dropped: a datacenter address is a DIFFERENT fact from a proxy
+// address, and IsVPN() does not see it.
+//
+// The cases that matter are the ones where the two disagree. A rented VPS used
+// as a game proxy is commonly hosting-but-not-proxy, and that combination read
+// as entirely clean before this existed.
+func TestIPInfoIsDataCenter(t *testing.T) {
+	t.Run("IPAPI", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			resp           IPAPIResponse
+			wantDataCenter bool
+			wantVPN        bool
+		}{
+			{
+				// The gap, stated as a test.
+				name:           "HostingButNotProxy",
+				resp:           IPAPIResponse{Hosting: true, Proxy: false},
+				wantDataCenter: true,
+				wantVPN:        false,
+			},
+			{
+				name:           "ProxyButNotHosting",
+				resp:           IPAPIResponse{Hosting: false, Proxy: true},
+				wantDataCenter: false,
+				wantVPN:        true,
+			},
+			{
+				name:           "Both",
+				resp:           IPAPIResponse{Hosting: true, Proxy: true},
+				wantDataCenter: true,
+				wantVPN:        true,
+			},
+			{
+				name:           "Residential",
+				resp:           IPAPIResponse{},
+				wantDataCenter: false,
+				wantVPN:        false,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				d := &ipapiData{Response: tt.resp}
+				if got := d.IsDataCenter(); got != tt.wantDataCenter {
+					t.Errorf("IsDataCenter() = %v, want %v", got, tt.wantDataCenter)
+				}
+				// Pinned alongside, so that widening IsVPN to include hosting
+				// is a deliberate edit to this test rather than a silent
+				// enforcement change. That decision is open on #516.
+				if got := d.IsVPN(); got != tt.wantVPN {
+					t.Errorf("IsVPN() = %v, want %v", got, tt.wantVPN)
+				}
+			})
+		}
+	})
+
+	t.Run("IPQS", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			connectionType string
+			want           bool
+		}{
+			{name: "DocumentedSpelling", connectionType: "Data Center", want: true},
+			{name: "NoSpace", connectionType: "DataCenter", want: true},
+			{name: "Lowercase", connectionType: "data center", want: true},
+			{name: "Residential", connectionType: "Residential", want: false},
+			{name: "Corporate", connectionType: "Corporate", want: false},
+			{name: "Mobile", connectionType: "Mobile", want: false},
+			// An absent value must not read as datacenter. IPQS omits the
+			// field on some plans, and "unknown" is not "yes".
+			{name: "Absent", connectionType: "", want: false},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				d := &IPQSData{Response: IPQSResponse{ConnectionType: tt.connectionType}}
+				if got := d.IsDataCenter(); got != tt.want {
+					t.Errorf("IsDataCenter(%q) = %v, want %v", tt.connectionType, got, tt.want)
+				}
+			})
+		}
+	})
+
+	// A known shared provider is a false positive for both questions, which is
+	// what the shared-provider list exists to prevent. Whatever the flags say,
+	// a shared provider must not be reported as a datacenter.
+	t.Run("SharedProviderShortCircuits", func(t *testing.T) {
+		// Taken from the real list rather than invented, so this fails if the
+		// list is emptied rather than passing vacuously against a string
+		// nothing recognises.
+		if len(knownSharedIPProviders) == 0 {
+			t.Fatal("knownSharedIPProviders is empty; this test would prove nothing")
+		}
+		shared := knownSharedIPProviders[0]
+		if !isKnownSharedIPProvider(shared, "") {
+			t.Fatalf("precondition failed: %q is not recognised as a shared provider", shared)
+		}
+
+		ipapi := &ipapiData{Response: IPAPIResponse{Hosting: true, ISP: shared, Organization: shared}}
+		if ipapi.IsDataCenter() {
+			t.Errorf("ipapi IsDataCenter() = true for known shared provider %q", shared)
+		}
+
+		ipqs := &IPQSData{Response: IPQSResponse{ConnectionType: "Data Center", ISP: shared, Organization: shared}}
+		if ipqs.IsDataCenter() {
+			t.Errorf("ipqs IsDataCenter() = true for known shared provider %q", shared)
+		}
+	})
+
+	t.Run("StubIsNeverDataCenter", func(t *testing.T) {
+		if (StubIPInfo{}).IsDataCenter() {
+			t.Error("StubIPInfo.IsDataCenter() = true; the stub must claim nothing")
+		}
+	})
+}

--- a/server/evr_ip_info_provider_ipapi.go
+++ b/server/evr_ip_info_provider_ipapi.go
@@ -65,6 +65,19 @@ func (r *ipapiData) IsVPN() bool {
 	return r.Response.Proxy
 }
 
+// IsDataCenter reports ip-api's `hosting` flag, which is a separate field from
+// `proxy` and is already requested in this client's field mask.
+//
+// IsSharedIP short-circuits it for the same reason IsVPN does: a known shared
+// provider is a false positive for both questions, and the shared-provider list
+// exists precisely to stop those from being treated as evidence.
+func (r *ipapiData) IsDataCenter() bool {
+	if r.IsSharedIP() {
+		return false
+	}
+	return r.Response.Hosting
+}
+
 func (r *ipapiData) IsSharedIP() bool {
 	return isKnownSharedIPProvider(r.Response.ISP, r.Response.Organization)
 }

--- a/server/evr_ip_info_provider_ipqs.go
+++ b/server/evr_ip_info_provider_ipqs.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -112,6 +113,20 @@ func (r *IPQSData) IsVPN() bool {
 		return false
 	}
 	return r.Response.VPN
+}
+
+// IsDataCenter reports IPQS's connection_type, which is reported independently
+// of its vpn flag.
+//
+// Matched case-insensitively and without assuming spacing: IPQS documents the
+// value as "Data Center", but a classifier that silently answers "no" because a
+// provider changed a space is worse than one that is slightly loose here.
+func (r *IPQSData) IsDataCenter() bool {
+	if r.IsSharedIP() {
+		return false
+	}
+	normalized := strings.ToLower(strings.ReplaceAll(r.Response.ConnectionType, " ", ""))
+	return normalized == "datacenter"
 }
 
 func (r *IPQSData) IsSharedIP() bool {

--- a/server/evr_lobby_joinentrant.go
+++ b/server/evr_lobby_joinentrant.go
@@ -520,6 +520,16 @@ func (p *EvrPipeline) lobbyAuthorize(ctx context.Context, logger *zap.Logger, se
 					Inline: true,
 				},
 				{
+					// Informational, and deliberately separate from the VPN
+					// determination that produced this embed: a datacenter
+					// address is a different fact from a proxy address, and a
+					// moderator reading this should be able to tell which one
+					// they are looking at.
+					Name:   "Data Center",
+					Value:  fmt.Sprintf("%t", params.ipInfo.IsDataCenter()),
+					Inline: true,
+				},
+				{
 					Name:   "City",
 					Value:  params.ipInfo.City(),
 					Inline: true,


### PR DESCRIPTION
`Refs #516`. **Same defect shape as #516 itself: captured, stored, read by nothing.**

## What was already there

| provider | field | |
|---|---|---|
| ip-api | `Hosting bool \`json:"hosting"\`` | And the client's field mask **explicitly requests it**: `...,proxy,hosting,query` |
| IPQS | `ConnectionType string` | `"Data Center"` is one of its values |

Before this, `grep` returned **exactly one line** for each — the struct field. Both were fetched on every lookup, parsed, and cached in Redis, and nothing could see them, because `IPInfo` had no method to ask.

This corrects my own earlier escalation on this issue, which said item 2 might need a new data source. It never did.

## A datacenter address is not a proxy address

Both providers treat these as separate facts — ip-api documents `proxy` as *"proxy, VPN or Tor exit"* against `hosting` as *"hosting, colocated or data center"*.

**A rented VPS used as a game proxy is commonly hosting-but-not-proxy**, and read as entirely clean. That case is now a test:

```go
{
    name:           "HostingButNotProxy",
    resp:           IPAPIResponse{Hosting: true, Proxy: false},
    wantDataCenter: true,
    wantVPN:        false,
},
```

**Mutation-proven** — collapsing `IsDataCenter` into `Proxy` turns it red:

```
--- FAIL: TestIPInfoIsDataCenter/IPAPI/HostingButNotProxy
--- FAIL: TestIPInfoIsDataCenter/IPAPI/ProxyButNotHosting
```

## Details that earned a test

- **`IsSharedIP` short-circuits both providers**, for the same reason `IsVPN` already does: a known shared provider is a false positive for both questions, and that list exists to stop those being treated as evidence. The test pulls its sample from the real list and fails if the list is emptied, rather than passing vacuously against a string nothing recognises.
- **IPQS matching is case- and space-insensitive.** The documented value is `"Data Center"`, but a classifier that silently answers "no" because a provider changed a space is worse than one that is slightly loose.
- **An absent value reads as not-a-datacenter.** IPQS omits the field on some plans, and unknown is not yes.

## The consumer

The moderator embed that already reports ISP, ASN and fraud score on a VPN block. **Informational only — no enforcement changes here.** The field is deliberately separate from the VPN determination that produced the embed, so a moderator can tell which fact they are looking at.

## Deliberately not done

`ipapiData.IsVPN()` still ignores `Response.Hosting`, so `BlockVPNUsers` still does not see a hosting-but-not-proxy address. **Widening it would block players in every guild that has `BlockVPNUsers` on** — an enforcement change nobody asked for, and the same reasoning that kept #562 and #564 opt-in.

The current behaviour is now **pinned by test alongside `IsDataCenter`**, so making that change later is a deliberate edit to an assertion rather than a silent shift. The decision is open on #516.

## What this does and does not unblock

This is the prerequisite for **#516 item 2**. Item 2 itself remains blocked on its own question, which no amount of code answers: *is a `/24` within a datacenter narrow enough to be a key rather than a bucket?* An ASN plainly is not — it is shared by every customer of that provider. That needs production data on how many unrelated players share a datacenter `/24`.

Per the rule #551 established: when you widen a matching key, ask what the most common value of the new key is. I am not guessing at that answer.

Full `just test-audit` green: 3391 pass, 130 skip, 0 fail.

Co-authored-by: Andrew Bates <a@sprock.io>