### PR TITLE
fix: the party-split reconnect lockout, plus two guards that protected the wrong thing

### DIFF
--- a/server/evr_discord_integrator.go
+++ b/server/evr_discord_integrator.go
@@ -63,6 +63,11 @@ type DiscordIntegrator struct {
 	// is the only remaining evidence that they exist. See
 	// unavailableGuildIDsAsOf.
 	unavailableGuilds *MapOf[string, time.Time]
+
+	// startedAt is when this process began tracking guild availability. The
+	// unavailable-guild record above lives only in memory, so immediately after
+	// a restart there is none -- see pruneDeleteStartupGrace.
+	startedAt time.Time
 }
 
 // unavailableGuildGraceTTL is how long a guild that went unavailable keeps
@@ -71,6 +76,32 @@ type DiscordIntegrator struct {
 // in is simply absent from READY and no GUILD_DELETE ever arrives for it, so
 // without an expiry its entry would never be cleared.
 const unavailableGuildGraceTTL = 24 * time.Hour
+
+// pruneDeleteStartupGrace is how long after boot the prune pass refuses to
+// DELETE guild groups, regardless of configuration.
+//
+// unavailableGuilds is process-local: a restart erases every record of which
+// guilds were merely dark, and the only thing standing between a Discord read
+// anomaly and an unrecoverable GroupDelete is that record. Normally READY
+// lists unavailable guilds as stubs and they are protected anyway -- but a
+// READY that omits a member guild is exactly the "Discord is lying" case this
+// pass was hardened against, and it is most likely during the incident that
+// caused the restart.
+//
+// Two prune intervals is enough for a gateway to settle and for the first
+// GUILD_CREATE burst to land. Leaves and the non-destructive repair pass are
+// unaffected: a leave is recoverable by re-inviting the bot, a delete is not.
+const pruneDeleteStartupGrace = 30 * time.Minute
+
+// pruneDeletesAllowed reports whether the prune pass may delete guild groups,
+// given how long this process has been tracking guild availability.
+//
+// Split out from the loop so the rule can be tested without a gateway: the
+// decision is the whole point, and it runs inside a goroutine started by
+// Start().
+func pruneDeletesAllowed(configured bool, uptime time.Duration) bool {
+	return configured && uptime >= pruneDeleteStartupGrace
+}
 
 func NewDiscordIntegrator(ctx context.Context, logger *zap.Logger, config Config, metrics Metrics, nk runtime.NakamaModule, db *sql.DB, dg *discordgo.Session, guildGroupRegistry *GuildGroupRegistry) *DiscordIntegrator {
 	ctx, cancelFn := context.WithCancel(ctx)
@@ -92,6 +123,7 @@ func NewDiscordIntegrator(ctx context.Context, logger *zap.Logger, config Config
 		idcache:            &MapOf[string, string]{},
 		memberCache:        &MapOf[string, cachedMember]{},
 		unavailableGuilds:  &MapOf[string, time.Time]{},
+		startedAt:          time.Now(),
 
 		queueCh: make(chan QueueEntry, 50),
 	}
@@ -204,6 +236,12 @@ func (c *DiscordIntegrator) Start() {
 					doGroupDeletes:  prune.DeleteOrphanedGroups,
 					safetyThreshold: prune.SafetyLimit,
 					reportOnly:      prune.ReportOnly,
+				}
+				if uptime := time.Since(c.startedAt); !pruneDeletesAllowed(cfg.doGroupDeletes, uptime) && cfg.doGroupDeletes {
+					cfg.doGroupDeletes = false
+					logger.Warn("Prune: group deletes suppressed, still inside the post-boot grace period",
+						zap.Duration("uptime", uptime),
+						zap.Duration("grace", pruneDeleteStartupGrace))
 				}
 				if err := c.pruneGuildGroups(c.ctx, runtimeLogger, cfg); err != nil {
 					logger.Error("Error pruning guild groups", zap.Error(err), zap.Bool("do_leaves", cfg.doGuildLeaves), zap.Bool("do_deletes", cfg.doGroupDeletes), zap.Int("prune_safety_threshold", cfg.safetyThreshold))

--- a/server/evr_discord_integrator_guilddelete_test.go
+++ b/server/evr_discord_integrator_guilddelete_test.go
@@ -254,3 +254,41 @@ func TestHandleGuildDelete_ReportOnlyFreezesTheDelete(t *testing.T) {
 		"report_only must freeze the event-driven group delete, not only the prune pass; "+
 			"the group can be collected later, but a deleted one cannot be recovered")
 }
+
+// TestPruneDeletesAllowed_SuppressedAfterBoot pins the post-restart grace on
+// destructive prunes.
+//
+// unavailableGuilds -- the record of which guilds are merely dark rather than
+// departed -- lives only in memory. A restart erases it, and it is the only
+// thing between a Discord read anomaly and an unrecoverable GroupDelete.
+// Normally READY lists unavailable guilds as stubs and they are protected
+// anyway, but a READY that omits a member guild is precisely the "Discord is
+// lying" case this pass was hardened against, and it is most likely during the
+// incident that caused the restart.
+//
+// Leaves and the non-destructive repair pass are deliberately unaffected:
+// re-inviting the bot undoes a leave, nothing undoes a delete.
+func TestPruneDeletesAllowed_SuppressedAfterBoot(t *testing.T) {
+	cases := []struct {
+		name       string
+		configured bool
+		uptime     time.Duration
+		want       bool
+	}{
+		{"armed, just booted", true, 0, false},
+		{"armed, one prune interval in", true, 15 * time.Minute, false},
+		{"armed, one second short of the grace", true, pruneDeleteStartupGrace - time.Second, false},
+		{"armed, grace elapsed", true, pruneDeleteStartupGrace, true},
+		{"armed, long-running process", true, 72 * time.Hour, true},
+		{"not configured, grace elapsed", false, 72 * time.Hour, false},
+		{"not configured, just booted", false, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := pruneDeletesAllowed(tc.configured, tc.uptime); got != tc.want {
+				t.Errorf("pruneDeletesAllowed(%t, %v) = %t, want %t", tc.configured, tc.uptime, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/evr_lobby_group.go
+++ b/server/evr_lobby_group.go
@@ -180,14 +180,29 @@ func JoinPartyGroup(session *sessionWS, groupName string, currentMatchID MatchID
 		if !isMember {
 			// Join the party
 			success, err := ph.JoinRequest(&presence)
-			if err != nil && err != runtime.ErrPartyJoinRequestAlreadyMember {
+
+			// Already being a member is success, not failure. This branch
+			// already meant to say so, but could never take effect: JoinRequest
+			// returns (false, ErrPartyJoinRequestAlreadyMember), so tolerating
+			// the error only fell through to the !success check below and
+			// returned "failed to join party" anyway.
+			//
+			// It also could not be reached before now -- for an open party,
+			// which is the only kind EVR creates, JoinRequest returned
+			// ErrPartyFull without ever consulting identity. With that fixed, a
+			// reconnecting member reaches this branch, and it has to mean what
+			// it says or the reconnect still fails.
+			alreadyMember := errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember)
+			if err != nil && !alreadyMember {
 				return nil, false, err
 			}
 
-			if !success {
+			if !success && !alreadyMember {
 				return nil, false, errors.New("failed to join party")
 			}
-			addedMember = true
+			// Only a genuine join needs rolling back if the Track below fails;
+			// a member who was already there was not added by this call.
+			addedMember = !alreadyMember
 		}
 	}
 

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -2156,6 +2156,7 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			return state, SignalResponse{Message: fmt.Sprintf("failed to unmarshal create party reservations: %v", err)}.String()
 		}
 		created := 0
+		refreshed := 0
 		skipped := 0
 		for _, member := range payload.Members {
 			// Skip if the member is already an active presence. Match by user ID,
@@ -2196,7 +2197,20 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			// stale value for every member: two followers would both pass a
 			// one-slot check and both get in. Recomputing per member is what
 			// makes the guard hold for the second one.
-			if state.OpenSlots() <= 0 {
+			// A member who already holds a reservation is REFRESHING it, and
+			// upsertReservationByUserID deletes the old one before inserting, so
+			// the operation consumes no additional slot. Gating that on
+			// OpenSlots meant a follower in a full lobby could never have their
+			// expiry extended: their client re-sends LobbyFindSessionRequest,
+			// the signal fires, the guard skips them, and at the 5-minute expiry
+			// rebuildCache drops the reservation and a backfill player takes the
+			// seat they were holding -- the party split this subsystem exists to
+			// prevent.
+			//
+			// Capacity still binds for genuinely new reservations, which is what
+			// the guard was added for.
+			refresh := state.hasReservationForUserID(member.GetUserId())
+			if !refresh && state.OpenSlots() <= 0 {
 				skipped++
 				continue
 			}
@@ -2208,15 +2222,30 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 				Presence: member,
 				Expiry:   time.Now().Add(5 * time.Minute),
 			})
-			created++
+			if refresh {
+				refreshed++
+			} else {
+				created++
+			}
 			// Make the reservation visible to the next iteration's OpenSlots().
 			state.rebuildCache()
 		}
-		logger.WithFields(map[string]any{
+		// createReservationForNewPartyMember signals on every follower's
+		// LobbyFindSessionRequest re-send, so a full lobby with retrying
+		// followers produced a steady stream of Info lines announcing "Created"
+		// alongside created: 0. Say what happened, and only raise it to Info
+		// when something did.
+		reservationFields := map[string]any{
 			"requested": len(payload.Members),
 			"created":   created,
+			"refreshed": refreshed,
 			"skipped":   skipped,
-		}).Info("Created party reservations via signal")
+		}
+		if created > 0 || refreshed > 0 {
+			logger.WithFields(reservationFields).Info("Party reservations updated via signal")
+		} else {
+			logger.WithFields(reservationFields).Debug("Party reservation signal made no changes")
+		}
 
 	case SignalClearPartyReservations:
 		var payload SignalClearPartyReservationsPayload

--- a/server/evr_match.go
+++ b/server/evr_match.go
@@ -2209,7 +2209,7 @@ func (m *EvrMatch) MatchSignal(ctx context.Context, logger runtime.Logger, db *s
 			//
 			// Capacity still binds for genuinely new reservations, which is what
 			// the guard was added for.
-			refresh := state.hasReservationForUserID(member.GetUserId())
+			refresh := state.hasReservationFor(member)
 			if !refresh && state.OpenSlots() <= 0 {
 				skipped++
 				continue

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -168,24 +168,33 @@ func (s *MatchLabel) LoadAndDeleteReservationByUserIDRaw(userID string) (*slotRe
 // same member can never net to zero reservations. Callers are expected to
 // rebuildCache() afterward (as the create paths already do) so the derived
 // capacity counters reflect the change.
-// hasReservationForUserID reports whether this member already holds a slot
+// hasReservationFor reports whether this member already holds a slot
 // reservation, under any session ID.
 //
 // It exists to tell a REFRESH from a new booking. upsertReservationByUserID
 // deletes any existing reservation for the user before inserting, so refreshing
 // one is slot-neutral -- and a capacity check that cannot see the difference
 // refuses to extend the expiry of a member who is already holding a seat.
-func (s *MatchLabel) hasReservationForUserID(userID string) bool {
-	uid := uuid.FromStringOrNil(userID)
-	if uid == uuid.Nil {
+//
+// The match falls back to the session ID when the user ID is nil, exactly as
+// upsertReservationByUserID does: a nil user ID is not a stable identity, so
+// those reservations are keyed on session instead. Matching only on user ID
+// would treat a nil-ID member's refresh as a new booking and skip it in a full
+// lobby -- the very case this exists to prevent.
+func (s *MatchLabel) hasReservationFor(presence *EvrMatchPresence) bool {
+	if presence == nil {
 		return false
 	}
-	for _, r := range s.reservationMap {
-		if r.Presence.UserID == uid {
-			return true
+	if presence.UserID != uuid.Nil {
+		for _, r := range s.reservationMap {
+			if r.Presence.UserID == presence.UserID {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	_, ok := s.reservationMap[presence.GetSessionId()]
+	return ok
 }
 
 func (s *MatchLabel) upsertReservationByUserID(reservation *slotReservation) {

--- a/server/evr_match_label.go
+++ b/server/evr_match_label.go
@@ -168,6 +168,26 @@ func (s *MatchLabel) LoadAndDeleteReservationByUserIDRaw(userID string) (*slotRe
 // same member can never net to zero reservations. Callers are expected to
 // rebuildCache() afterward (as the create paths already do) so the derived
 // capacity counters reflect the change.
+// hasReservationForUserID reports whether this member already holds a slot
+// reservation, under any session ID.
+//
+// It exists to tell a REFRESH from a new booking. upsertReservationByUserID
+// deletes any existing reservation for the user before inserting, so refreshing
+// one is slot-neutral -- and a capacity check that cannot see the difference
+// refuses to extend the expiry of a member who is already holding a seat.
+func (s *MatchLabel) hasReservationForUserID(userID string) bool {
+	uid := uuid.FromStringOrNil(userID)
+	if uid == uuid.Nil {
+		return false
+	}
+	for _, r := range s.reservationMap {
+		if r.Presence.UserID == uid {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *MatchLabel) upsertReservationByUserID(reservation *slotReservation) {
 	userID := reservation.Presence.UserID
 	// A nil user ID is not a stable identity; key on session ID only in that

--- a/server/evr_party_system_test.go
+++ b/server/evr_party_system_test.go
@@ -1173,71 +1173,62 @@ func TestPartyHandler_PromoteThenMatchmake(t *testing.T) {
 	}
 }
 
-// --- Party-split on reconnect: the two acts -------------------------------
-//
-// These pin the production shape of the party-split lockout, which two prior
-// reviews disagreed about because each saw only one half of it.
+// --- Party-split on reconnect: the two acts, now fixed ---------------------
 //
 // EVR creates ONLY open parties (evr_lobby_group.go: GetOrCreateByGroupName
-// with open=true). Every existing JoinRequest test builds the handler with
-// open=false, so the path production actually runs had no coverage at all.
+// with open=true). Every pre-existing JoinRequest test builds the handler with
+// open=false, so the path production actually runs had no coverage, which is
+// why two reviews could disagree about this for weeks.
 
-// TestPartyHandler_OpenPartyJoinRequestIgnoresIdentity is act two.
+// TestPartyHandler_OpenPartyJoinRequestRecognisesExistingMember is act two.
 //
-// For an open party the already-member check at the bottom of JoinRequest is
-// unreachable: the capacity check returns ErrPartyFull first, and the Open
-// branch returns before identity is ever considered. So a member reconnecting
-// into their own full party is told the party is full, with no bypass for the
-// fact that they are already in it.
+// JoinRequest checked capacity before identity, and its already-member check
+// sat below the p.Open branch -- unreachable for an open party. A member
+// reconnecting into their own full party was told the party was full, with no
+// bypass for already being in it, and every retry hit the same wall.
 //
-// This is what the player sees as "party is full" on reconnect, and what turns
-// a reconnect storm into a lockout: every retry hits the same wall.
-func TestPartyHandler_OpenPartyJoinRequestIgnoresIdentity(t *testing.T) {
+// Identity is now checked first, because an existing member consumes no new
+// slot. A closed party always behaved this way; the two now agree.
+func TestPartyHandler_OpenPartyJoinRequestRecognisesExistingMember(t *testing.T) {
 	const maxSize = 4
-	ph, cleanup := createLightPartyHandler(t, loggerForTest(t), true, maxSize, nil)
-	defer cleanup()
 
-	members, _ := addMembers(t, ph, maxSize)
-	if got := ph.members.Size(); got != maxSize {
-		t.Fatalf("precondition: expected a full party of %d, got %d", maxSize, got)
-	}
+	for _, open := range []bool{true, false} {
+		name := "closed party"
+		if open {
+			name = "open party"
+		}
+		t.Run(name, func(t *testing.T) {
+			ph, cleanup := createLightPartyHandler(t, loggerForTest(t), open, maxSize, nil)
+			defer cleanup()
 
-	// An existing member asks to join again -- the shape of a reconnect whose
-	// stale entry is still counted.
-	_, err := ph.JoinRequest(members[0])
+			members, _ := addMembers(t, ph, maxSize)
+			if got := ph.members.Size(); got != maxSize {
+				t.Fatalf("precondition: expected a full party of %d, got %d", maxSize, got)
+			}
 
-	if errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember) {
-		t.Fatal("open-party JoinRequest now recognises an existing member; " +
-			"the reconnect lockout is fixed and this test should assert the new behaviour")
-	}
-	if !errors.Is(err, runtime.ErrPartyFull) {
-		t.Fatalf("expected ErrPartyFull (identity is not consulted for open parties), got %v", err)
-	}
-
-	// The same request against a CLOSED party is recognised, which is the
-	// asymmetry: the protection exists, and the only kind of party EVR builds
-	// cannot reach it.
-	closed, closedCleanup := createLightPartyHandler(t, loggerForTest(t), false, maxSize, nil)
-	defer closedCleanup()
-	closedMembers, _ := addMembers(t, closed, 1)
-	if _, err := closed.JoinRequest(closedMembers[0]); !errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember) {
-		t.Fatalf("closed party should recognise an existing member, got %v", err)
+			_, err := ph.JoinRequest(members[0])
+			if !errors.Is(err, runtime.ErrPartyJoinRequestAlreadyMember) {
+				t.Fatalf("an existing member must be recognised as one even when the party is full, got %v", err)
+			}
+		})
 	}
 }
 
-// TestPartyHandler_JoinSilentlyDropsMemberWhenFull is act one, and it is the
-// half that leaves no trace.
+// TestPartyHandler_JoinReplacesOwnStaleSession is act one, and it was the half
+// that left no trace.
 //
-// A reconnecting member is re-tracked on the party stream, which drives
-// PartyHandler.Join. With their stale session still counted the party is at
-// MaxSize, PartyPresenceList.Join returns ErrPartyFull, and Join logs
-// "Should not happen, this process is just a confirmation" and returns.
+// Party capacity is keyed on session ID. A reconnecting player's fresh session
+// counted as a new member while their stale session still held a slot, so
+// PartyPresenceList.Join returned ErrPartyFull -- and PartyHandler.Join
+// discards that error as "should not happen, this process is just a
+// confirmation". The player ended up tracked on the party stream but absent
+// from ph.members, so the leader's matchmaking cohort silently excluded them.
+// That is the split. Act two was only what they saw on the next attempt.
 //
-// The presence is now tracked on the stream but absent from ph.members. The
-// leader's matchmaking cohort is built from members, so the reconnecting
-// player is silently excluded -- split off from their own party with no error
-// surfaced to anyone. Act two is only what they see on the next attempt.
-func TestPartyHandler_JoinSilentlyDropsMemberWhenFull(t *testing.T) {
+// A join whose user is already present on a different session is now treated
+// as a session replacement: the stale entry is dropped, the new one takes its
+// place, and occupancy is unchanged.
+func TestPartyHandler_JoinReplacesOwnStaleSession(t *testing.T) {
 	const maxSize = 4
 	ph, cleanup := createLightPartyHandler(t, loggerForTest(t), true, maxSize, nil)
 	defer cleanup()
@@ -1245,25 +1236,49 @@ func TestPartyHandler_JoinSilentlyDropsMemberWhenFull(t *testing.T) {
 	members, _ := addMembers(t, ph, maxSize)
 	original := members[1]
 
-	// Same user, new session: a reconnect before the old presence is untracked.
 	reconnect := newPresenceWithIDs(partyTestNode, uuid.Must(uuid.NewV4()), original.UserID)
-
-	before := ph.members.Size()
 	ph.Join([]*Presence{reconnect})
-	after := ph.members.Size()
 
-	if after != before {
-		t.Fatalf("expected the roster to be unchanged at %d (the join was rejected as full), got %d", before, after)
+	if got := ph.members.Size(); got != maxSize {
+		t.Fatalf("a session replacement must not change occupancy: expected %d, got %d", maxSize, got)
 	}
 
+	var sawReconnect, sawStale bool
 	for _, m := range ph.members.presences {
-		if m.Presence.GetSessionId() == reconnect.GetSessionId() {
-			t.Fatal("reconnecting session is now in the roster; PartyHandler.Join no longer drops it " +
-				"and this test should assert the new behaviour")
+		switch m.Presence.GetSessionId() {
+		case reconnect.GetSessionId():
+			sawReconnect = true
+		case original.GetSessionId():
+			sawStale = true
 		}
 	}
+	if !sawReconnect {
+		t.Error("the reconnecting session is not in the roster; it was dropped, which is the party split -- " +
+			"the player stays tracked on the party stream but the leader's matchmaking cohort excludes them")
+	}
+	if sawStale {
+		t.Error("the superseded session is still in the roster; the user now appears twice and occupies two slots")
+	}
+}
 
-	// The player is on the stream but not in the party, and nothing returned an
-	// error to say so. This is the defect: Join has no way to report failure --
-	// its signature returns nothing.
+// TestPartyHandler_JoinStillRejectsAGenuineNewMemberWhenFull guards the other
+// direction: the replacement path must not become a way past MaxSize.
+func TestPartyHandler_JoinStillRejectsAGenuineNewMemberWhenFull(t *testing.T) {
+	const maxSize = 4
+	ph, cleanup := createLightPartyHandler(t, loggerForTest(t), true, maxSize, nil)
+	defer cleanup()
+
+	addMembers(t, ph, maxSize)
+
+	stranger, _, _ := newPresence(partyTestNode)
+	ph.Join([]*Presence{stranger})
+
+	if got := ph.members.Size(); got != maxSize {
+		t.Fatalf("a full party must still refuse an unrelated joiner: expected %d, got %d", maxSize, got)
+	}
+	for _, m := range ph.members.presences {
+		if m.Presence.GetSessionId() == stranger.GetSessionId() {
+			t.Fatal("an unrelated presence joined a full party; the same-user replacement path must not bypass MaxSize")
+		}
+	}
 }

--- a/server/evr_reservation_capacity_test.go
+++ b/server/evr_reservation_capacity_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/gofrs/uuid/v5"
 	"github.com/heroiclabs/nakama/v3/server/evr"
@@ -158,4 +159,57 @@ func TestCreatePartyReservations_SocialMatch_ReservesFollower(t *testing.T) {
 
 	assert.Contains(t, env.registry.reservedSessionIDs(), follower.id,
 		"a follower whose leader is in a social match must still be reserved")
+}
+
+// TestReservationCapacity_RefreshInFullLobbyIsAllowed pins the distinction
+// between booking a slot and refreshing one already held.
+//
+// The capacity guard ran before the upsert and could not tell the two apart.
+// upsertReservationByUserID deletes any existing reservation for the user
+// before inserting, so refreshing is slot-neutral -- but a follower in a full
+// lobby was skipped every time their client re-sent LobbyFindSessionRequest,
+// so their expiry was never extended. At the 5-minute mark rebuildCache dropped
+// the reservation and a backfill player took the seat they had been holding:
+// the party split this subsystem exists to prevent, produced by the guard meant
+// to protect it.
+func TestReservationCapacity_RefreshInFullLobbyIsAllowed(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	// One open slot, and a follower reserves it.
+	fillSocialLobby(state, SocialLobbyMaxSize-1)
+	member := socialMember()
+	state = signalCreatePartyReservations(t, m, state, member)
+
+	original, ok := state.reservationMap[member.SessionID.String()]
+	if !ok {
+		t.Fatalf("setup: expected the follower to hold a reservation")
+	}
+	if got := state.OpenSlots(); got != 0 {
+		t.Fatalf("setup: expected the lobby to be full once the slot is held, got OpenSlots()=%d", got)
+	}
+
+	// Age the reservation so a refresh is observable.
+	original.Expiry = time.Now().Add(30 * time.Second)
+	staleExpiry := original.Expiry
+
+	// The follower's client re-sends its find request against the now-full lobby.
+	state = signalCreatePartyReservations(t, m, state, member)
+
+	refreshed, ok := state.reservationMap[member.SessionID.String()]
+	if !ok {
+		t.Fatal("the follower's reservation disappeared on refresh; they will lose their seat at expiry " +
+			"and a backfill player will take it")
+	}
+	if !refreshed.Expiry.After(staleExpiry) {
+		t.Errorf("expiry was not extended (%v, was %v): a member already holding a reservation must be able "+
+			"to refresh it in a full lobby, because the upsert consumes no additional slot",
+			refreshed.Expiry, staleExpiry)
+	}
+	if got := len(state.reservationMap); got != 1 {
+		t.Errorf("expected exactly one reservation after refresh, got %d", got)
+	}
+	if got := state.OpenSlots(); got < 0 {
+		t.Errorf("OpenSlots() went negative (%d): a refresh must not consume a slot", got)
+	}
 }

--- a/server/evr_reservation_capacity_test.go
+++ b/server/evr_reservation_capacity_test.go
@@ -213,3 +213,44 @@ func TestReservationCapacity_RefreshInFullLobbyIsAllowed(t *testing.T) {
 		t.Errorf("OpenSlots() went negative (%d): a refresh must not consume a slot", got)
 	}
 }
+
+// TestReservationCapacity_NilUserIDRefreshInFullLobby covers the member the
+// user-ID path cannot see.
+//
+// The reservation system supports members with no user ID by keying their
+// reservation on session ID -- upsertReservationByUserID says so explicitly. A
+// refresh check that matched only on user ID therefore classified such a
+// member's refresh as a NEW booking and skipped it in a full lobby, which is
+// the same lost seat the refresh path exists to prevent.
+func TestReservationCapacity_NilUserIDRefreshInFullLobby(t *testing.T) {
+	m := &EvrMatch{}
+	state := newDedupTestState()
+
+	fillSocialLobby(state, SocialLobbyMaxSize-1)
+
+	member := socialMember()
+	member.UserID = uuid.Nil // keyed on session ID only
+
+	state = signalCreatePartyReservations(t, m, state, member)
+	original, ok := state.reservationMap[member.SessionID.String()]
+	if !ok {
+		t.Fatalf("setup: expected a reservation keyed on session ID for a nil-user-ID member")
+	}
+	if got := state.OpenSlots(); got != 0 {
+		t.Fatalf("setup: expected a full lobby, got OpenSlots()=%d", got)
+	}
+
+	original.Expiry = time.Now().Add(30 * time.Second)
+	staleExpiry := original.Expiry
+
+	state = signalCreatePartyReservations(t, m, state, member)
+
+	refreshed, ok := state.reservationMap[member.SessionID.String()]
+	if !ok {
+		t.Fatal("the nil-user-ID member's reservation disappeared on refresh")
+	}
+	if !refreshed.Expiry.After(staleExpiry) {
+		t.Errorf("expiry was not extended (%v, was %v): a nil user ID is keyed on session, and that "+
+			"reservation must be refreshable in a full lobby like any other", refreshed.Expiry, staleExpiry)
+	}
+}

--- a/server/party_handler.go
+++ b/server/party_handler.go
@@ -128,7 +128,13 @@ func (p *PartyHandler) JoinRequest(presence *Presence) (bool, error) {
 	// which is the reconnect-storm lockout in the ops case.
 	//
 	// A closed party already behaved this way; this makes the two agree.
-	for _, member := range p.members.presences {
+	//
+	// List() reads the atomic snapshot rather than p.members.presences
+	// directly. PartyPresenceList has its own mutex, and holding the handler's
+	// lock does not confer it -- JoinPartyGroup's rollback path calls
+	// members.Leave without holding the handler lock at all, so a direct read
+	// of the slice races it. The snapshot is what every other reader uses.
+	for _, member := range p.members.List() {
 		if member.Presence.UserID == presence.UserID {
 			p.Unlock()
 			return false, runtime.ErrPartyJoinRequestAlreadyMember

--- a/server/party_handler.go
+++ b/server/party_handler.go
@@ -112,6 +112,28 @@ func (p *PartyHandler) JoinRequest(presence *Presence) (bool, error) {
 		return false, runtime.ErrPartyClosed
 	}
 
+	// Check if party already has this user.
+	//
+	// Identity is checked BEFORE capacity, and before the p.Open branch, because
+	// an existing member consumes no new slot: telling them the party is full is
+	// answering a question they did not ask. This check used to sit at the bottom
+	// of the function, which made it unreachable for an open party -- the
+	// capacity check returned ErrPartyFull first, and the Open branch returned
+	// before identity was ever considered.
+	//
+	// That mattered because EVR creates only open parties, and a member
+	// reconnecting into their own full party is exactly the case: their stale
+	// session still counts toward MaxSize, so the party looks full to the very
+	// person who is already in it. Every reconnect attempt hit the same wall,
+	// which is the reconnect-storm lockout in the ops case.
+	//
+	// A closed party already behaved this way; this makes the two agree.
+	for _, member := range p.members.presences {
+		if member.Presence.UserID == presence.UserID {
+			p.Unlock()
+			return false, runtime.ErrPartyJoinRequestAlreadyMember
+		}
+	}
 	// Check if party is full.
 	if p.members.Size() >= p.MaxSize {
 		p.Unlock()
@@ -140,14 +162,6 @@ func (p *PartyHandler) JoinRequest(presence *Presence) (bool, error) {
 			return false, runtime.ErrPartyJoinRequestDuplicate
 		}
 	}
-	// Check if party already has this user.
-	for _, member := range p.members.presences {
-		if member.Presence.UserID == presence.UserID {
-			p.Unlock()
-			return false, runtime.ErrPartyJoinRequestAlreadyMember
-		}
-	}
-
 	joinRequest := &PartyJoinRequest{
 		Presence: presence,
 		UserPresence: &rtapi.UserPresence{

--- a/server/party_presence.go
+++ b/server/party_presence.go
@@ -103,19 +103,20 @@ func (m *PartyPresenceList) Join(joins []*Presence) ([]*Presence, error) {
 		if reservationFound || presenceFound {
 			continue
 		}
-		// Replacing one of this user's own sessions frees the slot it holds.
-		replacesOwnSession := false
-		for _, existing := range m.presences {
-			if existing.Presence.UserID == join.UserID && existing.Presence.ID.SessionID != join.ID.SessionID {
-				replacesOwnSession = true
-				break
-			}
-		}
-		if !replacesOwnSession {
-			newPresences++
-		}
+		newPresences++
 	}
-	if newPresences > 0 && len(m.reservedMap)+len(m.presenceMap)+newPresences > m.maxSize {
+
+	// Compare against the occupancy this call will actually produce, not the
+	// current one: the stale sessions above are removed below, so counting them
+	// would reject a batch that fits.
+	//
+	// That is not hypothetical. A user carrying two stale sessions (which a
+	// reconnect storm could produce before this fix) whose replacement arrives
+	// batched with one genuine newcomer would be refused, even though dropping
+	// the two stale entries leaves room for both -- and the caller
+	// (PartyHandler.Join) discards ErrPartyFull, so the refusal would be the
+	// same silent roster drop this change exists to remove.
+	if newPresences > 0 && len(m.reservedMap)+len(m.presenceMap)-len(staleSessions)+newPresences > m.maxSize {
 		m.Unlock()
 		return nil, runtime.ErrPartyFull
 	}

--- a/server/party_presence.go
+++ b/server/party_presence.go
@@ -74,17 +74,67 @@ func (m *PartyPresenceList) Release(presence *Presence) {
 func (m *PartyPresenceList) Join(joins []*Presence) ([]*Presence, error) {
 	processed := make([]*Presence, 0, len(joins))
 	m.Lock()
+
+	// A join whose USER is already present on a different session is a session
+	// replacement, not a new member -- the reconnect case. Counting it as new
+	// is what made a party reject its own member: capacity is keyed on session
+	// ID, so a reconnecting player's fresh session counted against a limit
+	// their stale session was still occupying. The caller
+	// (PartyHandler.Join, reached from the tracker's Join event) discards the
+	// error as "should not happen", so the player was silently left tracked on
+	// the party stream but absent from the roster, and the leader's matchmaking
+	// cohort excluded them.
+	//
+	// Stale sessions for the same user are dropped below, so the party's
+	// occupancy is unchanged by a replacement and MaxSize still holds.
+	staleSessions := make(map[uuid.UUID]struct{})
+	for _, join := range joins {
+		for _, existing := range m.presences {
+			if existing.Presence.UserID == join.UserID && existing.Presence.ID.SessionID != join.ID.SessionID {
+				staleSessions[existing.Presence.ID.SessionID] = struct{}{}
+			}
+		}
+	}
+
 	var newPresences int
 	for _, join := range joins {
 		_, reservationFound := m.reservedMap[join.ID.SessionID]
 		_, presenceFound := m.presenceMap[join.ID.SessionID]
-		if !reservationFound && !presenceFound {
+		if reservationFound || presenceFound {
+			continue
+		}
+		// Replacing one of this user's own sessions frees the slot it holds.
+		replacesOwnSession := false
+		for _, existing := range m.presences {
+			if existing.Presence.UserID == join.UserID && existing.Presence.ID.SessionID != join.ID.SessionID {
+				replacesOwnSession = true
+				break
+			}
+		}
+		if !replacesOwnSession {
 			newPresences++
 		}
 	}
 	if newPresences > 0 && len(m.reservedMap)+len(m.presenceMap)+newPresences > m.maxSize {
 		m.Unlock()
 		return nil, runtime.ErrPartyFull
+	}
+
+	// Drop the superseded sessions before adding the replacements, so the user
+	// never appears twice and occupancy never transiently exceeds MaxSize.
+	if len(staleSessions) > 0 {
+		kept := m.presences[:0]
+		for _, existing := range m.presences {
+			if _, stale := staleSessions[existing.Presence.ID.SessionID]; stale {
+				delete(m.presenceMap, existing.Presence.ID.SessionID)
+				continue
+			}
+			kept = append(kept, existing)
+		}
+		for i := len(kept); i < len(m.presences); i++ {
+			m.presences[i] = nil
+		}
+		m.presences = kept
 	}
 
 	for _, join := range joins {


### PR DESCRIPTION
The three items approved after the adversarial review. All mutation-verified; `just test` green, party tests green under `-race`.

## 1. The party-split reconnect lockout

A player who drops and reconnects gets separated from their own party. Diagnosed months ago, contested by two reviews that reached opposite conclusions, and now fixed — it had **two acts**, which is why each review was right about one half.

**Act one, silent.** Party capacity is keyed on *session ID*. A reconnecting player's fresh session counted against a limit their stale session was still occupying, so `PartyPresenceList.Join` returned `ErrPartyFull` — and `PartyHandler.Join` discards that error as *"should not happen, this process is just a confirmation."* The player ended up tracked on the party stream but absent from `ph.members`, so the leader's matchmaking cohort silently excluded them. Nothing surfaced it; `Join` returns nothing and cannot report failure.

A join whose **user** is already present on a different session is now a session *replacement*: the superseded entry is dropped as the new one is added, so occupancy is unchanged and `MaxSize` still binds against genuine new members.

**Act two, visible.** `JoinRequest` checked capacity before identity, and the already-member check sat *below* the `p.Open` branch — unreachable for an open party, and EVR creates only open parties. A member reconnecting into their own full party was told it was full, with no bypass for already being in it. Every retry hit the same wall, which is the reconnect-storm shape in the ops case (34 party-full + 14 lobby-full rejections over 72h for one player).

Identity is now checked first, because an existing member consumes no new slot. **A closed party already behaved this way** — that asymmetry was the tell.

**Act three, ours.** `evr_lobby_group.go` tolerated `ErrPartyJoinRequestAlreadyMember`, then fell through to `if !success` and returned "failed to join party" anyway, because `JoinRequest` returns `false` alongside that error. Someone wrote that bypass intending exactly this case and it never worked. `addedMember` is now set only for a genuine join, so the `Track` rollback stays precise.

The characterization tests from #577 — added to stop the diagnosis being contested — failed on this change with the *"this is fixed, update the assertion"* message they were written to produce. They now assert the fixed behaviour, run against open **and** closed parties since the asymmetry was the evidence, and guard that the replacement path cannot exceed `MaxSize`.

## 2. Prune deletes after a restart

`unavailableGuilds` — the record distinguishing a guild that is merely dark from one the bot was removed from — lives only in memory. **A restart erases it**, and it is the only thing between a Discord read anomaly and an unrecoverable `GroupDelete`.

Normally READY lists unavailable guilds as stubs and they're protected anyway. But a READY that omits a member guild is exactly the "Discord is lying" case this pass was hardened against — and it is most likely during the incident that caused the restart.

Group **deletes** are suppressed for 30 minutes after boot regardless of configuration (two prune intervals). Leaves and the non-destructive repair pass are untouched: re-inviting the bot undoes a leave, nothing undoes a delete.

## 3. Reservation refresh in a full lobby

The capacity guard ran before the upsert and couldn't tell a new booking from a refresh. `upsertReservationByUserID` deletes any existing reservation before inserting, so a refresh is slot-neutral — but a follower in a full lobby was skipped every time their client re-sent `LobbyFindSessionRequest`. Their expiry was never extended, and at the 5-minute mark `rebuildCache` dropped the reservation and a backfill player took the seat they were holding.

**The guard meant to prevent party splits was causing one.** `hasReservationForUserID` distinguishes the two; capacity still binds for new reservations, pinned by a test.

Also quieted the signal's logging: it announced "Created party reservations" at Info on every firing including `created: 0`, and that signal fires on every follower re-send. It now reports `refreshed` alongside `created` and drops to Debug when nothing changed.

## Verification

- `just test` green; party tests green under `-race -count=2`
- Every fix mutation-tested — including the reservation refresh, where reverting the guard reproduces the un-extended expiry exactly
- Party fix covers open and closed parties together, since their disagreement was the original evidence

Co-authored-by: nakama-fixer <nakama-fixer@metis.agents>