### PR TITLE
fix(reservations): /create actually holds slots for online party members

### DIFF
--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -834,6 +834,10 @@ func (d *DiscordAppBot) handleCreateMatch(ctx context.Context, logger runtime.Lo
 		teamAlignments[memberUserID] = teamAlignment
 	}
 
+	// Hold slots for online party members against backfill (RESV-1). The creator
+	// joins directly via the normal join race, so only followers need a reservation.
+	reservations := getOnlinePartyReservations(ctx, d.nk, logger, userID, partyUserIDs, teamAlignment)
+
 	settings := &MatchSettings{
 		Mode:                mode,
 		Level:               level,
@@ -841,6 +845,7 @@ func (d *DiscordAppBot) handleCreateMatch(ctx context.Context, logger runtime.Lo
 		StartTime:           startTime.UTC().Add(1 * time.Minute),
 		SpawnedBy:           userID,
 		TeamAlignments:      teamAlignments,
+		Reservations:        reservations,
 		ReservationLifetime: 45 * time.Second,
 	}
 

--- a/server/evr_discord_appbot_reservations_test.go
+++ b/server/evr_discord_appbot_reservations_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap"
+)
+
+// mockOnlinePresence is a runtime.Presence with a configurable session ID and
+// username, used to simulate a party member's live login-service presence.
+type mockOnlinePresence struct {
+	userID    string
+	sessionID string
+	username  string
+}
+
+func (p *mockOnlinePresence) GetUserId() string                 { return p.userID }
+func (p *mockOnlinePresence) GetSessionId() string              { return p.sessionID }
+func (p *mockOnlinePresence) GetNodeId() string                 { return "testnode" }
+func (p *mockOnlinePresence) GetHidden() bool                   { return false }
+func (p *mockOnlinePresence) GetPersistence() bool              { return false }
+func (p *mockOnlinePresence) GetUsername() string               { return p.username }
+func (p *mockOnlinePresence) GetStatus() string                 { return "" }
+func (p *mockOnlinePresence) GetReason() runtime.PresenceReason { return runtime.PresenceReasonUnknown }
+
+// mockNakamaModuleForReservations serves login-service presence lookups for a
+// fixed set of "online" users, and asserts the caller only ever queries the
+// login-service stream (the primitive getOnlinePartyReservations is documented
+// to use for the online check).
+type mockNakamaModuleForReservations struct {
+	runtime.NakamaModule
+	online map[string]*mockOnlinePresence // keyed by userID
+	calls  []string                       // userIDs queried, in order
+}
+
+func (m *mockNakamaModuleForReservations) StreamUserList(mode uint8, subject, _ string, label string, _, _ bool) ([]runtime.Presence, error) {
+	if mode != StreamModeService || label != StreamLabelLoginService {
+		return nil, fmt.Errorf("unexpected stream lookup: mode=%d label=%s", mode, label)
+	}
+	m.calls = append(m.calls, subject)
+	p, ok := m.online[subject]
+	if !ok {
+		return nil, nil
+	}
+	return []runtime.Presence{p}, nil
+}
+
+func TestGetOnlinePartyReservations(t *testing.T) {
+	logger := NewRuntimeGoLogger(zap.NewNop())
+	creatorID := uuid.Must(uuid.NewV4()).String()
+	followerOnlineID := uuid.Must(uuid.NewV4()).String()
+	followerOfflineID := uuid.Must(uuid.NewV4()).String()
+	followerOnlineSession := uuid.Must(uuid.NewV4())
+
+	nk := &mockNakamaModuleForReservations{
+		online: map[string]*mockOnlinePresence{
+			followerOnlineID: {
+				userID:    followerOnlineID,
+				sessionID: followerOnlineSession.String(),
+				username:  "follower-online",
+			},
+			// creator intentionally omitted -- must never be queried (skipped
+			// before any lookup, since the creator joins directly).
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "testnode")
+
+	t.Run("solo creator produces no reservations", func(t *testing.T) {
+		nk.calls = nil
+		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, []string{creatorID}, evr.TeamBlue)
+		if len(got) != 0 {
+			t.Fatalf("expected no reservations for solo creator, got %d", len(got))
+		}
+		if len(nk.calls) != 0 {
+			t.Fatalf("expected creator to be skipped without a stream lookup, got calls=%v", nk.calls)
+		}
+	})
+
+	t.Run("online follower gets a reservation, offline follower is skipped", func(t *testing.T) {
+		nk.calls = nil
+		partyUserIDs := []string{creatorID, followerOnlineID, followerOfflineID}
+		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, partyUserIDs, evr.TeamBlue)
+
+		if len(got) != 1 {
+			t.Fatalf("expected exactly 1 reservation (online follower only), got %d: %+v", len(got), got)
+		}
+
+		r := got[0]
+		if r.UserID.String() != followerOnlineID {
+			t.Errorf("expected reservation for user %s, got %s", followerOnlineID, r.UserID.String())
+		}
+		if r.SessionID != followerOnlineSession {
+			t.Errorf("expected reservation session %s, got %s", followerOnlineSession, r.SessionID)
+		}
+		if r.Username != "follower-online" {
+			t.Errorf("expected username 'follower-online', got %q", r.Username)
+		}
+		if r.RoleAlignment != evr.TeamBlue {
+			t.Errorf("expected role alignment %d, got %d", evr.TeamBlue, r.RoleAlignment)
+		}
+		if r.Node != "testnode" {
+			t.Errorf("expected node 'testnode', got %q", r.Node)
+		}
+
+		// Both followers should have been checked; the offline one produced no reservation.
+		checked := map[string]bool{}
+		for _, c := range nk.calls {
+			checked[c] = true
+		}
+		if !checked[followerOnlineID] || !checked[followerOfflineID] {
+			t.Errorf("expected both followers to be checked for online status, got calls=%v", nk.calls)
+		}
+		if checked[creatorID] {
+			t.Errorf("creator should never be queried for online status, got calls=%v", nk.calls)
+		}
+	})
+
+	t.Run("empty party produces no reservations", func(t *testing.T) {
+		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, nil, evr.TeamBlue)
+		if len(got) != 0 {
+			t.Fatalf("expected no reservations for empty party, got %d", len(got))
+		}
+	})
+
+	t.Run("missing node in context bails out", func(t *testing.T) {
+		got := getOnlinePartyReservations(context.Background(), nk, logger, creatorID, []string{creatorID, followerOnlineID}, evr.TeamBlue)
+		if got != nil {
+			t.Fatalf("expected nil reservations when node is missing from context, got %+v", got)
+		}
+	})
+}

--- a/server/evr_match_create_reservation_test.go
+++ b/server/evr_match_create_reservation_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama/v3/server/evr"
+	"go.uber.org/zap/zapcore"
+)
+
+// TestMatchJoinAttempt_CreateReservationHoldsSlotAgainstBackfill is the RESV-1
+// integration test: it drives the real MatchJoinAttempt capacity gate to prove
+// that a slot reserved for an online party member at /create time is held
+// against backfill, and can still be claimed by the party member even though
+// their eventual match-connection session ID differs from the placeholder
+// session captured when the reservation was made (getOnlinePartyReservations
+// resolves party members via their *login*-service presence, since they have
+// not started their own match connection yet -- see evr_runtime.go).
+//
+// The reservation is installed exactly the way SignalPrepareSession installs
+// settings.Reservations into state.reservationMap (evr_match.go, SignalPrepareSession
+// case, "for _, e := range settings.Reservations"), so this test exercises the
+// same production conversion that /create's new getOnlinePartyReservations
+// output feeds into MatchSettings.Reservations.
+func TestMatchJoinAttempt_CreateReservationHoldsSlotAgainstBackfill(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeSocialPublic
+	state.LobbyType = PublicLobby
+	// A tiny 2-slot lobby makes the backfill-blocking behavior unambiguous:
+	// creator (1) + reservation (1) == full, with zero slack for a backfill join.
+	state.MaxSize = 2
+	state.PlayerLimit = 2
+
+	partyID := uuid.Must(uuid.NewV4())
+	creatorUserID := uuid.Must(uuid.NewV4())
+	creatorSessionID := uuid.Must(uuid.NewV4())
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	// followerLoginSessionID stands in for the placeholder session ID
+	// getOnlinePartyReservations captures from the follower's login-service
+	// presence at /create time -- NOT the session they'll actually join with.
+	followerLoginSessionID := uuid.Must(uuid.NewV4())
+	followerMatchSessionID := uuid.Must(uuid.NewV4())
+
+	backfillUserID := uuid.Must(uuid.NewV4())
+	backfillSessionID := uuid.Must(uuid.NewV4())
+
+	// --- Step 1: simulate /create's SignalPrepareSession, which converts
+	// MatchSettings.Reservations (produced by getOnlinePartyReservations) into
+	// state.reservationMap. This is the exact loop body from evr_match.go's
+	// SignalPrepareSession case.
+	settingsReservations := []*EvrMatchPresence{
+		{
+			Node:          "testnode",
+			SessionID:     followerLoginSessionID,
+			UserID:        followerUserID,
+			Username:      "follower",
+			PartyID:       partyID,
+			RoleAlignment: evr.TeamSocial,
+		},
+	}
+	reservationLifetime := 45 * time.Second
+	for _, e := range settingsReservations {
+		state.reservationMap[e.GetSessionId()] = &slotReservation{
+			Presence: e,
+			Expiry:   time.Now().Add(reservationLifetime),
+		}
+	}
+	state.rebuildCache()
+
+	if state.OpenSlots() != 1 {
+		t.Fatalf("expected 1 open slot before the creator joins (reservation holds the other), got OpenSlots()=%d", state.OpenSlots())
+	}
+
+	m := &EvrMatch{}
+	ctx := context.Background()
+	logger := NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
+	nk := &reconnectTestNakamaModule{}
+	disp := &reconnectTestDispatcher{}
+
+	// --- Step 2: the creator joins directly (no reservation needed -- they win
+	// the normal join race), taking the lobby's one remaining open slot and
+	// bringing total occupancy (1 actual + 1 reservation) to the 2-slot cap.
+	creatorPresence := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     creatorSessionID,
+		UserID:        creatorUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 1},
+		Username:      "creator",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+	}
+	creatorMeta := NewJoinMetadata(creatorPresence)
+	resultState, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, creatorPresence, creatorMeta.ToMatchMetadata())
+	if !allowed {
+		t.Fatalf("expected creator join to succeed, got rejected: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	if state.OpenSlots() != 0 {
+		t.Fatalf("expected the lobby to be at capacity (creator + reservation), got OpenSlots()=%d", state.OpenSlots())
+	}
+
+	// --- Step 3: an unrelated backfill player attempts to join. The reservation
+	// must hold the slot -- this is the crux of RESV-1: today's bug is that
+	// nothing ever populates settings.Reservations, so a match like this would
+	// have zero reservations and this backfill join would incorrectly succeed.
+	backfillPresence := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     backfillSessionID,
+		UserID:        backfillUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 999},
+		Username:      "backfiller",
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+	}
+	backfillMeta := NewJoinMetadata(backfillPresence)
+
+	resultState, allowed, reason = m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, backfillPresence, backfillMeta.ToMatchMetadata())
+	if allowed {
+		t.Fatalf("expected backfill join to be rejected while the party reservation holds the slot, got allowed with reason=%q", reason)
+	}
+	if reason != ErrJoinRejectReasonLobbyFull.Error() {
+		t.Fatalf("expected lobby-full rejection for backfill join, got: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	if _, exists := state.reservationMap[followerLoginSessionID.String()]; !exists {
+		t.Fatal("reservation must survive a rejected backfill join attempt")
+	}
+
+	// --- Step 4: the reserved party member joins with their real match-connection
+	// session (different from the login-session placeholder). The reservation must
+	// be found via the user-ID fallback (LoadAndDeleteReservationByUserIDRaw) and
+	// consumed, freeing the slot the total-capacity gate would otherwise deny.
+	followerPresence := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerMatchSessionID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 2},
+		Username:      "follower",
+		PartyID:       partyID,
+		RoleAlignment: evr.TeamSocial,
+		SessionExpiry: 9999999999,
+	}
+	followerMeta := NewJoinMetadata(followerPresence)
+	resultState, allowed, reason = m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, followerPresence, followerMeta.ToMatchMetadata())
+	if !allowed {
+		t.Fatalf("expected reserved party member to join by consuming their reservation, got rejected: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	if _, exists := state.reservationMap[followerLoginSessionID.String()]; exists {
+		t.Error("reservation should have been consumed once the reserved member actually joined")
+	}
+	if _, joined := state.presenceMap[followerMatchSessionID.String()]; !joined {
+		t.Error("follower should now be a real presence in the match")
+	}
+}

--- a/server/evr_match_signals.go
+++ b/server/evr_match_signals.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -21,7 +20,6 @@ const (
 	SignalEndedSession
 	SignalGetEndpoint
 	SignalGetPresences
-	SignalReserveSlots
 	SignalPruneUnderutilized
 	SignalShutdown
 	SignalPlayerUpdate
@@ -98,12 +96,6 @@ type SignalShutdownPayload struct {
 
 type SignalKickEntrantsPayload struct {
 	UserIDs []uuid.UUID `json:"user_ids"`
-}
-
-type SignalReserveSlotsPayload struct {
-	SessionIDs    []string
-	RoleAlignment int
-	ExpiryTime    time.Time
 }
 
 // SignalCreatePartyReservationsPayload carries the list of party members

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -742,6 +742,64 @@ func getPartyMembersForUser(ctx context.Context, nk runtime.NakamaModule, partyR
 	return partyUserIDs
 }
 
+// getOnlinePartyReservations resolves party members (excluding the creator) who are
+// currently online into EvrMatchPresence placeholders suitable for
+// MatchSettings.Reservations, so a newly-created match can hold their slot against
+// backfill for the settings.ReservationLifetime (see RESV-1). A member's login-service
+// presence is used as the placeholder session -- it does not need to match the session
+// ID the member eventually joins with, because MatchJoinAttempt falls back to a
+// user-ID lookup (LoadAndDeleteReservationByUserIDRaw) when the session ID differs.
+// Members who are not currently online (no resolvable login-service presence) are
+// skipped -- reservations can only be made for resolvable, connected presences.
+// This function never returns an error; unresolvable members are silently skipped
+// (matching getPartyMembersForUser's fail-open convention above).
+func getOnlinePartyReservations(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, creatorUserID string, partyUserIDs []string, roleAlignment int) []*EvrMatchPresence {
+	node, ok := ctx.Value(runtime.RUNTIME_CTX_NODE).(string)
+	if !ok {
+		return nil
+	}
+
+	reservations := make([]*EvrMatchPresence, 0, len(partyUserIDs))
+	for _, memberUserID := range partyUserIDs {
+		if memberUserID == "" || memberUserID == creatorUserID {
+			continue // the creator joins directly; no reservation needed
+		}
+
+		presences, err := nk.StreamUserList(StreamModeService, memberUserID, "", StreamLabelLoginService, false, true)
+		if err != nil || len(presences) == 0 {
+			logger.WithField("user_id", memberUserID).Debug("Skipping match reservation for offline party member")
+			continue
+		}
+
+		var presence runtime.Presence
+		for _, p := range presences {
+			if p.GetUserId() == memberUserID {
+				presence = p
+				break
+			}
+		}
+		if presence == nil {
+			continue
+		}
+
+		sessionID := uuid.FromStringOrNil(presence.GetSessionId())
+		userID := uuid.FromStringOrNil(memberUserID)
+		if sessionID == uuid.Nil || userID == uuid.Nil {
+			continue
+		}
+
+		reservations = append(reservations, &EvrMatchPresence{
+			Node:          node,
+			SessionID:     sessionID,
+			UserID:        userID,
+			Username:      presence.GetUsername(),
+			RoleAlignment: roleAlignment,
+		})
+	}
+
+	return reservations
+}
+
 func SetNextMatchID(ctx context.Context, nk runtime.NakamaModule, userID string, matchID MatchID, role TeamIndex, hostDiscordID string) error {
 	directive := &JoinDirective{
 		MatchID:       matchID,


### PR DESCRIPTION
Closes #572.

## What was wrong

`handleCreateMatch` set `ReservationLifetime: 45 * time.Second` but never populated `MatchSettings.Reservations`. The lifetime applied to an empty list, so a party leader running `/create` on a public match had **no slots held for their party** — followers raced backfill for their own lobby's slots.

## What changed

- **`getOnlinePartyReservations()`** (`evr_runtime.go`) resolves the creator's online party members into `EvrMatchPresence` placeholders from their login-service stream presence. Offline members are skipped; the creator is excluded (they join directly via the normal join race).
- **`handleCreateMatch`** passes the result as `Reservations`.
- **Removed `SignalReserveSlots` / `SignalReserveSlotsPayload`** — no callers, superseded by `SignalCreatePartyReservations`.

The placeholder session ID does not need to match the session the member eventually joins with: `MatchJoinAttempt` falls back to `LoadAndDeleteReservationByUserIDRaw` when it differs.

## On the 45s lifetime

Left unchanged, deliberately. Reservation lifetimes elsewhere: lobby builder 20s, lobby find 30s, post-match social transition 5min. `/create` is already the most generous of the cases where a player must navigate in. `StartTime` does not gate joinability — it feeds `Started()` and the `PublicMatchWaitTime` backfill cutoff only.

## Provenance

Recovered from an uncommitted working tree dated 2026-07-03 during the branch audit, held on `wip/572-create-match-reservations`. Cherry-picked onto main with no conflicts.

## Verification

- `go build ./server/` — clean
- Both recovered tests execute and pass (`-v` confirmed, 5 subtests):
  - `TestGetOnlinePartyReservations` — solo creator, online/offline follower split, empty party, missing node
  - `TestMatchJoinAttempt_CreateReservationHoldsSlotAgainstBackfill`
- `just test` green; `server` package 130.077s

Co-authored-by: nakama-fixer <nakama-fixer@metis.agents>