### PR TITLE
fix(reservations): stop SignalCreatePartyReservations overbooking a full lobby

### DIFF
--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -2116,6 +2116,7 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal create party reservations: %v", err)}.String()
 		}
 		created := 0
+		skipped := 0
 		for _, member := range payload.Members {
 			// Skip if the member is already an active presence. Match by user ID,
 			// not just session ID: a member who reconnected holds their presence
@@ -2141,6 +2142,24 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			if alreadyPresent {
 				continue // already in match
 			}
+			// Refuse to reserve a slot the match does not have.
+			//
+			// Without this the handler overbooks: OpenSlots() goes negative and
+			// the lobby holds more reservations than seats. What the spec asks
+			// for is in docs/spec-party-reservation-system.md -- "should only
+			// create reservations for members that fit" -- and it was never
+			// implemented.
+			//
+			// The check has to be INSIDE the loop, and rebuildCache below has to
+			// be too. OpenSlots() is computed from the cached Size and
+			// ReservationCount, so a single check before the loop reads the same
+			// stale value for every member: two followers would both pass a
+			// one-slot check and both get in. Recomputing per member is what
+			// makes the guard hold for the second one.
+			if state.OpenSlots() <= 0 {
+				skipped++
+				continue
+			}
 			// Upsert by user ID: replace any existing reservation for this member
 			// (possibly under a stale session ID from a prior connection) so they
 			// end up with exactly one reservation. Symmetric with the UserID-aware
@@ -2150,13 +2169,13 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 				Expiry:   time.Now().Add(5 * time.Minute),
 			})
 			created++
-		}
-		if created > 0 {
+			// Make the reservation visible to the next iteration's OpenSlots().
 			state.rebuildCache()
 		}
 		logger.WithFields(map[string]any{
 			"requested": len(payload.Members),
 			"created":   created,
+			"skipped":   skipped,
 		}).Info("Created party reservations via signal")
 
 	case SignalClearPartyReservations:

--- a/server/evr_reservation_capacity_test.go
+++ b/server/evr_reservation_capacity_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"github.com/stretchr/testify/assert"
+)
+
+// These tests cover the atomic capacity guard on party-reservation creation
+// (production 2026-07-05, deployed as v3.27.2-evr.319). Before the fix,
+// SignalCreatePartyReservations upserted a reservation UNCONDITIONALLY -- it only
+// checked whether the member was already present. Reservations therefore stacked
+// onto already-full social lobbies; the follower's join then died at the capacity
+// gate (ErrJoinRejectReasonReservationViolated) and the client stormed rejects
+// (2-13 rejects, up to ~50s) before landing in a different lobby.
+//
+// The signal handler runs on the single match goroutine (match_handler.go's
+// select over signalCh/joinAttemptCh), so a capacity check inside the handler is
+// atomic with respect to joins AND to other reservation-creates. rebuildCache()
+// after each upsert keeps OpenSlots() current within the create loop, so the
+// SECOND follower in one signal sees the FIRST's reservation -- closing the
+// two-follower overbook race (issue #510 transactional shape).
+
+// fillSocialLobby adds n filler player presences to the match so that
+// OpenSlots() == MaxSize - n (Size counts real presences). It mirrors a lobby
+// that already has n occupants.
+func fillSocialLobby(state *MatchLabel, n int) {
+	for i := 0; i < n; i++ {
+		sid := uuid.Must(uuid.NewV4())
+		state.presenceMap[sid.String()] = &EvrMatchPresence{
+			UserID:        uuid.Must(uuid.NewV4()),
+			SessionID:     sid,
+			RoleAlignment: evr.TeamSocial,
+		}
+	}
+	state.rebuildCache()
+}
+
+func socialMember() *EvrMatchPresence {
+	return &EvrMatchPresence{
+		UserID:        uuid.Must(uuid.NewV4()),
+		SessionID:     uuid.Must(uuid.NewV4()),
+		RoleAlignment: evr.TeamSocial,
+	}
+}
+
+// FIX 1 test A: a reservation must NOT be created for a member when the lobby is
+// already full (OpenSlots == 0). RED without the guard (reservation created,
+// OpenSlots goes negative); GREEN with it (member simply gets no reservation).
+func TestReservationCapacity_NoReservationIntoFullLobby(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+	fillSocialLobby(state, SocialLobbyMaxSize) // OpenSlots == 0
+	if got := state.OpenSlots(); got != 0 {
+		t.Fatalf("setup: expected OpenSlots()==0 (full lobby), got %d", got)
+	}
+
+	member := socialMember()
+	before := len(state.reservationMap)
+	state = signalCreatePartyReservations(t, m, state, member)
+
+	if got := len(state.reservationMap); got != before {
+		t.Errorf("expected NO reservation created into a full lobby; reservationMap grew %d -> %d", before, got)
+	}
+	if _, ok := state.reservationMap[member.SessionID.String()]; ok {
+		t.Errorf("a reservation was created for the member despite the lobby being full")
+	}
+	if got := state.OpenSlots(); got < 0 {
+		t.Errorf("OpenSlots() went negative (%d): the reservation overbooked a full lobby", got)
+	}
+}
+
+// FIX 1 test B: the two-follower race. A lobby with exactly ONE open slot and a
+// single signal carrying TWO members must produce exactly ONE reservation -- the
+// second is skipped for lack of room. RED without the in-handler check + rebuild
+// (both created -> overbook, OpenSlots == -1); GREEN with it (exactly one).
+func TestReservationCapacity_TwoFollowersOneSlot_OnlyOneReserved(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+	fillSocialLobby(state, SocialLobbyMaxSize-1) // OpenSlots == 1
+	if got := state.OpenSlots(); got != 1 {
+		t.Fatalf("setup: expected OpenSlots()==1 (one open slot), got %d", got)
+	}
+
+	m1 := socialMember()
+	m2 := socialMember()
+	state = signalCreatePartyReservations(t, m, state, m1, m2)
+
+	reserved := 0
+	if _, ok := state.reservationMap[m1.SessionID.String()]; ok {
+		reserved++
+	}
+	if _, ok := state.reservationMap[m2.SessionID.String()]; ok {
+		reserved++
+	}
+	if reserved != 1 {
+		t.Errorf("expected exactly 1 of 2 followers reserved into a 1-slot lobby, got %d (overbook)", reserved)
+	}
+	if state.ReservationCount != 1 {
+		t.Errorf("expected ReservationCount==1, got %d", state.ReservationCount)
+	}
+	if got := state.OpenSlots(); got != 0 {
+		t.Errorf("expected OpenSlots()==0 after the single slot is filled, got %d", got)
+	}
+}
+
+// FIX 1 test C: happy path -- a lobby with room for the whole party reserves all
+// members (no regression).
+func TestReservationCapacity_RoomForWholeParty_AllReserved(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+	fillSocialLobby(state, SocialLobbyMaxSize-3) // OpenSlots == 3
+	if got := state.OpenSlots(); got != 3 {
+		t.Fatalf("setup: expected OpenSlots()==3, got %d", got)
+	}
+
+	members := []*EvrMatchPresence{socialMember(), socialMember(), socialMember()}
+	state = signalCreatePartyReservations(t, m, state, members...)
+
+	for i, mm := range members {
+		if _, ok := state.reservationMap[mm.SessionID.String()]; !ok {
+			t.Errorf("member %d (%s) should be reserved when there is room", i, mm.SessionID)
+		}
+	}
+	if state.ReservationCount != 3 {
+		t.Errorf("expected ReservationCount==3, got %d", state.ReservationCount)
+	}
+	if got := state.OpenSlots(); got != 0 {
+		t.Errorf("expected OpenSlots()==0 after reserving the whole party, got %d", got)
+	}
+}
+
+// The arena-mode guard that used to be tested here is deliberately NOT part of
+// this change. createPartyReservations hardcodes RoleAlignment: evr.TeamSocial,
+// so gating it on label.IsSocial() is correct in principle -- but both current
+// callers already gate, making it defence in depth rather than a live fix, and
+// adding it breaks TestCreatePartyReservations_GroupParty_ReservesFollower,
+// which calls the function with a match ID it never registers. That test is
+// valid under the current contract, where the function trusts its callers.
+// Changing that contract is a separate change with its own test updates.
+
+func TestCreatePartyReservations_SocialMatch_ReservesFollower(t *testing.T) {
+	env := mkGroupReservationEnv(t, "monarch12")
+	groupID := uuid.Must(uuid.NewV4())
+
+	follower := newPartyMemberSession(t, "follower", env.tracker, env.pr, env.ep)
+	env.sessions.sessions[follower.id] = follower
+	env.tracker.Track(context.Background(), env.leaderSID, env.ph.Stream, env.leaderUID, PresenceMeta{Username: "leader"})
+	env.tracker.Track(context.Background(), follower.id, env.ph.Stream, follower.userID, PresenceMeta{Username: "follower"})
+
+	socialMatchID := MatchID{UUID: uuid.Must(uuid.NewV4()), Node: "testnode"}
+	env.registry.SetMatch(socialMatchID, mkGroupSocialLabel(socialMatchID, groupID))
+
+	env.ep.createPartyReservations(context.Background(), loggerForTest(t), socialMatchID, env.leaderSID, env.ph.ID)
+
+	assert.Contains(t, env.registry.reservedSessionIDs(), follower.id,
+		"a follower whose leader is in a social match must still be reserved")
+}


### PR DESCRIPTION
**PR-C of 3.** A live bug in `main`, with the RED test that proves it.

## The bug

`SignalCreatePartyReservations` (`evr_match.go:2113`) upserted a reservation for every eligible member **without ever asking whether the match had room**. `OpenSlots()` went negative; the lobby held more reservations than seats.

Verified against a clean extract of `origin/main` before writing any fix:

```
--- FAIL: TestReservationCapacity_NoReservationIntoFullLobby
    reservationMap grew 0 -> 1
    OpenSlots() went negative (-1): the reservation overbooked a full lobby
--- FAIL: TestReservationCapacity_TwoFollowersOneSlot_OnlyOneReserved
    expected exactly 1 of 2 followers reserved into a 1-slot lobby, got 2 (overbook)
    expected OpenSlots()==0 after the single slot is filled, got -1
```

**The spec already required this.** `docs/spec-party-reservation-system.md:581` — *"`createPartyReservations` should only create reservations for members that fit."* Never implemented, and no test in main drove the signal handler against a full lobby, so nothing caught it.

Reachable on the live path: `createReservationForNewPartyMember` dispatches on every follower `LobbyFindSessionRequest` re-send and gates on `IsSocial()` only, never on capacity.

## Why the guard is inside the loop

This is the part worth reviewing. `OpenSlots()` is derived from the **cached** `Size` and `ReservationCount`, so a single check before the loop reads the same stale value for every member — two followers both pass a one-slot check and both get in.

So the check *and* `rebuildCache()` both moved inside the loop. `TwoFollowersOneSlot` is precisely the test that distinguishes the two designs: a pre-loop check leaves it red.

## Where the tests came from

They were not written for this fix. They were **recovered from a working tree** during a branch audit — uncommitted since 2026-07-05, on a branch whose committed content was byte-identical to main. By every git-visible measure that branch was empty and safe to delete; the tests existed only on disk.

They compile against main unmodified and were red before this change.

## Deliberately not included

Gating `createPartyReservations` on `label.IsSocial()`. That function hardcodes `RoleAlignment: evr.TeamSocial`, so the gate is correct in principle — but both callers already check, making it defence in depth, and adding it **breaks `TestCreatePartyReservations_GroupParty_ReservesFollower`**, which calls the function with a match ID it never registers. That test is valid under the current contract, where the function trusts its callers.

Changing that contract needs its own test updates. I tried it, saw the breakage, and backed it out rather than adjust a green test to fit. The reasoning is recorded in the test file so the next reader doesn't rediscover it.

`just test-audit` green: **3415 pass, 130 skip, 0 fail**.

Co-authored-by: Andrew Bates <a@sprock.io>