### PR TITLE
docs: settle the alternate-enforcement decisions, and state them as decisions

### DIFF
--- a/docs/handoff-2026-08-08-enforcement-and-coverage-floor.md
+++ b/docs/handoff-2026-08-08-enforcement-and-coverage-floor.md
@@ -9,20 +9,25 @@ which is still current for everything it covers except its open-issue table.
 
 ## The one thing to read if you read nothing else
 
-**Nothing mechanical is left on #516 or #553. Everything remaining is an
-operator decision, and one of those decisions is a question nobody has answered
-in three attempts:**
+**Nothing mechanical is left on #516 or #553, and the enforcement questions are
+settled. Two things remain, both cost/data calls rather than code: #553's
+`pull_request` trigger, and #516 item 2.**
 
-> Is `KickPlayersWithDisabledAlternates` actually enabled in production?
+The enforcement side is closed out:
 
-It matters more than any code in this campaign. It is the switch on the
-delayed-kick path — the only enforcement #516 has ever had. If it is **off**,
-then the alt-linker has been detecting correctly and doing nothing about it the
-entire time, every detection fix in this campaign has landed in front of an
-inert path, and the right next move is to turn one setting on rather than to
-write anything.
+- `KickPlayersWithDisabledAlternates` **is enabled.** The delayed-kick path is
+  live, so the detection work from #551 onward feeds something real.
+- **The delayed kick's current behaviour is deliberate.** It is not a rough
+  edge, and it is not waiting to be upgraded into a login-time reject. The
+  `RejectDisabledAlternatesOnMachineMatch` setting built for that is **off and
+  stays off**.
 
-Check it before building anything else on #516.
+> **Do not enable `RejectDisabledAlternatesOnMachineMatch`, and do not change
+> the delayed kick's timing, without asking the service owner first.**
+
+That is the one instruction in this document that is not a suggestion. Both
+gates being built-and-off is a decision that has already been made, not one
+left open for the next seat.
 
 ---
 
@@ -52,7 +57,7 @@ rather than an upgrade, and the trade belongs to whoever runs the service.
 | setting | what it does | why it is off |
 |---|---|---|
 | `MinimumNakamaAccountAgeDays` (per guild) | gates on the EchoVR account's age, which the existing gate cannot see — it reads the Discord snowflake, so a fresh burner on an aged Discord clears it | making Nakama age authoritative rejects **genuinely new EchoVR players with long-standing Discord accounts** — a real population, and not the one it aims at |
-| `RejectDisabledAlternatesOnMachineMatch` (service) | refuses the login on an exact machine-fingerprint match to a disabled account, instead of admitting the session and kicking it 1–4 minutes later | the delayed kick buys **ambiguity about which signal caught them**; rejecting at login tells an evader exactly what to change, on the login that carried it |
+| `RejectDisabledAlternatesOnMachineMatch` (service) | refuses the login on an exact machine-fingerprint match to a disabled account, instead of admitting the session and kicking it 1–4 minutes later | **Settled: it stays off.** The existing delayed kick is deliberate and is not a placeholder for this. Do not enable it, and do not change the kick timing, without asking the service owner |
 | — | `ipapiData.IsVPN()` ignoring `Response.Hosting` is **left as-is** | widening it blocks players in every guild with `BlockVPNUsers` on. The current behaviour is now pinned by test, so changing it is a deliberate edit rather than a silent shift |
 
 ---
@@ -228,10 +233,21 @@ Run `git add` **before** the checks, not after.
 
 In order:
 
-1. **Answer the `KickPlayersWithDisabledAlternates` question.** Everything else
-   on #516 is downstream of it.
-2. Decide whether to enable the two new gates. Both are built and off.
+1. ~~Answer the `KickPlayersWithDisabledAlternates` question.~~ **Answered: it
+   is enabled.** The delayed-kick path is live, so the detection work from #551
+   onward feeds something real.
+2. ~~Decide whether to enable the two new gates.~~ **Both settled, both stay
+   off:**
+   - `RejectDisabledAlternatesOnMachineMatch` — **do not enable it, and do not
+     change the delayed kick's timing, without asking the service owner.** The
+     current behaviour is deliberate. This is not an upgrade waiting to be
+     switched on.
+   - `MinimumDiscordAccountAgeDays` — one guild uses it, and that guild is the
+     owner's to configure. `MinimumNakamaAccountAgeDays` stays available and
+     off.
 3. #553's `pull_request` trigger — a cost call, and the suite can now complete.
+   **Still open.**
 4. Only then, item 2, and only with production data on datacenter `/24` sharing.
+   **Still open.**
 
 Do not implement item 2 by reasoning about it. That is how a bucket ships.

--- a/server/evr_global_settings.go
+++ b/server/evr_global_settings.go
@@ -87,10 +87,10 @@ type ServiceSettingsData struct {
 	// NOT trigger it -- they are rotated trivially, and a shared IP is a
 	// household, not a person.
 	//
-	// Off by default, because it is a trade rather than an upgrade. The delayed
-	// kick costs a few minutes of presence and buys ambiguity about which signal
-	// caught them; rejecting at login is immediate but tells an evader exactly
-	// what to change, on the login that carried it. See #516.
+	// OFF, AND IT STAYS OFF UNLESS THE SERVICE OWNER SAYS OTHERWISE. The
+	// existing delayed kick is deliberate and is not a placeholder for this.
+	// Do not enable this, and do not change the kick timing, without asking
+	// first. See #516.
 	RejectDisabledAlternatesOnMachineMatch bool   `json:"reject_disabled_alts_on_machine_match"`
 	VRMLEntitlementNotifyChannelID         string `json:"vrml_entitlement_notify_channel_id"`
 	VRMLOutageMode                         bool   `json:"vrml_outage_mode"` // Disable live VRML API calls and rely on cached data only.

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -626,9 +626,9 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 	// two filters cannot mask one another; machineMatchedAlts applies its own,
 	// stricter test.
 	//
-	// Off unless the operator turns it on -- see
-	// RejectDisabledAlternatesOnMachineMatch for the trade. ignoreDisabledAlternates
-	// is honoured here exactly as the delayed-kick path honours it, so an account
+	// Off, and it stays off unless the service owner says otherwise -- see
+	// RejectDisabledAlternatesOnMachineMatch. ignoreDisabledAlternates is
+	// honoured here exactly as the delayed-kick path honours it, so an account
 	// cleared by a moderator stays cleared.
 	if ServiceSettings().RejectDisabledAlternatesOnMachineMatch && !params.ignoreDisabledAlternates {
 		if machineIDs := machineMatchedAlts(loginHistory, firstIDs, detector); len(machineIDs) > 0 {
@@ -650,10 +650,8 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 
 				metricsTags["error"] = "machine_matched_disabled_alt"
 
-				// The same error a disabled account itself gets. Telling an
-				// evader which signal caught them is the cost this whole
-				// setting trades against; the audit log above carries the
-				// detail for moderators.
+				// The same error a disabled account itself gets. The audit log
+				// above carries the detail for moderators.
 				return AccountDisabledError{
 					message:   "Account Disabled",
 					reportURL: ServiceSettings().ReportURL,


### PR DESCRIPTION
Comments and documentation only. No behaviour change.

## What is settled

- **`KickPlayersWithDisabledAlternates` is enabled.** The delayed-kick path is live, so the detection work from #551 onward feeds something real. The handoff no longer leads with that as an open question.
- **`RejectDisabledAlternatesOnMachineMatch` stays off.** The existing delayed kick is deliberate — not a rough edge waiting to be upgraded into a login-time reject.

## Why this is worth a commit

A setting that is built, tested, documented, and off reads to the next person as **an improvement nobody has got round to switching on**. Left framed that way, it invites exactly the change it must not receive.

The three places that framed it as a tradeoff to be weighed now say *ask first* instead:

- `server/evr_global_settings.go` — the setting's own doc comment
- `server/evr_pipeline_login.go` — two comments at the gate
- `docs/handoff-2026-08-08-enforcement-and-coverage-floor.md` — the settings table row

## Handoff decision list

Items 1 and 2 are struck through and marked closed. **Items 3 and 4 are unchanged and still open** — #553's `pull_request` trigger (a cost call) and #516 item 2 (needs production data on datacenter `/24` sharing).

The lead section is replaced; it was built entirely around the now-answered question, and it was the first thing anyone would read.

Full `just test-audit` green: 3411 pass, 130 skip, 0 fail.

Co-authored-by: Andrew Bates <a@sprock.io>