### PR TITLE
chore: gitignore .claude/, the one agent directory that was missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ go.work.sum
 .serena/
 .opencode/
 .vscode/
+# Claude Code's per-clone state, including any worktrees it creates under
+# .claude/worktrees. Same category as the agent and editor directories
+# above; it was the only one missing, so it showed up as untracked noise in
+# every `git status` and in the fmt/exec-bit checks that glob the tree.
+.claude/
 
 ### Angular ###
 ## Angular ##


### PR DESCRIPTION
**PR-D.** One line plus a comment.

`.gitignore` already lists `.sisyphus/`, `.serena/`, `.opencode/` and `.vscode/` on consecutive lines, and `.claude-line/` further down. **`.claude/` was the only one of its kind not covered**, so every clone Claude Code touched reported it as untracked forever.

Not purely cosmetic: `.claude/worktrees` holds full repo checkouts — **110 MB in this clone** — inside the working tree, where the repo's own tooling globs. It sat in every `git status`, and any check walking untracked files had to step over it.

**Verified rather than assumed.** With the rule in place, creating `.claude/worktrees/` and `.claude/settings.local.json` leaves `git status` completely clean.

Placed directly beneath its siblings rather than appended, so the group stays readable as one category.

Co-authored-by: Andrew Bates <a@sprock.io>