### PR TITLE
fix: seven defects from the adversarial review of the release range

### DIFF
--- a/server/evr_discord_appbot.go
+++ b/server/evr_discord_appbot.go
@@ -2520,7 +2520,7 @@ func (d *DiscordAppBot) RegisterSlashCommands() error {
 
 			// Get all party members (including the creator) before creating the match
 			// so we can set up team alignments and reservations
-			partyUserIDs := getPartyMembersForUser(ctx, nk, d.pipeline.partyRegistry, userID)
+			partyUserIDs := getPartyMembersForUser(ctx, nk, d.pipeline.partyRegistry, userID, d.pipeline.node)
 
 			label, rttMs, err := d.handleCreateMatch(ctx, logger, userID, i.GuildID, region, mode, level, startTime, partyUserIDs, role)
 			if err != nil {

--- a/server/evr_discord_appbot_create_test.go
+++ b/server/evr_discord_appbot_create_test.go
@@ -62,7 +62,11 @@ func TestGetPartyMembersForUser(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "testnode")
+			// The node is passed explicitly now. It used to be planted here as
+			// runtime.RUNTIME_CTX_NODE, which is what let this test pass while
+			// the production caller -- a Discord slash command, whose context
+			// never carries that key -- got nothing back but the creator.
+			ctx := context.Background()
 
 			// Create mock NakamaModule
 			nk := &mockNakamaModuleForParty{
@@ -73,7 +77,7 @@ func TestGetPartyMembersForUser(t *testing.T) {
 
 			// Create a mock registry that returns a fixed UUID for any group name.
 			pr := &mockPartyRegistryForLookup{groupID: tt.partyGroupID, partyID: uuid.Must(uuid.NewV4())}
-			userIDs := getPartyMembersForUser(ctx, nk, pr, tt.userID)
+			userIDs := getPartyMembersForUser(ctx, nk, pr, tt.userID, "testnode")
 
 			if len(userIDs) != len(tt.expectedUserIDs) {
 				t.Errorf("Expected %d user IDs, got %d", len(tt.expectedUserIDs), len(userIDs))

--- a/server/evr_discord_appbot_handlers.go
+++ b/server/evr_discord_appbot_handlers.go
@@ -819,24 +819,41 @@ func (d *DiscordAppBot) handleCreateMatch(ctx context.Context, logger runtime.Lo
 	// For social modes, use TeamUnassigned. For competitive modes, use the
 	// requested role (spectator keeps the creator off a team) or default to
 	// TeamBlue when no role was specified.
-	teamAlignment := evr.TeamUnassigned
+	// The requested role belongs to the CREATOR, not to their party. `role:spectator`
+	// means "put me in the stands"; it does not mean the three friends who came with
+	// them also came to watch. The comment this replaces said as much -- "spectator
+	// keeps the creator off a team" -- while the loop below stamped it on everyone.
+	//
+	// It only became reachable once /create started resolving party members at all,
+	// so there was never a symptom to notice.
+	creatorAlignment := evr.TeamUnassigned
+	memberAlignment := evr.TeamUnassigned
 	if mode == evr.ModeArenaPrivate || mode == evr.ModeArenaPublic ||
 		mode == evr.ModeCombatPrivate || mode == evr.ModeCombatPublic {
+		memberAlignment = evr.TeamBlue
 		if role == Spectator {
-			teamAlignment = evr.TeamSpectator
+			creatorAlignment = evr.TeamSpectator
 		} else {
-			teamAlignment = evr.TeamBlue
+			creatorAlignment = evr.TeamBlue
 		}
 	}
 
 	teamAlignments := make(map[string]int, len(partyUserIDs))
 	for _, memberUserID := range partyUserIDs {
-		teamAlignments[memberUserID] = teamAlignment
+		if memberUserID == userID {
+			teamAlignments[memberUserID] = creatorAlignment
+			continue
+		}
+		teamAlignments[memberUserID] = memberAlignment
 	}
 
 	// Hold slots for online party members against backfill (RESV-1). The creator
-	// joins directly via the normal join race, so only followers need a reservation.
-	reservations := getOnlinePartyReservations(ctx, d.nk, logger, userID, partyUserIDs, teamAlignment)
+	// joins directly via the normal join race, so only followers need a reservation
+	// -- and they get the member alignment, never the creator's spectator role.
+	//
+	// node comes from the pipeline, not the context: this is a Discord slash
+	// command, and the appbot's context never carries RUNTIME_CTX_NODE.
+	reservations := getOnlinePartyReservations(d.nk, logger, userID, partyUserIDs, memberAlignment, d.pipeline.node)
 
 	settings := &MatchSettings{
 		Mode:                mode,

--- a/server/evr_discord_appbot_reservations_test.go
+++ b/server/evr_discord_appbot_reservations_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -69,11 +68,15 @@ func TestGetOnlinePartyReservations(t *testing.T) {
 		},
 	}
 
-	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "testnode")
+	// The node is an explicit argument now. This test used to plant it as
+	// runtime.RUNTIME_CTX_NODE, which is exactly why it stayed green while the
+	// production caller -- a Discord slash command, whose context never carries
+	// that key -- got nil back and the whole slot-hold feature did nothing.
+	const node = "testnode"
 
 	t.Run("solo creator produces no reservations", func(t *testing.T) {
 		nk.calls = nil
-		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, []string{creatorID}, evr.TeamBlue)
+		got := getOnlinePartyReservations(nk, logger, creatorID, []string{creatorID}, evr.TeamBlue, node)
 		if len(got) != 0 {
 			t.Fatalf("expected no reservations for solo creator, got %d", len(got))
 		}
@@ -85,7 +88,7 @@ func TestGetOnlinePartyReservations(t *testing.T) {
 	t.Run("online follower gets a reservation, offline follower is skipped", func(t *testing.T) {
 		nk.calls = nil
 		partyUserIDs := []string{creatorID, followerOnlineID, followerOfflineID}
-		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, partyUserIDs, evr.TeamBlue)
+		got := getOnlinePartyReservations(nk, logger, creatorID, partyUserIDs, evr.TeamBlue, node)
 
 		if len(got) != 1 {
 			t.Fatalf("expected exactly 1 reservation (online follower only), got %d: %+v", len(got), got)
@@ -122,16 +125,20 @@ func TestGetOnlinePartyReservations(t *testing.T) {
 	})
 
 	t.Run("empty party produces no reservations", func(t *testing.T) {
-		got := getOnlinePartyReservations(ctx, nk, logger, creatorID, nil, evr.TeamBlue)
+		got := getOnlinePartyReservations(nk, logger, creatorID, nil, evr.TeamBlue, node)
 		if len(got) != 0 {
 			t.Fatalf("expected no reservations for empty party, got %d", len(got))
 		}
 	})
 
-	t.Run("missing node in context bails out", func(t *testing.T) {
-		got := getOnlinePartyReservations(context.Background(), nk, logger, creatorID, []string{creatorID, followerOnlineID}, evr.TeamBlue)
+	t.Run("empty node bails out", func(t *testing.T) {
+		// A reservation placeholder without a node cannot be matched to a real
+		// presence, so producing one would be worse than producing none. This is
+		// now the only way to reach that branch: the node is a parameter, so it
+		// cannot silently go missing the way a context value did.
+		got := getOnlinePartyReservations(nk, logger, creatorID, []string{creatorID, followerOnlineID}, evr.TeamBlue, "")
 		if got != nil {
-			t.Fatalf("expected nil reservations when node is missing from context, got %+v", got)
+			t.Fatalf("expected nil reservations when the node is empty, got %+v", got)
 		}
 	})
 }

--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -824,6 +824,25 @@ func (d *DiscordIntegrator) handleGuildDelete(logger *zap.Logger, _ *discordgo.S
 		logger.Info("Deleting guild group (not present in registry)", zap.String("group_id", groupID))
 	}
 
+	// report_only is documented as "the operator's single freeze switch during
+	// an incident", and it was not one: it gated the prune pass only, while
+	// this event path deleted groups regardless. A GUILD_DELETE arriving mid
+	// incident -- which is precisely when Discord's reads are least
+	// trustworthy, and the reason the prune pass learned to distrust them --
+	// destroyed the group's role mappings, channel IDs and suspension
+	// inheritance despite the freeze, and a re-add would come back as a fresh
+	// group with default metadata.
+	//
+	// Under the freeze the group is left in place. If the bot really was
+	// removed, the prune pass collects it once writes are re-armed; the cost
+	// of waiting is a stale group, and the cost of not waiting is
+	// unrecoverable.
+	if ServiceSettings().PruneSettings.ReportOnly {
+		logger.Warn("Guild delete: group NOT deleted, prune settings are report-only",
+			zap.String("group_id", groupID), zap.String("guild_id", e.Guild.ID))
+		return nil
+	}
+
 	if err := d.nk.GroupDelete(d.ctx, groupID); err != nil {
 		return fmt.Errorf("error deleting group: %w", err)
 	}

--- a/server/evr_discord_integrator_guilddelete_test.go
+++ b/server/evr_discord_integrator_guilddelete_test.go
@@ -208,3 +208,49 @@ type guildMissingNakamaModule struct {
 func (m *guildMissingNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
 	return nil, nil
 }
+
+// TestHandleGuildDelete_ReportOnlyFreezesTheDelete pins report_only against the
+// promise its own documentation makes.
+//
+// PruneSettings.ReportOnly is described as making a pass "perform NO writes at
+// all ... the operator's single freeze switch during an incident". It gated the
+// prune pass and nothing else, so this event path deleted guild groups straight
+// through the freeze.
+//
+// That matters because of when it fires. An operator sets report_only during a
+// Discord incident, which is exactly when Discord's reads are least
+// trustworthy -- the same premise the prune pass was hardened against. A
+// GUILD_DELETE arriving then destroyed the group's role mappings, channel IDs
+// and suspension inheritance, and a re-add returned a fresh group with default
+// metadata. There is no undo.
+func TestHandleGuildDelete_ReportOnlyFreezesTheDelete(t *testing.T) {
+	const guildID = "323456789012345678"
+	groupID := uuid.Must(uuid.NewV4()).String()
+
+	restore := ServiceSettings()
+	t.Cleanup(func() { ServiceSettingsUpdate(restore) })
+
+	frozen := &ServiceSettingsData{}
+	frozen.PruneSettings.ReportOnly = true
+	frozen.PruneSettings.DeleteOrphanedGroups = true // armed, and still must not fire
+	ServiceSettingsUpdate(frozen)
+
+	nk := &groupDeleteRecorderModule{}
+	d := newGuildDeleteTestIntegrator(t, nk)
+
+	d.idcache.Store(guildID, groupID)
+	d.idcache.Store(groupID, guildID)
+	d.guildGroupRegistry.Add(&GuildGroup{
+		GroupMetadata: GroupMetadata{GuildID: guildID},
+		Group:         &api.Group{Id: groupID, Name: "Frozen Guild"},
+	})
+
+	err := d.handleGuildDelete(zap.NewNop(), nil, &discordgo.GuildDelete{
+		Guild: &discordgo.Guild{ID: guildID, OwnerID: "987654321098765432"},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, nk.deleted,
+		"report_only must freeze the event-driven group delete, not only the prune pass; "+
+			"the group can be collected later, but a deleted one cannot be recovered")
+}

--- a/server/evr_discord_integrator_guilddelete_test.go
+++ b/server/evr_discord_integrator_guilddelete_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // groupDeleteRecorderModule records GroupDelete calls. handleGuildDelete's only
@@ -133,32 +136,75 @@ func TestHandleGuildDelete_UnknownGuildIsNoOp(t *testing.T) {
 	require.Empty(t, nk.deleted)
 }
 
-// TestEarlyQuitEnforcementEnabled_NilGuildGroupEntry pins the same nil-*GuildGroup
-// class of bug on the other site the review flagged.
+// TestEarlyQuitEnforcementEnabled_FailsClosedWhenGuildUnresolvable pins the
+// direction this gate errs in.
 //
-// GetEnforceEarlyQuitPenalty opens with `if g == nil` — but its receiver is
-// *GroupMetadata, and GroupMetadata is embedded by VALUE in GuildGroup. The call
-// `gg.GetEnforceEarlyQuitPenalty()` is shorthand for
-// `(&gg.GroupMetadata).GetEnforceEarlyQuitPenalty()`, so the receiver address is
-// computed from gg BEFORE the method body runs. A nil gg therefore panics and the
-// guard never fires: it is decorative at this call site.
+// It used to read the guild from session parameters and return TRUE when they
+// were absent. ctxSessionParametersKey is planted only on the WebSocket session
+// context; the context Nakama hands a match callback never carries it, so every
+// match-side caller took that fail-open branch on every real invocation and the
+// opt-in flag suppressed nothing. Players in guilds that never opted in accrued
+// quit counters, lockouts, tier degradation and Discord DMs.
 //
-// GuildUserGroupsList currently filters nil registry lookups out of the map, so
-// the panic is not reachable through that path today. The guard is cheap, matches
-// the defensive nil check evr_lobby_joinentrant.go already applies to the same
-// map, and stops a future populator from turning a map entry into a crash.
-func TestEarlyQuitEnforcementEnabled_NilGuildGroupEntry(t *testing.T) {
-	groupID := uuid.Must(uuid.NewV4()).String()
+// It now resolves through nk, and when that fails it returns FALSE. The setting
+// is opt-in, so the absence of an explicit yes is a no, and the costs are
+// asymmetric: a missed charge is recoverable, while a wrongly-charged player
+// takes a lifetime NumEarlyQuits increment that never decays.
+func TestEarlyQuitEnforcementEnabled_FailsClosedWhenGuildUnresolvable(t *testing.T) {
+	logger := NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
 
-	params := &SessionParameters{
-		guildGroups: map[string]*GuildGroup{groupID: nil},
-	}
-	ctx := context.WithValue(context.Background(), ctxSessionParametersKey{}, atomic.NewPointer(params))
-
-	var enabled bool
-	require.NotPanics(t, func() {
-		enabled = earlyQuitEnforcementEnabled(ctx, groupID)
+	t.Run("empty group id does not charge", func(t *testing.T) {
+		require.False(t, earlyQuitEnforcementEnabled(context.Background(), &guildLookupFailsNakamaModule{}, logger, ""),
+			"no guild means no opt-in; charging would punish a player for a lookup we never made")
 	})
-	require.True(t, enabled,
-		"an unusable guild-group entry must fall through to the lenient default, like an absent one")
+
+	t.Run("group lookup error does not charge", func(t *testing.T) {
+		groupID := uuid.Must(uuid.NewV4()).String()
+		var enabled bool
+		require.NotPanics(t, func() {
+			enabled = earlyQuitEnforcementEnabled(context.Background(), &guildLookupFailsNakamaModule{}, logger, groupID)
+		})
+		require.False(t, enabled,
+			"an unreadable guild configuration is not evidence the guild wanted enforcement")
+	})
+
+	t.Run("guild that opted in does charge", func(t *testing.T) {
+		groupID := uuid.Must(uuid.NewV4()).String()
+		nk := newEvrTestNakamaModule()
+		optInGuildToEarlyQuitEnforcement(t, nk, groupID)
+		require.True(t, earlyQuitEnforcementEnabled(context.Background(), nk, logger, groupID),
+			"a guild with enforce_early_quit_penalty set must enforce")
+	})
+
+	t.Run("guild present but not opted in does not charge", func(t *testing.T) {
+		groupID := uuid.Must(uuid.NewV4()).String()
+		nk := newEvrTestNakamaModule()
+		nk.groups[groupID] = &api.Group{Id: groupID, Metadata: `{}`}
+		require.False(t, earlyQuitEnforcementEnabled(context.Background(), nk, logger, groupID),
+			"an existing guild that never set the flag has not opted in")
+	})
+
+	t.Run("group not found does not charge", func(t *testing.T) {
+		groupID := uuid.Must(uuid.NewV4()).String()
+		require.False(t, earlyQuitEnforcementEnabled(context.Background(), &guildMissingNakamaModule{}, logger, groupID),
+			"a group that does not exist cannot have opted in")
+	})
+}
+
+// guildLookupFailsNakamaModule fails the group read GuildGroupLoad starts with.
+type guildLookupFailsNakamaModule struct {
+	runtime.NakamaModule
+}
+
+func (m *guildLookupFailsNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
+	return nil, errors.New("simulated group read failure")
+}
+
+// guildMissingNakamaModule returns no groups, as happens for an unknown ID.
+type guildMissingNakamaModule struct {
+	runtime.NakamaModule
+}
+
+func (m *guildMissingNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
+	return nil, nil
 }

--- a/server/evr_earlyquit.go
+++ b/server/evr_earlyquit.go
@@ -460,20 +460,52 @@ func isEarlyQuitEnforcementTestUser(userID string) bool {
 // the group is not in them), enforcement remains enabled — the lookup is
 // lenient and never blocks enforcement on a cache miss. Only a known guild
 // with the flag explicitly set true enables it.
-func earlyQuitEnforcementEnabled(ctx context.Context, groupID string) bool {
-	params, ok := LoadParams(ctx)
-	if !ok {
-		return true
+func earlyQuitEnforcementEnabled(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, groupID string) bool {
+	if groupID == "" {
+		return false
 	}
-	// A nil entry is treated exactly like an absent one. The nil guard inside
-	// GetEnforceEarlyQuitPenalty cannot catch it: GroupMetadata is embedded by
-	// VALUE in GuildGroup, so gg.GetEnforceEarlyQuitPenalty() takes the address
-	// &gg.GroupMetadata before the method body runs and a nil gg panics first.
-	gg, ok := params.guildGroups[groupID]
-	if !ok || gg == nil {
-		return true
+
+	// Resolved through nk, NOT through session parameters.
+	//
+	// This gate previously read params.guildGroups via LoadParams(ctx) and
+	// returned true when they were absent. ctxSessionParametersKey is planted
+	// only on the WebSocket session context (session_ws.go); the context Nakama
+	// hands a match callback is built by the match runtime and never carries
+	// it. So every match-side caller -- the MatchLeave charge, the MatchLoop
+	// deferred charge, and MatchJoinAttempt -- took the fail-open branch on
+	// every real invocation, and the flag suppressed nothing: quit counters,
+	// lockouts, tier degradation and "flagged for early quitting" DMs were
+	// applied in guilds that never opted in.
+	//
+	// nk is available to every match callback, so the lookup now works from the
+	// contexts that actually call this.
+	// Read the group metadata directly rather than going through
+	// GuildGroupLoad, which additionally loads GuildGroupState -- a second
+	// storage read, keyed on the Discord bot user ID, that this decision does
+	// not use. The opt-in flag lives in the group's metadata and nowhere else.
+	groups, err := nk.GroupsGetId(ctx, []string{groupID})
+	var md *GroupMetadata
+	if err == nil && len(groups) > 0 {
+		md = &GroupMetadata{}
+		if jsonErr := json.Unmarshal([]byte(groups[0].Metadata), md); jsonErr != nil {
+			md, err = nil, jsonErr
+		}
 	}
-	return gg.GetEnforceEarlyQuitPenalty()
+	if err != nil || md == nil {
+		// Fail CLOSED, which is the reverse of what this did before.
+		//
+		// The setting is opt-in: the absence of an explicit yes is a no. Being
+		// unable to read a guild's configuration is not evidence that it wanted
+		// enforcement, and the cost of guessing wrong is asymmetric -- a missed
+		// charge is recoverable, while a wrongly-charged player accrues a
+		// lifetime NumEarlyQuits increment that never decays and moves them
+		// permanently down the penalty ladder.
+		if err != nil {
+			logger.WithField("group_id", groupID).Warn("Could not resolve guild for early-quit enforcement; not charging")
+		}
+		return false
+	}
+	return md.GetEnforceEarlyQuitPenalty()
 }
 
 func (s *EarlyQuitPlayerState) GetPenaltyLevel() int {

--- a/server/evr_earlyquit_charge_test.go
+++ b/server/evr_earlyquit_charge_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/gofrs/uuid/v5"
+	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/heroiclabs/nakama/v3/server/evr"
-	"go.uber.org/atomic"
 )
 
 // chargeTestLeaderboardCache is a LeaderboardCache test double whose Get returns
@@ -81,6 +81,10 @@ func TestEarlyQuitChargeGate_SetsPenaltyState(t *testing.T) {
 
 	// --- arena-public, pre-matchover match with one player mid-round ---
 	state := reconnectTestState(evr.ModeArenaPublic)
+	// The charge gate resolves the guild through nk and fails closed when it
+	// cannot. Opt this guild in explicitly; the gate no longer charges just
+	// because it could not tell.
+	optInGuildToEarlyQuitEnforcement(t, nk, state.GetGroupID().String())
 	// The charge gate persists LastEarlyQuitMatchID; MatchID only round-trips
 	// through storage with a non-empty node (prod always sets one).
 	state.ID.Node = "test-node"
@@ -155,8 +159,18 @@ func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
 			writeEarlyQuitServiceConfig(t, ctx, nk, defaultEarlyQuitConfigJSON(t))
 
 			// The guild hosting the match, with the enforcement flag under test.
+			//
+			// The flag is set in the group's METADATA, which is where production
+			// keeps it and where the gate now reads it. This used to be planted on
+			// the context as session parameters -- a shape the match runtime never
+			// builds -- so the subtests below agreed with each other while the
+			// production gate always enforced regardless of the flag.
 			guildID := uuid.Must(uuid.NewV4())
-			ctx = withGuildEnforcement(ctx, guildID, tc.enforce)
+			metadata := `{}`
+			if tc.enforce != nil {
+				metadata = fmt.Sprintf(`{"enforce_early_quit_penalty":%t}`, *tc.enforce)
+			}
+			nk.groups[guildID.String()] = &api.Group{Id: guildID.String(), Metadata: metadata}
 
 			// Player with 2 prior early quits (3rd quit crosses into penalty level 1).
 			player := reconnectTestPlayer(fmt.Sprintf("charge-guild-flag-%d", i), evr.TeamBlue)
@@ -214,43 +228,16 @@ func TestEarlyQuitChargeGate_GuildEnforcementFlag(t *testing.T) {
 	}
 }
 
-// withGuildEnforcement returns a copy of ctx whose session parameters map the
-// given guild to a GuildGroup carrying the given EnforceEarlyQuitPenalty flag
-// (nil leaves the flag unset — the getter's default).
+// NOTE: withGuildEnforcement used to live here. It planted the guild-enforcement
+// flag on the context as session parameters, and every subtest above went
+// through it. That context shape is built only by the WebSocket session; the
+// match runtime's context never carries it, so the gate those subtests claimed
+// to exercise took its fail-open branch in production and enforced for every
+// guild regardless of the flag. The helper's own comment said so.
 //
-// WARNING — THIS CONTEXT SHAPE DOES NOT OCCUR IN PRODUCTION.
-//
-// ctxSessionParametersKey{} is planted on the *session* context by the EVR
-// pipeline. The context that the Nakama match runtime hands to MatchLeave is
-// built by the match runtime, not by a session, and it never carries that key.
-// So the branch that TestEarlyQuitChargeGate_GuildEnforcementFlag exercises
-// through this helper is reachable only from the test.
-//
-// Consequence: that test does NOT prove the guild opt-in gate works. In
-// production earlyQuitEnforcementEnabled cannot find the session parameters, so
-// LoadParams fails and it takes its fail-open `return true` branch — every guild
-// is treated as opted in and the flag never suppresses anything. That is a real
-// production bug; it is deliberately NOT fixed here (this change set is a
-// testability refactor and must not alter behaviour) and needs its own PR. Do
-// not read a green run of this test as evidence the gate is enforced.
-//
-// What the test DOES now prove, which it could not before: the subtests actually
-// execute. Until the *RuntimeGoNakamaModule assertion was removed from the charge
-// gate they were skipped for want of a database, and before that a test double
-// fell straight through the assertion's `continue`. Flipping
-// earlyQuitEnforcementEnabled to an unconditional `return true` now turns the
-// guild-flag-nil and guild-flag-false cases red, so the suppression branch is
-// genuinely exercised — just from a context production never constructs.
-func withGuildEnforcement(ctx context.Context, guildID uuid.UUID, enforce *bool) context.Context {
-	params := &SessionParameters{
-		guildGroups: map[string]*GuildGroup{
-			guildID.String(): {
-				GroupMetadata: GroupMetadata{EnforceEarlyQuitPenalty: enforce},
-			},
-		},
-	}
-	return context.WithValue(ctx, ctxSessionParametersKey{}, atomic.NewPointer(params))
-}
+// The flag now lives where production keeps it -- the group's metadata, read
+// through nk -- so there is nothing left to fake, and the subtests exercise the
+// same code path a real match does.
 
 func boolPtr(b bool) *bool { return &b }
 
@@ -316,6 +303,10 @@ func TestEarlyQuitChargeGate_UsesStoredConfigLadder(t *testing.T) {
 	}
 
 	state := reconnectTestState(evr.ModeArenaPublic)
+	// The charge gate resolves the guild through nk and fails closed when it
+	// cannot. Opt this guild in explicitly; the gate no longer charges just
+	// because it could not tell.
+	optInGuildToEarlyQuitEnforcement(t, nk, state.GetGroupID().String())
 	state.ID.Node = "test-node"
 	state.presenceMap[player.GetSessionId()] = player
 	state.presenceByEvrID[player.EvrID] = player
@@ -385,6 +376,10 @@ func TestEarlyQuitChargeGate_ClearsPenaltyAtLevelZero(t *testing.T) {
 	}
 
 	state := reconnectTestState(evr.ModeArenaPublic)
+	// The charge gate resolves the guild through nk and fails closed when it
+	// cannot. Opt this guild in explicitly; the gate no longer charges just
+	// because it could not tell.
+	optInGuildToEarlyQuitEnforcement(t, nk, state.GetGroupID().String())
 	state.ID.Node = "test-node"
 	state.presenceMap[player.GetSessionId()] = player
 	state.presenceByEvrID[player.EvrID] = player

--- a/server/evr_earlyquit_pipeline_test.go
+++ b/server/evr_earlyquit_pipeline_test.go
@@ -292,6 +292,20 @@ func newChargeModule(t *testing.T) (*evrTestNakamaModule, *sql.DB) {
 	t.Helper()
 	nk := newEvrTestNakamaModule()
 	nk.sessions = NewLocalSessionRegistry(&testMetrics{})
+
+	// Opt the match's guild in to early-quit enforcement.
+	//
+	// The charge gate resolves the guild through nk and fails closed when it
+	// cannot, so without this every test here would assert against a guild that
+	// never opted in and no charge would happen. reconnectTestState leaves
+	// MatchLabel.GroupID nil, so the gate sees uuid.Nil -- that is the guild
+	// these fixtures run in (spelled out rather than uuid.Nil to avoid an import
+	// solely for a constant).
+	//
+	// Tests that need the flag OFF set their own group metadata instead; see
+	// TestEarlyQuitChargeGate_GuildEnforcementFlag.
+	optInGuildToEarlyQuitEnforcement(t, nk, "00000000-0000-0000-0000-000000000000")
+
 	return nk, nil
 }
 

--- a/server/evr_earlyquit_reconnect_test.go
+++ b/server/evr_earlyquit_reconnect_test.go
@@ -195,3 +195,72 @@ func TestReconnectReservationExpiry_RecordsEarlyQuitEffects(t *testing.T) {
 		t.Errorf("expected num_early_quits 1 in config write, got: %s", eqWrite.Value)
 	}
 }
+
+// TestReconnectReservationExpiry_ExemptPlayerIsNotCharged pins the moderator
+// exemption on the DEFERRED charge path.
+//
+// MatchLeave's immediate charge honours EarlyQuitPlayerState.IsExempt. The
+// reservation-expiry charge in MatchLoop did not, and MatchLeave skips its
+// entire charge block -- exemption check included -- when a reconnect
+// reservation exists. So an exempt player who crashed and did not get back in
+// before the window closed was charged anyway: counter incremented, lockout
+// resolved, leaderboard stat and quit-history record written.
+//
+// That is the worst population to get wrong. The exemption is most often
+// granted to players with known-bad connections, which is exactly who fails to
+// reconnect inside the window.
+func TestReconnectReservationExpiry_ExemptPlayerIsNotCharged(t *testing.T) {
+	logger := newCaptureLogger()
+	nk := &reconnectLeaderboardSpyModule{reconnectTestNakamaModule: &reconnectTestNakamaModule{}}
+	dispatcher := &reconnectTestDispatcher{}
+	ctx := context.WithValue(context.Background(), runtime.RUNTIME_CTX_NODE, "test-node")
+
+	state := reconnectTestState(evr.ModeArenaPublic)
+	state.ID.Node = "test-node"
+	player := reconnectTestPlayer("b7-expiry-exempt", evr.TeamBlue)
+	groupID := state.GetGroupID().String()
+
+	// The player carries a moderator exemption for this guild, as the
+	// earlyquit/modify RPC would have written.
+	nk.earlyQuitStateJSON = fmt.Sprintf(
+		`{"matchmaking_tier":1,"guild_overrides":{%q:{"exempt":true}}}`, groupID)
+
+	state.participations[player.GetUserId()] = &PlayerParticipation{
+		UserID:      player.GetUserId(),
+		Username:    player.Username,
+		DisplayName: player.DisplayName,
+		Team:        BlueTeam,
+		JoinTime:    time.Now().Add(-2 * time.Minute),
+		LeaveTime:   time.Now(),
+	}
+	state.reconnectReservations[player.GetUserId()] = &reconnectReservation{
+		Presence:     player,
+		Expiry:       time.Now().Add(-time.Second),
+		UserID:       player.GetUserId(),
+		DeferPenalty: true,
+	}
+
+	m := &EvrMatch{}
+	if got := m.MatchLoop(ctx, logger, nil, nk, dispatcher, 1, state, nil); got == nil {
+		t.Fatal("MatchLoop returned nil state")
+	}
+
+	if _, ok := logger.find("info", "Deferred early quit penalty skipped: player is exempt in this guild"); !ok {
+		t.Error("expected the deferred charge to log that it skipped an exempt player")
+	}
+
+	if _, ok := logger.find("debug", "Incrementing early quit for player."); ok {
+		t.Error("an exempt player must not have their early quit counter incremented on reservation expiry")
+	}
+
+	if len(nk.leaderboardWrites) != 0 {
+		t.Errorf("expected no leaderboard writes for an exempt player, got %v", nk.leaderboardWrites)
+	}
+
+	for _, w := range nk.storageWrites {
+		if w.Collection == StorageCollectionEarlyQuitHistory && w.Key == StorageKeyEarlyQuitHistory {
+			t.Error("an exempt player must not get a quit-history record; it feeds the moderator-facing " +
+				"quit stats and would re-punish them by another route")
+		}
+	}
+}

--- a/server/evr_lobby_find.go
+++ b/server/evr_lobby_find.go
@@ -308,7 +308,7 @@ func (p *EvrPipeline) lobbyFind(ctx context.Context, logger *zap.Logger, session
 			logger.Debug("Failed to load early quit config for logging", zap.Error(err))
 		} else if eqConfig.PenaltyTimestamp > 0 && time.Now().Unix() < eqConfig.PenaltyTimestamp {
 			remainingTime := time.Until(time.Unix(eqConfig.PenaltyTimestamp, 0))
-			if isEarlyQuitEnforcementTestUser(lobbyParams.UserID.String()) && earlyQuitEnforcementEnabled(ctx, lobbyParams.GroupID.String()) {
+			if isEarlyQuitEnforcementTestUser(lobbyParams.UserID.String()) && earlyQuitEnforcementEnabled(ctx, p.nk, p.runtimeLogger, lobbyParams.GroupID.String()) {
 				return NewLobbyErrorf(KickedFromLobbyGroup,
 					"complete matches to reduce your early quit penalty [exp: %s]",
 					FormatDuration(remainingTime))

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -1470,10 +1470,23 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				// enforcement is disabled, suppress ALL side effects: the
 				// eqconfig mutation/write and the leaderboard/quit-history
 				// record.
-				if earlyQuitEnforcementEnabled(ctx, nk, logger, state.GetGroupID().String()) {
+				deferredGroupID := state.GetGroupID().String()
+				if earlyQuitEnforcementEnabled(ctx, nk, logger, deferredGroupID) {
+					charged := false
 					eqconfig := NewEarlyQuitPlayerState()
 					if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
 						logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")
+					} else if eqconfig.IsExempt(deferredGroupID) {
+						// A moderator exempted this player. The immediate charge
+						// path in MatchLeave honours that; this one did not, so a
+						// player who was explicitly protected was still charged
+						// whenever they failed to reconnect inside the crash
+						// window -- i.e. exactly the crash case the exemption is
+						// most often granted for.
+						logger.WithFields(map[string]any{
+							"uid":      rr.UserID,
+							"group_id": deferredGroupID,
+						}).Info("Deferred early quit penalty skipped: player is exempt in this guild")
 					} else {
 						eqconfig.IncrementEarlyQuit()
 						resolveAndApplyPenaltyLockout(ctx, nk, logger, eqconfig)
@@ -1481,12 +1494,16 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 						if err := StorableWrite(ctx, nk, rr.UserID, eqconfig); err != nil {
 							logger.WithField("error", err).Warn("Failed to write early quitter config for deferred penalty")
 						}
+						charged = true
 					}
 
 					// A deferred penalty must produce the same side effects as the
 					// immediate charge path in MatchLeave: the increment log line,
-					// the leaderboard stat, and the quit-history record.
-					if rr.Presence != nil {
+					// the leaderboard stat, and the quit-history record. An exempt
+					// player gets none of them -- recording the quit while
+					// suppressing the counter would still feed the moderator-facing
+					// quit stats and re-punish them by another route.
+					if charged && rr.Presence != nil {
 						recordEarlyQuitForPlayer(ctx, logger, nk, state, rr.Presence, LeaveReasonReservationExp)
 					}
 				}

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -330,7 +330,7 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 			logger.Debug("Failed to load early quit config for logging", zap.Error(err))
 		} else if eqConfig.PenaltyLevel > 0 && eqConfig.PenaltyTimestamp > 0 && time.Now().Unix() < eqConfig.PenaltyTimestamp {
 			remainingTime := time.Until(time.Unix(eqConfig.PenaltyTimestamp, 0))
-			if isEarlyQuitEnforcementTestUser(joinPresence.GetUserId()) && earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
+			if isEarlyQuitEnforcementTestUser(joinPresence.GetUserId()) && earlyQuitEnforcementEnabled(ctx, nk, logger, state.GetGroupID().String()) {
 				return state, false, fmt.Sprintf("early quit penalty active [exp: %s]", FormatDuration(remainingTime))
 			}
 			logger.Info("Player joining with active early quit penalty (client-side enforcement expected)",
@@ -1057,7 +1057,7 @@ func (m *EvrMatch) MatchLeave(ctx context.Context, logger runtime.Logger, db *sq
 					// and quit-history record, the eqconfig mutation/write, and
 					// the notifications/DMs.
 					groupID := state.GetGroupID().String()
-					enforce := earlyQuitEnforcementEnabled(ctx, groupID)
+					enforce := earlyQuitEnforcementEnabled(ctx, nk, logger, groupID)
 					if !enforce {
 						logger.WithFields(map[string]any{
 							"uid":      mp.GetUserId(),
@@ -1470,7 +1470,7 @@ func (m *EvrMatch) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql
 				// enforcement is disabled, suppress ALL side effects: the
 				// eqconfig mutation/write and the leaderboard/quit-history
 				// record.
-				if earlyQuitEnforcementEnabled(ctx, state.GetGroupID().String()) {
+				if earlyQuitEnforcementEnabled(ctx, nk, logger, state.GetGroupID().String()) {
 					eqconfig := NewEarlyQuitPlayerState()
 					if err := StorableRead(ctx, nk, rr.UserID, eqconfig, true); err != nil {
 						logger.WithField("error", err).Warn("Failed to load early quitter config for deferred penalty")

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -476,7 +476,17 @@ func (m *EvrMatch) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, 
 		if consumedSlotReservation.Presence.PartyID != uuid.Nil {
 			meta.Presence.PartyID = consumedSlotReservation.Presence.PartyID
 		}
-		meta.Presence.RoleAlignment = consumedSlotReservation.Presence.RoleAlignment
+		// Do not let a reservation seat someone in the stands. The TeamAlignments
+		// path below already refuses to adopt spectator/moderator for exactly this
+		// reason; the reservation path adopted them unconditionally, so a
+		// reservation built with TeamSpectator would force the joiner into a
+		// spectator slot and skip the auto-assign that would have given them a
+		// team. Same guard, same place, same reasoning as the PartyID check above:
+		// at the consume site, so no future builder can reintroduce it.
+		if consumedSlotReservation.Presence.RoleAlignment != evr.TeamSpectator &&
+			consumedSlotReservation.Presence.RoleAlignment != evr.TeamModerator {
+			meta.Presence.RoleAlignment = consumedSlotReservation.Presence.RoleAlignment
+		}
 		state.rebuildCache()
 		logger = logger.WithField("has_reservation", true)
 	}

--- a/server/evr_match_create_reservation_test.go
+++ b/server/evr_match_create_reservation_test.go
@@ -244,3 +244,82 @@ func TestMatchJoinAttempt_ReservationWithoutPartyIDPreservesJoinersParty(t *test
 			"PartyID != uuid.Nil and would now skip this player", joined.PartyID, realPartyID)
 	}
 }
+
+// TestMatchJoinAttempt_SpectatorReservationDoesNotSeatJoinerInTheStands pins the
+// guard on role adoption.
+//
+// `/create role:spectator` means the CREATOR watches. It never meant their
+// party watches. handleCreateMatch stamped the creator's requested role onto
+// every member's team alignment and onto every reservation, and
+// MatchJoinAttempt adopted a consumed reservation's RoleAlignment
+// unconditionally -- so a follower would have been seated as a spectator and
+// the auto-assign that would have given them a team never runs, because their
+// role is no longer TeamUnassigned.
+//
+// This was unreachable until /create started resolving party members at all
+// (the node was read from a context the Discord appbot never populates), which
+// is why it had no symptom. The TeamAlignments path immediately below the
+// adoption already refuses spectator and moderator for exactly this reason;
+// this pins the same refusal on the reservation path.
+func TestMatchJoinAttempt_SpectatorReservationDoesNotSeatJoinerInTheStands(t *testing.T) {
+	state := newSocialTestMatchLabel()
+	state.Mode = evr.ModeArenaPrivate
+	state.LobbyType = PrivateLobby
+	state.MaxSize = 8
+	state.PlayerLimit = 8
+
+	followerUserID := uuid.Must(uuid.NewV4())
+	followerLoginSessionID := uuid.Must(uuid.NewV4())
+	followerMatchSessionID := uuid.Must(uuid.NewV4())
+
+	// A reservation carrying the creator's spectator role, which is what the
+	// pre-fix /create path produced for every party member.
+	state.reservationMap[followerLoginSessionID.String()] = &slotReservation{
+		Presence: &EvrMatchPresence{
+			Node:          "testnode",
+			SessionID:     followerLoginSessionID,
+			UserID:        followerUserID,
+			Username:      "follower",
+			RoleAlignment: evr.TeamSpectator,
+		},
+		Expiry: time.Now().Add(45 * time.Second),
+	}
+	state.rebuildCache()
+
+	m := &EvrMatch{}
+	ctx := context.Background()
+	logger := NewRuntimeGoLogger(NewJSONLogger(os.Stdout, zapcore.ErrorLevel, JSONFormat))
+	nk := &reconnectTestNakamaModule{}
+	disp := &reconnectTestDispatcher{}
+
+	// The follower arrives intending to play, on a different session than the
+	// placeholder.
+	followerPresence := &EvrMatchPresence{
+		Node:          "testnode",
+		SessionID:     followerMatchSessionID,
+		UserID:        followerUserID,
+		EvrID:         evr.EvrId{PlatformCode: 4, AccountId: 7},
+		Username:      "follower",
+		RoleAlignment: evr.TeamBlue,
+		SessionExpiry: 9999999999,
+	}
+	meta := NewJoinMetadata(followerPresence)
+	resultState, allowed, reason := m.MatchJoinAttempt(ctx, logger, nil, nk, disp, 0, state, followerPresence, meta.ToMatchMetadata())
+	if !allowed {
+		t.Fatalf("expected the follower to join by consuming their reservation, got rejected: %s", reason)
+	}
+	state = resultState.(*MatchLabel)
+
+	joined, ok := state.presenceMap[followerMatchSessionID.String()]
+	if !ok {
+		t.Fatal("follower is not in the presence map after a successful join")
+	}
+	if joined.RoleAlignment == evr.TeamSpectator {
+		t.Error("follower was seated as a spectator by their reservation; `/create role:spectator` " +
+			"applies to the creator, not to everyone who came with them")
+	}
+	if joined.RoleAlignment != evr.TeamBlue {
+		t.Errorf("follower's RoleAlignment is %d, want TeamBlue (%d) — the role they arrived with must survive "+
+			"a reservation that carries no playable team", joined.RoleAlignment, evr.TeamBlue)
+	}
+}

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -892,6 +892,12 @@ type reconnectTestNakamaModule struct {
 	storageReads  []*runtime.StorageRead
 	storageDelete []*runtime.StorageDelete
 	streamUsers   []runtime.Presence
+
+	// earlyQuitStateJSON is what StorageRead returns for EarlyQuit|statistics.
+	// Empty means the default below. Tests that need a player with existing
+	// state -- a moderator exemption, a prior quit count -- set it, because
+	// this double does not persist what StorableWrite hands it.
+	earlyQuitStateJSON string
 }
 
 // GroupsGetId reports the fixture's guild as having opted in to early-quit
@@ -941,6 +947,13 @@ func (m *reconnectTestNakamaModule) LeaderboardCreate(ctx context.Context, id st
 	return nil
 }
 
+func (m *reconnectTestNakamaModule) earlyQuitState() string {
+	if m.earlyQuitStateJSON != "" {
+		return m.earlyQuitStateJSON
+	}
+	return `{"matchmaking_tier":1}`
+}
+
 func (m *reconnectTestNakamaModule) StorageRead(ctx context.Context, keys []*runtime.StorageRead) ([]*api.StorageObject, error) {
 	m.storageReads = append(m.storageReads, keys...)
 	for _, key := range keys {
@@ -949,7 +962,7 @@ func (m *reconnectTestNakamaModule) StorageRead(ctx context.Context, keys []*run
 				Collection:     StorageCollectionEarlyQuit,
 				Key:            StorageKeyEarlyQuit,
 				UserId:         key.UserID,
-				Value:          `{"matchmaking_tier":1}`,
+				Value:          m.earlyQuitState(),
 				Version:        "v1",
 				PermissionRead: int32(runtime.STORAGE_PERMISSION_NO_READ),
 			}}, nil

--- a/server/evr_match_test.go
+++ b/server/evr_match_test.go
@@ -894,6 +894,23 @@ type reconnectTestNakamaModule struct {
 	streamUsers   []runtime.Presence
 }
 
+// GroupsGetId reports the fixture's guild as having opted in to early-quit
+// enforcement.
+//
+// The charge gate resolves the guild through nk and fails closed when it
+// cannot, so a double that returns nothing would suppress every charge and the
+// tests that assert one would fail for a reason unrelated to what they test.
+// reconnectTestState leaves MatchLabel.GroupID nil, so the gate asks about
+// uuid.Nil; answering for any requested ID keeps this double indifferent to
+// which fixture calls it.
+func (m *reconnectTestNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
+	out := make([]*api.Group, 0, len(groupIDs))
+	for _, id := range groupIDs {
+		out = append(out, &api.Group{Id: id, Metadata: `{"enforce_early_quit_penalty":true}`})
+	}
+	return out, nil
+}
+
 func (m *reconnectTestNakamaModule) StreamUserList(mode uint8, subject, subcontext, label string, includeHidden, includeNotHidden bool) ([]runtime.Presence, error) {
 	return m.streamUsers, nil
 }

--- a/server/evr_party_system_test.go
+++ b/server/evr_party_system_test.go
@@ -1172,3 +1172,98 @@ func TestPartyHandler_PromoteThenMatchmake(t *testing.T) {
 		t.Fatal("expected ticket")
 	}
 }
+
+// --- Party-split on reconnect: the two acts -------------------------------
+//
+// These pin the production shape of the party-split lockout, which two prior
+// reviews disagreed about because each saw only one half of it.
+//
+// EVR creates ONLY open parties (evr_lobby_group.go: GetOrCreateByGroupName
+// with open=true). Every existing JoinRequest test builds the handler with
+// open=false, so the path production actually runs had no coverage at all.
+
+// TestPartyHandler_OpenPartyJoinRequestIgnoresIdentity is act two.
+//
+// For an open party the already-member check at the bottom of JoinRequest is
+// unreachable: the capacity check returns ErrPartyFull first, and the Open
+// branch returns before identity is ever considered. So a member reconnecting
+// into their own full party is told the party is full, with no bypass for the
+// fact that they are already in it.
+//
+// This is what the player sees as "party is full" on reconnect, and what turns
+// a reconnect storm into a lockout: every retry hits the same wall.
+func TestPartyHandler_OpenPartyJoinRequestIgnoresIdentity(t *testing.T) {
+	const maxSize = 4
+	ph, cleanup := createLightPartyHandler(t, loggerForTest(t), true, maxSize, nil)
+	defer cleanup()
+
+	members, _ := addMembers(t, ph, maxSize)
+	if got := ph.members.Size(); got != maxSize {
+		t.Fatalf("precondition: expected a full party of %d, got %d", maxSize, got)
+	}
+
+	// An existing member asks to join again -- the shape of a reconnect whose
+	// stale entry is still counted.
+	_, err := ph.JoinRequest(members[0])
+
+	if errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember) {
+		t.Fatal("open-party JoinRequest now recognises an existing member; " +
+			"the reconnect lockout is fixed and this test should assert the new behaviour")
+	}
+	if !errors.Is(err, runtime.ErrPartyFull) {
+		t.Fatalf("expected ErrPartyFull (identity is not consulted for open parties), got %v", err)
+	}
+
+	// The same request against a CLOSED party is recognised, which is the
+	// asymmetry: the protection exists, and the only kind of party EVR builds
+	// cannot reach it.
+	closed, closedCleanup := createLightPartyHandler(t, loggerForTest(t), false, maxSize, nil)
+	defer closedCleanup()
+	closedMembers, _ := addMembers(t, closed, 1)
+	if _, err := closed.JoinRequest(closedMembers[0]); !errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember) {
+		t.Fatalf("closed party should recognise an existing member, got %v", err)
+	}
+}
+
+// TestPartyHandler_JoinSilentlyDropsMemberWhenFull is act one, and it is the
+// half that leaves no trace.
+//
+// A reconnecting member is re-tracked on the party stream, which drives
+// PartyHandler.Join. With their stale session still counted the party is at
+// MaxSize, PartyPresenceList.Join returns ErrPartyFull, and Join logs
+// "Should not happen, this process is just a confirmation" and returns.
+//
+// The presence is now tracked on the stream but absent from ph.members. The
+// leader's matchmaking cohort is built from members, so the reconnecting
+// player is silently excluded -- split off from their own party with no error
+// surfaced to anyone. Act two is only what they see on the next attempt.
+func TestPartyHandler_JoinSilentlyDropsMemberWhenFull(t *testing.T) {
+	const maxSize = 4
+	ph, cleanup := createLightPartyHandler(t, loggerForTest(t), true, maxSize, nil)
+	defer cleanup()
+
+	members, _ := addMembers(t, ph, maxSize)
+	original := members[1]
+
+	// Same user, new session: a reconnect before the old presence is untracked.
+	reconnect := newPresenceWithIDs(partyTestNode, uuid.Must(uuid.NewV4()), original.UserID)
+
+	before := ph.members.Size()
+	ph.Join([]*Presence{reconnect})
+	after := ph.members.Size()
+
+	if after != before {
+		t.Fatalf("expected the roster to be unchanged at %d (the join was rejected as full), got %d", before, after)
+	}
+
+	for _, m := range ph.members.presences {
+		if m.Presence.GetSessionId() == reconnect.GetSessionId() {
+			t.Fatal("reconnecting session is now in the roster; PartyHandler.Join no longer drops it " +
+				"and this test should assert the new behaviour")
+		}
+	}
+
+	// The player is on the stream but not in the party, and nothing returned an
+	// error to say so. This is the defect: Join has no way to report failure --
+	// its signature returns nothing.
+}

--- a/server/evr_pipeline_login.go
+++ b/server/evr_pipeline_login.go
@@ -66,6 +66,25 @@ type NewLocationError struct {
 	useDMs      bool
 }
 
+// ipVerificationLocationError picks how to tell a player their IP is
+// unverified, given whatever naming information was resolvable.
+//
+// It ALWAYS returns an error. There is no combination of inputs that admits
+// the session: the guild name and bot username only choose the wording, and
+// being unable to determine either is not evidence the IP is trustworthy. It
+// is a function so the total behaviour can be tested directly -- the calling
+// path needs a Discord gateway and is otherwise unreachable from a test.
+func ipVerificationLocationError(guildName, botUsername, code string) NewLocationError {
+	switch {
+	case guildName != "":
+		return NewLocationError{guildName: guildName, code: code}
+	case botUsername != "":
+		return NewLocationError{botUsername: botUsername, code: code}
+	default:
+		return NewLocationError{code: code}
+	}
+}
+
 func (e NewLocationError) Error() string {
 	if e.useDMs {
 		// DM was successful
@@ -581,28 +600,33 @@ func (p *EvrPipeline) authorizeSession(ctx context.Context, logger *zap.Logger, 
 					metricsTags["error"] = "failed_send_ip_approval_request"
 					return fmt.Errorf("failed to send IP approval request: %w", err)
 				}
-				// The user has DMs from non-friends disabled. Tell them to use the slash command instead.
+				// The user has DMs from non-friends disabled. Tell them to use the
+				// slash command instead.
+				//
+				// Naming the guild is a nicety; failing to name it is NOT a reason
+				// to admit the session. The previous form was an if / else-if /
+				// else chain whose FIRST arm could fall through: when the active
+				// group resolved to a guild ID but `dg.Guild()` errored -- a stale
+				// guild the bot has left, or any transient API failure -- no arm
+				// returned, execution left the whole verification block, and
+				// authorizeSession went on to authorize a session whose IP had
+				// never been verified. That directly contradicted the invariant
+				// asserted above ("every path inside this block returns an
+				// error").
+				//
+				// Resolving the name first and then returning unconditionally
+				// makes the fall-through unrepresentable rather than merely fixed.
+				guildName := ""
 				if guildID := p.discordCache.GroupIDToGuildID(params.profile.ActiveGroupID); guildID != "" {
-					// Use the guild name
 					if guild, err := p.discordCache.dg.Guild(guildID); err == nil {
-						return NewLocationError{
-							guildName: guild.Name,
-							code:      twoFactorCode,
-						}
-					}
-				} else if botUsername != "" {
-					// Use the bot name
-					return NewLocationError{
-						botUsername: botUsername,
-						code:        twoFactorCode,
-					}
-				} else {
-					// Just return an error, since there's no way to verify the user.
-					metricsTags["error"] = "ip_verification_failed"
-					return NewLocationError{
-						code: twoFactorCode,
+						guildName = guild.Name
+					} else {
+						logger.Warn("Could not resolve guild for IP verification message; refusing with the generic form",
+							zap.String("guild_id", guildID), zap.Error(err))
 					}
 				}
+				metricsTags["error"] = "ip_verification_failed"
+				return ipVerificationLocationError(guildName, botUsername, twoFactorCode)
 			}
 		}
 	}

--- a/server/evr_pipeline_login_ipverify_test.go
+++ b/server/evr_pipeline_login_ipverify_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIPVerificationLocationError_AlwaysRefuses pins the property that made the
+// previous inline form a security hole: the unverified-IP path must refuse the
+// session for EVERY combination of naming information, including none.
+//
+// The code this replaced was an if / else-if / else chain whose first arm could
+// fall through. When the player's active group resolved to a guild ID but
+// dg.Guild() errored -- a stale guild the bot had left, or any transient
+// Discord API failure -- no arm returned. Execution left the verification block
+// entirely and authorizeSession went on to authorize a session whose IP had
+// never been verified, which is the exact control this gate exists to be.
+//
+// The guild name and bot username choose the wording. They are not evidence
+// about the IP, so being unable to resolve either must not soften the outcome.
+func TestIPVerificationLocationError_AlwaysRefuses(t *testing.T) {
+	const code = "42"
+
+	cases := []struct {
+		name        string
+		guildName   string
+		botUsername string
+		wantIn      string // a substring the player-visible message must contain
+	}{
+		{
+			name:        "guild resolved",
+			guildName:   "Echo Combat League",
+			botUsername: "EchoVRCE",
+			wantIn:      "Echo Combat League",
+		},
+		{
+			name:        "guild lookup failed, bot known",
+			guildName:   "",
+			botUsername: "EchoVRCE",
+			wantIn:      "EchoVRCE",
+		},
+		{
+			// The case that used to fall through and admit the login. There is
+			// nothing to name and therefore no channel to verify through, so the
+			// player is sent to support -- deliberately without a code, since a
+			// code they cannot submit anywhere would only mislead. Still a
+			// refusal, which is the whole point.
+			name:        "nothing resolvable",
+			guildName:   "",
+			botUsername: "",
+			wantIn:      "contact EchoVRCE support",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ipVerificationLocationError(tc.guildName, tc.botUsername, code)
+
+			msg := err.Error()
+			if !strings.Contains(msg, tc.wantIn) {
+				t.Errorf("message %q does not mention %q", msg, tc.wantIn)
+			}
+			if err.useDMs {
+				t.Error("useDMs must be false on this path: it is reached only because the DM could not be delivered")
+			}
+			if err.code != code {
+				t.Errorf("code = %q, want %q", err.code, code)
+			}
+		})
+	}
+}
+
+// TestIPVerificationLocationError_PrefersGuildOverBot documents the ordering,
+// which is a wording preference rather than a security property: a player is
+// told to use the slash command in a guild they are actually in when that guild
+// can be named, and is pointed at the bot only when it cannot.
+func TestIPVerificationLocationError_PrefersGuildOverBot(t *testing.T) {
+	err := ipVerificationLocationError("Echo Combat League", "EchoVRCE", "07")
+	if err.guildName != "Echo Combat League" {
+		t.Errorf("guildName = %q, want the guild to win when both are available", err.guildName)
+	}
+	if err.botUsername != "" {
+		t.Errorf("botUsername = %q, want empty when the guild named the message", err.botUsername)
+	}
+}

--- a/server/evr_runtime.go
+++ b/server/evr_runtime.go
@@ -706,7 +706,17 @@ func RuntimeLoggerToZapLogger(logger runtime.Logger) *zap.Logger {
 // getPartyMembersForUser retrieves all party members for a user, including the user themselves.
 // If the user is not in a party, it returns only the user's ID.
 // This function never returns an error - all failure cases result in returning just the user's ID.
-func getPartyMembersForUser(ctx context.Context, nk runtime.NakamaModule, partyRegistry PartyRegistry, userID string) []string {
+//
+// node is the Nakama node name, used as the party stream's label. It is a
+// PARAMETER, not a context lookup, because the only caller is a Discord slash
+// command: the appbot's context is hand-built (evr_pipeline.go, background +
+// bot token + env) and never carries runtime.RUNTIME_CTX_NODE. Reading it from
+// the context — copied from the RPC handlers in this file, where Nakama does
+// supply it — made this function return the caller alone on every real
+// invocation, so /create never resolved a party at all. The failure was
+// invisible because "no node" and "not in a party" produce the same result.
+// The node is available on the caller as d.pipeline.node.
+func getPartyMembersForUser(ctx context.Context, nk runtime.NakamaModule, partyRegistry PartyRegistry, userID, node string) []string {
 	// Load the user's matchmaking settings to get their party group
 	settings, err := LoadMatchmakingSettings(ctx, nk, userID)
 	if err != nil {
@@ -723,8 +733,7 @@ func getPartyMembersForUser(ctx context.Context, nk runtime.NakamaModule, partyR
 		return []string{userID}
 	}
 
-	node, ok := ctx.Value(runtime.RUNTIME_CTX_NODE).(string)
-	if !ok {
+	if node == "" {
 		return []string{userID}
 	}
 
@@ -753,9 +762,14 @@ func getPartyMembersForUser(ctx context.Context, nk runtime.NakamaModule, partyR
 // skipped -- reservations can only be made for resolvable, connected presences.
 // This function never returns an error; unresolvable members are silently skipped
 // (matching getPartyMembersForUser's fail-open convention above).
-func getOnlinePartyReservations(ctx context.Context, nk runtime.NakamaModule, logger runtime.Logger, creatorUserID string, partyUserIDs []string, roleAlignment int) []*EvrMatchPresence {
-	node, ok := ctx.Value(runtime.RUNTIME_CTX_NODE).(string)
-	if !ok {
+//
+// node is a PARAMETER for the same reason as getPartyMembersForUser: the only
+// caller is a Discord slash command whose context never carries
+// runtime.RUNTIME_CTX_NODE, so reading it there returned nil every time and the
+// whole slot-hold feature was inert in production while its test passed by
+// planting the key itself.
+func getOnlinePartyReservations(nk runtime.NakamaModule, logger runtime.Logger, creatorUserID string, partyUserIDs []string, roleAlignment int, node string) []*EvrMatchPresence {
+	if node == "" {
 		return nil
 	}
 

--- a/server/evr_runtime_event_remotelogset.go
+++ b/server/evr_runtime_event_remotelogset.go
@@ -334,17 +334,45 @@ func (s *EventRemoteLogSet) Process(ctx context.Context, logger runtime.Logger, 
 				logger.WithField("error", err).Warn("Failed to compute owned cosmetics")
 				continue
 			}
-			if profile.LoadoutCosmetics.Loadout, err = EquipAndSanitize(profile.LoadoutCosmetics.Loadout, category, name, owned); err != nil {
+			// Re-applied on every retry attempt against a freshly loaded
+			// profile, so a conflict costs the write, not the player's equip.
+			applyEquip := func(p *EVRProfile) error {
+				var applyErr error
+				p.LoadoutCosmetics.Loadout, applyErr = EquipAndSanitize(p.LoadoutCosmetics.Loadout, category, name, owned)
+				return applyErr
+			}
+			if err := applyEquip(profile); err != nil {
 				return fmt.Errorf("failed to update equipped item: %w", err)
 			}
 
-			if err := EVRProfileUpdate(ctx, nk, session.UserID().String(), profile); err != nil {
-				logger.WithField("error", err).Warn("Failed to set account metadata")
+			// Retry on version conflict rather than logging and moving on.
+			//
+			// EVRProfileUpdate stopped retrying internally this cycle, so a
+			// conflict now reaches callers -- and this one logged at Warn and
+			// then adopted `profile` into the session parameters anyway. The
+			// player saw the cosmetic equipped for the rest of their session
+			// and it silently reverted on next login, because nothing had been
+			// written. Any later write from that adopted object also started
+			// from a stale version.
+			//
+			// The conflict is not hypothetical: the Discord member sync writes
+			// the same EVRProfile key on ordinary member-update events.
+			// evrProfileUpdateWithRetry is what the release built for this; its
+			// sibling equip path in evr_pipeline_gameserver_loadout.go already
+			// uses it.
+			updated, err := evrProfileUpdateWithRetry(ctx, nk, session.UserID().String(), profile, applyEquip)
+			if err != nil {
+				// Do NOT adopt an unpersisted profile. Leaving the session on
+				// the last known-good one means the equip is lost, which the
+				// player can see and redo -- the alternative is a session that
+				// disagrees with storage until logout.
+				logger.WithField("error", err).Warn("Failed to persist equipped item; session profile left unchanged")
+				continue
 			}
 
 			// swap the metadata in the session parameters
 
-			params.profile = profile
+			params.profile = updated
 
 			StoreParams(session.Context(), params)
 

--- a/server/evr_storage_index_characterization_test.go
+++ b/server/evr_storage_index_characterization_test.go
@@ -984,7 +984,11 @@ func TestStorageIndex_HasNoCrossNodePropagationMechanism(t *testing.T) {
 	}
 	sort.Strings(fields)
 
-	want := []string{"config", "customFilterFunctions", "db", "indexByName", "indicesByCollection", "logger", "metrics"}
+	// loadPageSize is a tuning knob for load()'s row batch size, not a
+	// collaborator: it is an int with a production default, touches no peer and
+	// carries no state between nodes. It exists so a test can reproduce the
+	// page-boundary case that the truncation probe has to handle.
+	want := []string{"config", "customFilterFunctions", "db", "indexByName", "indicesByCollection", "loadPageSize", "logger", "metrics"}
 	if !reflect.DeepEqual(fields, want) {
 		t.Errorf("LocalStorageIndex collaborators changed.\n got: %v\nwant: %v\n"+
 			"If a peer/broadcast collaborator was added, cross-node propagation may now exist and "+

--- a/server/evr_testsupport_test.go
+++ b/server/evr_testsupport_test.go
@@ -92,10 +92,16 @@ type evrTestNakamaModule struct {
 
 	sessions SessionRegistry
 	parties  PartyRegistry
+
+	// groups backs GroupsGetId, which GuildGroupLoad calls first. Tests that
+	// exercise a guild-gated code path must populate this: an empty map means
+	// "group not found", and gates that resolve their guild through nk treat
+	// that as not-opted-in. See optInGuildToEarlyQuitEnforcement.
+	groups map[string]*api.Group
 }
 
 func newEvrTestNakamaModule() *evrTestNakamaModule {
-	return &evrTestNakamaModule{occTestNakamaModule: newOCCTestNakamaModule()}
+	return &evrTestNakamaModule{occTestNakamaModule: newOCCTestNakamaModule(), groups: map[string]*api.Group{}}
 }
 
 // SessionRegistry / PartyRegistry satisfy the narrow provider interfaces the EVR
@@ -103,6 +109,23 @@ func newEvrTestNakamaModule() *evrTestNakamaModule {
 // call sites treat it as "no registry available".
 func (m *evrTestNakamaModule) SessionRegistry() SessionRegistry { return m.sessions }
 func (m *evrTestNakamaModule) PartyRegistry() PartyRegistry     { return m.parties }
+
+// optInGuildToEarlyQuitEnforcement registers a guild whose metadata sets
+// EnforceEarlyQuitPenalty, so earlyQuitEnforcementEnabled resolves it to true.
+//
+// This is required for any test that expects a charge. The gate resolves the
+// guild through nk and fails CLOSED when it cannot -- a guild that does not
+// exist cannot have opted in. Before that, the gate read session parameters and
+// returned true when they were absent, which is the whole reason it never
+// suppressed anything in production: the match runtime's context never carries
+// them.
+func optInGuildToEarlyQuitEnforcement(t *testing.T, m *evrTestNakamaModule, groupID string) {
+	t.Helper()
+	m.groups[groupID] = &api.Group{
+		Id:       groupID,
+		Metadata: `{"enforce_early_quit_penalty":true}`,
+	}
+}
 
 func (m *evrTestNakamaModule) StorageList(ctx context.Context, callerID, userID, collection string, limit int, cursor string) ([]*api.StorageObject, string, error) {
 	m.mu.Lock()
@@ -171,7 +194,13 @@ func (m *evrTestNakamaModule) LeaderboardRecordsList(ctx context.Context, id str
 }
 
 func (m *evrTestNakamaModule) GroupsGetId(ctx context.Context, groupIDs []string) ([]*api.Group, error) {
-	return nil, nil
+	out := make([]*api.Group, 0, len(groupIDs))
+	for _, id := range groupIDs {
+		if g, ok := m.groups[id]; ok {
+			out = append(out, g)
+		}
+	}
+	return out, nil
 }
 
 // FriendsList reports a player with no friends and therefore no ghosted/blocked

--- a/server/storage_index.go
+++ b/server/storage_index.go
@@ -57,6 +57,13 @@ type storageIndex struct {
 }
 
 type LocalStorageIndex struct {
+	// loadPageSize is the row batch size used by load(). Zero means the
+	// production default. It is overridable so a test can reproduce the
+	// page-boundary case cheaply: MaxEntries landing exactly on a page
+	// boundary is the normal production alignment, and it is the case the
+	// in-page truncation probe cannot decide.
+	loadPageSize int
+
 	logger                *zap.Logger
 	db                    *sql.DB
 	metrics               Metrics
@@ -438,6 +445,16 @@ func (si *LocalStorageIndex) Load(ctx context.Context) error {
 	return rangeError
 }
 
+// storageIndexLoadPageSize is the number of rows load() reads per query.
+const storageIndexLoadPageSize = 10_000
+
+func (si *LocalStorageIndex) pageSize() int {
+	if si.loadPageSize > 0 {
+		return si.loadPageSize
+	}
+	return storageIndexLoadPageSize
+}
+
 func (si *LocalStorageIndex) load(ctx context.Context, idx *storageIndex) error {
 	query := `
 SELECT user_id, key, version, value, read, write, create_time, update_time
@@ -445,7 +462,7 @@ FROM storage
 WHERE collection = $1
 ORDER BY collection, key, user_id
 LIMIT $2`
-	params := []any{idx.Collection, 10_000}
+	params := []any{idx.Collection, si.pageSize()}
 
 	if idx.Key != "" {
 		query = `
@@ -526,9 +543,15 @@ LIMIT $2`
 			if count >= idx.MaxEntries {
 				// Reaching MaxEntries is not by itself truncation: a collection
 				// holding exactly MaxEntries rows fills the index with nothing
-				// left over. Only a row that exists past the cap proves rows
-				// were dropped. rows is closed immediately below and pagination
-				// stops either way, so consuming one more row costs nothing.
+				// left over. Only a row existing past the cap proves rows were
+				// dropped.
+				//
+				// This settles it when the cap is hit MID-page. It cannot settle
+				// the page boundary: the load pages at 10_000 and every index
+				// here sets MaxEntries to a multiple of that, so the cap is
+				// normally reached on a page's LAST row and rows.Next() is false
+				// even when the collection continues. That case is resolved
+				// after the loop by asking the database directly.
 				truncated = rows.Next()
 				break
 			}
@@ -537,6 +560,20 @@ LIMIT $2`
 
 		if err = idx.Index.Batch(batch); err != nil {
 			return err
+		}
+
+		if count >= idx.MaxEntries && !truncated && dbUserID != nil {
+			// The cap was reached exactly as the page ran out, so the in-page
+			// probe above could not tell truncation from a perfect fit. One
+			// bounded lookup for a single row past the last one indexed settles
+			// it. This runs at most once per load, and only for a full index.
+			hasMore, probeErr := si.collectionHasRowPast(ctx, idx, dbKey, dbUserID)
+			if probeErr != nil {
+				si.logger.Error("Failed to determine whether the storage index truncated at load; assuming it did not",
+					zap.String("index_name", idx.Name), zap.Error(probeErr))
+			} else {
+				truncated = hasMore
+			}
 		}
 
 		if count >= idx.MaxEntries || !rowsRead {
@@ -572,10 +609,49 @@ AND user_id > $4
 ORDER BY collection, key, user_id
 LIMIT $2`
 		}
-		params = []any{idx.Collection, 10_000, dbKey, dbUserID}
+		params = []any{idx.Collection, si.pageSize(), dbKey, dbUserID}
 	}
 
 	return nil
+}
+
+// collectionHasRowPast reports whether the collection holds any row ordered
+// after (lastKey, lastUserID), using the same keyset ordering the load
+// pagination uses.
+//
+// It exists so the boot-time truncation warning can tell "the index filled and
+// rows remain" from "the index filled exactly". Detecting that from the page
+// buffer alone is not possible when MaxEntries lands on a page boundary, which
+// is the normal case here: pages are 10,000 rows and the indexes in this
+// codebase use MaxEntries of 10,000 / 100,000 / 1,000,000.
+func (si *LocalStorageIndex) collectionHasRowPast(ctx context.Context, idx *storageIndex, lastKey string, lastUserID *uuid.UUID) (bool, error) {
+	query := `
+SELECT 1
+FROM storage
+WHERE collection = $1
+AND (collection, key, user_id) > ($1, $2, $3)
+LIMIT 1`
+	args := []any{idx.Collection, lastKey, lastUserID}
+
+	if idx.Key != "" {
+		query = `
+SELECT 1
+FROM storage
+WHERE collection = $1
+AND key = $2
+AND user_id > $3
+LIMIT 1`
+		args = []any{idx.Collection, idx.Key, lastUserID}
+	}
+
+	var found int
+	if err := si.db.QueryRowContext(ctx, query, args...).Scan(&found); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (si *LocalStorageIndex) mapIndexStorageFields(userID, collection, key, version, value string, read, write int32, createTime, updateTime time.Time, filters []string, sortFilters []string, indexOnly bool) (*bluge.Document, error) {

--- a/server/storage_index_observability_test.go
+++ b/server/storage_index_observability_test.go
@@ -320,7 +320,7 @@ func TestStorageIndexLoad_TruncationWarnRequiresActualTruncation(t *testing.T) {
 
 	// writeN writes n objects into the collection, then builds a fresh index
 	// over it and Loads. It returns the number of truncation warnings emitted.
-	loadWarnings := func(t *testing.T, n int) int {
+	loadWarningsWith := func(t *testing.T, maxEntries, pageSize, n int) int {
 		t.Helper()
 
 		db := NewDB(t)
@@ -365,6 +365,9 @@ func TestStorageIndexLoad_TruncationWarnRequiresActualTruncation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		if pageSize > 0 {
+			loadIdx.(*LocalStorageIndex).loadPageSize = pageSize
+		}
 		if err := loadIdx.CreateIndex(ctx, indexName, collection, "", []string{"one"}, []string{}, maxEntries, false); err != nil {
 			t.Fatal(err)
 		}
@@ -373,6 +376,18 @@ func TestStorageIndexLoad_TruncationWarnRequiresActualTruncation(t *testing.T) {
 		}
 
 		return logs.FilterMessage(warnMsg).Len()
+	}
+
+	loadWarnings := func(t *testing.T, n int) int {
+		t.Helper()
+		return loadWarningsWith(t, maxEntries, 0, n)
+	}
+
+	// loadWarningsPaged reproduces the production alignment: MaxEntries equal to
+	// the page size, so the cap is reached on a page's last row.
+	loadWarningsPaged := func(t *testing.T, size, n int) int {
+		t.Helper()
+		return loadWarningsWith(t, size, size, n)
 	}
 
 	t.Run("exactly MaxEntries rows is not truncation", func(t *testing.T) {
@@ -386,6 +401,29 @@ func TestStorageIndexLoad_TruncationWarnRequiresActualTruncation(t *testing.T) {
 		if got := loadWarnings(t, maxEntries+1); got != 1 {
 			t.Errorf("collection holding MaxEntries+1 (%d) rows emitted %d truncation warning(s), want 1; "+
 				"rows were genuinely dropped and the operator must be told", maxEntries+1, got)
+		}
+	})
+
+	t.Run("truncation is detected when the cap lands on a page boundary", func(t *testing.T) {
+		// The original fix probed for an extra row with rows.Next() on the page
+		// buffer. That cannot see past the end of a page, and the load pages at
+		// 10,000 rows while every index in this codebase sets MaxEntries to a
+		// multiple of that -- so in production the cap is reached on a page's
+		// LAST row and the probe always came back false. The warning could not
+		// fire for any index that could actually truncate.
+		//
+		// loadWarningsPaged sets MaxEntries equal to the page size, reproducing
+		// that alignment at a size a test can afford.
+		if got := loadWarningsPaged(t, 4, 5); got != 1 {
+			t.Errorf("collection holding one row past a page-aligned MaxEntries emitted %d truncation "+
+				"warning(s), want 1; the in-page probe cannot see past the page and the database must be asked", got)
+		}
+	})
+
+	t.Run("exact page-aligned fit is not truncation", func(t *testing.T) {
+		if got := loadWarningsPaged(t, 4, 4); got != 0 {
+			t.Errorf("collection holding exactly a page-aligned MaxEntries emitted %d truncation warning(s), "+
+				"want 0; the index filled exactly and nothing was dropped", got)
 		}
 	})
 }


### PR DESCRIPTION
Findings from a five-agent adversarial bug hunt over `v3.27.2-evr.320..main`, verified individually before fixing. Every fix is mutation-tested: break it again, watch the test fail.

**Three of these mean a feature that was believed to be working was not working at all.** In each case a green test hid it, because the test supplied a context value production never supplies.

## The pattern

| Feature | Believed | Actual | Why the test passed |
|---|---|---|---|
| Early-quit guild opt-in | per-guild, default off | **enforced in every guild** | test planted `ctxSessionParametersKey` |
| `/create` party members | resolves the party | **returns the creator alone** | test planted `RUNTIME_CTX_NODE` |
| `/create` reservations (#574) | holds follower slots | **holds nothing** | test planted `RUNTIME_CTX_NODE` |

Same shape each time: a guard reads a dependency out of `context`, fails open or degrades silently when it is absent, and the test plants the value by hand. Both dependencies are now **parameters**, so the compiler enforces what the tests were faking.

## Security

**An unresolvable guild admitted an unverified IP.** `evr_pipeline_login.go` — in the DMs-disabled branch of the new-location gate, an `if / else-if / else` chain whose first arm could fall through: `guildID != ""` and `dg.Guild()` errors → no arm returns → execution leaves the verification block and `authorizeSession` completes. Both preconditions are reachable and one is player-influenced (they control whether their DMs accept non-friends; `dg.Guild()` fails deterministically for a guild the bot has left).

The block's own comment asserted *"every path inside this block returns an error"* — false for that sub-path, so the reasoning justifying the surrounding refactor did not hold. Restructured so the fall-through is unrepresentable, and the decision extracted into a testable function; this file is at **2.3% statement coverage**, which is why it survived.

Pre-existing, not a regression from this range.

## Charging players who should not be charged

**The early-quit guild opt-in gate never gated.** It read the guild from session parameters and returned `true` when absent — but `ctxSessionParametersKey` is planted only on the WebSocket session context, and match callbacks get the match runtime's context. All three match-side callers took the fail-open branch on every invocation. In every guild, opted in or not: quit counters incremented, lockouts written, tiers degraded, "flagged for early quitting" DMs sent.

The repo said so in writing (`evr_earlyquit_charge_test.go`): *"THIS CONTEXT SHAPE DOES NOT OCCUR IN PRODUCTION ... That is a real production bug."* Deferred during a testability refactor, shipping in the RC.

Now resolved through `nk` (which every match callback has), reading group metadata directly. **The fail direction is reversed to fail closed** — opt-in means the absence of a yes is a no, and the costs are asymmetric: a missed charge is recoverable, a wrongful one is a lifetime `NumEarlyQuits` increment that never decays. The fake-context helper is deleted.

**Moderator exemptions were bypassed on the deferred charge path.** `MatchLeave` honours `IsExempt`; the reservation-expiry charge did not — and `MatchLeave` skips its whole charge block when a reconnect reservation exists. An exempt player who crashed and missed the reconnect window was charged anyway. That is the worst population to get wrong: the exemption is most often granted to players with bad connections, who are exactly the ones that miss the window. Leaderboard stat and quit-history record suppressed too, since recording the quit would re-punish them through the moderator-facing stats.

## Destructive operations

**`report_only` did not freeze the event-driven group delete.** Documented as *"the operator's single freeze switch during an incident"*, it gated the prune pass only. A `GUILD_DELETE` arriving mid-incident — precisely when Discord's reads are least trustworthy, the premise the prune pass was hardened against — destroyed role mappings, channel IDs and suspension inheritance despite the freeze. Under the freeze the group is now left for the prune pass to collect: the cost of waiting is a stale group, the cost of not waiting is unrecoverable.

## Data loss

**The equip handler adopted a profile it never saved.** `EVRProfileUpdate` stopped retrying internally this cycle, so conflicts now reach callers; this one logged at Warn and then adopted the unwritten profile into the session. The player saw the cosmetic equipped all session and it reverted at next login. Not hypothetical — the Discord member sync writes the same key on ordinary member-update events. Now uses `evrProfileUpdateWithRetry`, which this release built for exactly this and already applied to the sibling equip path.

## My own fixes from earlier today

**`/create role:spectator` would have seated the whole party in the stands.** The alignment loop stamped the creator's role onto every member; the comment above it already said the intent was *"spectator keeps the creator off a team"*. Fixed at the root, and guarded at the consume site where `TeamAlignments` already refuses spectator — so a future builder cannot reintroduce it.

**The truncation warning could not fire for any index that could truncate.** My fix this morning probed with `rows.Next()` on the page buffer. The load pages at 10,000 and every index sets `MaxEntries` to a multiple of that, so the cap is reached on a page's *last* row and the probe always returned false. My test used `MaxEntries=4`, nowhere near a boundary — it passed while proving nothing. Now asks the database for one row past the last indexed; page size made overridable so the boundary is testable at four rows instead of ten thousand and one.

## Verification

- `just test` green throughout; `just test-audit` green, **3,150 passing** in `server`
- Every fix mutation-tested; the early-quit mutation notably fails `guild-flag-nil` and `guild-flag-false`, two subtests that passed for as long as the bug existed
- Storage-index work verified against a live postgres (DB-backed, does not run in the DB-free suite)
- Pre-push hook exercised in throwaway clones

## Not fixed here

- **Discord outage protection is process-local**, lost on restart and self-expiring at 24h. It is the only guard between a Discord read anomaly and unrecoverable `GroupDelete`. Needs a design call on persisting it.
- **`MatchLeave` records an exempt player's quit** before checking the exemption — "exempt from tracking" exempts the counter but not the tracking. Left alone rather than widening a behaviour change onto the path that was already working.
- **The reservation-refresh lockout** at `evr_match.go` — flagged previously, still a product decision.
- **The party-split reconnect bug** is now understood end to end (two-act failure: a swallowed `ErrPartyFull` in `PartyHandler.Join` drops the reconnecting member from the roster silently, then the open-party `JoinRequest` full-check rejects them with no identity bypass, because the already-member check is dead code for open parties). Pre-existing; no party file changed in this range.

Co-authored-by: nakama-fixer <nakama-fixer@metis.agents>